### PR TITLE
Issue 5650: Fix for Controller CreateReaderGroup API race condition

### DIFF
--- a/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
@@ -91,12 +91,12 @@ public class ReaderGroupManagerImpl implements ReaderGroupManager {
         createStreamHelper(getStreamForReaderGroup(groupName), StreamConfiguration.builder()
                                                                                   .scalingPolicy(ScalingPolicy.fixed(1))
                                                                                   .build());
-        getThrowingException(controller.createReaderGroup(scope, groupName, config));
+        ReaderGroupConfig ctrlConfig = getThrowingException(controller.createReaderGroup(scope, groupName, config));
         @Cleanup
         StateSynchronizer<ReaderGroupState> synchronizer = clientFactory.createStateSynchronizer(NameUtils.getStreamForReaderGroup(groupName),
                                               new ReaderGroupStateUpdatesSerializer(), new ReaderGroupStateInitSerializer(), SynchronizerConfig.builder().build());
-        Map<SegmentWithRange, Long> segments = ReaderGroupImpl.getSegmentsForStreams(controller, config);
-        synchronizer.initialize(new ReaderGroupState.ReaderGroupStateInit(config, segments, getEndSegmentsForStreams(config), false));
+        Map<SegmentWithRange, Long> segments = ReaderGroupImpl.getSegmentsForStreams(controller, ctrlConfig);
+        synchronizer.initialize(new ReaderGroupState.ReaderGroupStateInit(ctrlConfig, segments, getEndSegmentsForStreams(ctrlConfig), false));
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/control/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/control/impl/Controller.java
@@ -130,7 +130,7 @@ public interface Controller extends AutoCloseable {
      * @return A future which will throw if the operation fails, otherwise returning a boolean to
      *         indicate that the subscriber was updated in Stream Metadata.
      */
-    CompletableFuture<Boolean> createReaderGroup(final String scopeName, final String rgName, ReaderGroupConfig config);
+    CompletableFuture<ReaderGroupConfig> createReaderGroup(final String scopeName, final String rgName, ReaderGroupConfig config);
 
     /**
      * API to update a ReaderGroup config.

--- a/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
@@ -97,7 +97,7 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.TxnRequest;
 import io.pravega.controller.stream.api.grpc.v1.Controller.TxnState;
 import io.pravega.controller.stream.api.grpc.v1.Controller.TxnStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateStreamStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfiguration;
@@ -1530,8 +1530,8 @@ public class ControllerImpl implements Controller {
         final long requestId = requestIdGenerator.get();
         long traceId = LoggerHelpers.traceEnter(log, "createReaderGroup", rgConfig, requestId);
 
-        final CompletableFuture<CreateReaderGroupStatus> result = this.retryConfig.runAsync(() -> {
-            RPCAsyncCallback<CreateReaderGroupStatus> callback = new RPCAsyncCallback<>(requestId, "createReaderGroup", scope, rgName, rgConfig);
+        final CompletableFuture<CreateReaderGroupResponse> result = this.retryConfig.runAsync(() -> {
+            RPCAsyncCallback<CreateReaderGroupResponse> callback = new RPCAsyncCallback<>(requestId, "createReaderGroup", scope, rgName, rgConfig);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "createReaderGroup", scope, rgName)
                     .createReaderGroup(ModelHelper.decode(scope, rgName, rgConfig), callback);
             return callback.getFuture();
@@ -1848,7 +1848,7 @@ public class ControllerImpl implements Controller {
                     .deleteKeyValueTable(kvtInfo, callback);
         }
 
-        void createReaderGroup(ReaderGroupConfiguration rgConfig, RPCAsyncCallback<CreateReaderGroupStatus> callback) {
+        void createReaderGroup(ReaderGroupConfiguration rgConfig, RPCAsyncCallback<CreateReaderGroupResponse> callback) {
             clientStub.withDeadlineAfter(timeoutMillis, TimeUnit.MILLISECONDS)
                     .createReaderGroup(rgConfig, callback);
         }

--- a/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
@@ -1533,7 +1533,7 @@ public class ControllerImpl implements Controller {
         final CompletableFuture<CreateReaderGroupResponse> result = this.retryConfig.runAsync(() -> {
             RPCAsyncCallback<CreateReaderGroupResponse> callback = new RPCAsyncCallback<>(requestId, "createReaderGroup", scope, rgName, rgConfig);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "createReaderGroup", scope, rgName)
-                    .createReaderGroup(ModelHelper.decode(scope, rgName, rgConfig, rgConfig.getReaderGroupId()), callback);
+                    .createReaderGroup(ModelHelper.decode(scope, rgName, rgConfig), callback);
             return callback.getFuture();
         }, this.executor);
         return result.thenApply(x -> {
@@ -1574,7 +1574,7 @@ public class ControllerImpl implements Controller {
         final CompletableFuture<UpdateReaderGroupResponse> result = this.retryConfig.runAsync(() -> {
             RPCAsyncCallback<UpdateReaderGroupResponse> callback = new RPCAsyncCallback<>(requestId, "updateReaderGroup", scope, rgName, rgConfig);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "updateReaderGroup", scope, rgName)
-                    .updateReaderGroup(ModelHelper.decode(scope, rgName, rgConfig, rgConfig.getReaderGroupId()), callback);
+                    .updateReaderGroup(ModelHelper.decode(scope, rgName, rgConfig), callback);
             return callback.getFuture();
         }, this.executor);
         return result.thenApply(x -> {

--- a/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
@@ -1522,7 +1522,7 @@ public class ControllerImpl implements Controller {
     //endregion
 
     // region ReaderGroups
-    public CompletableFuture<Boolean> createReaderGroup(String scope, String rgName, final ReaderGroupConfig rgConfig) {
+    public CompletableFuture<ReaderGroupConfig> createReaderGroup(String scope, String rgName, final ReaderGroupConfig rgConfig) {
         Exceptions.checkNotClosed(closed.get(), this);
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Exceptions.checkNotNullOrEmpty(rgName, "rgName");
@@ -1533,7 +1533,7 @@ public class ControllerImpl implements Controller {
         final CompletableFuture<CreateReaderGroupResponse> result = this.retryConfig.runAsync(() -> {
             RPCAsyncCallback<CreateReaderGroupResponse> callback = new RPCAsyncCallback<>(requestId, "createReaderGroup", scope, rgName, rgConfig);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "createReaderGroup", scope, rgName)
-                    .createReaderGroup(ModelHelper.decode(scope, rgName, rgConfig), callback);
+                    .createReaderGroup(ModelHelper.decode(scope, rgName, rgConfig, rgConfig.getReaderGroupId()), callback);
             return callback.getFuture();
         }, this.executor);
         return result.thenApply(x -> {
@@ -1549,7 +1549,7 @@ public class ControllerImpl implements Controller {
                     throw new IllegalArgumentException("Scope does not exist: " + scope);
                 case SUCCESS:
                     log.info(requestId, "ReaderGroup created successfully: {}", rgName);
-                    return true;
+                    return ModelHelper.encode(x.getConfig());
                 case UNRECOGNIZED:
                 default:
                     throw new ControllerFailureException("Unknown return status creating reader group " + rgName
@@ -1574,7 +1574,7 @@ public class ControllerImpl implements Controller {
         final CompletableFuture<UpdateReaderGroupResponse> result = this.retryConfig.runAsync(() -> {
             RPCAsyncCallback<UpdateReaderGroupResponse> callback = new RPCAsyncCallback<>(requestId, "updateReaderGroup", scope, rgName, rgConfig);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "updateReaderGroup", scope, rgName)
-                    .updateReaderGroup(ModelHelper.decode(scope, rgName, rgConfig), callback);
+                    .updateReaderGroup(ModelHelper.decode(scope, rgName, rgConfig, rgConfig.getReaderGroupId()), callback);
             return callback.getFuture();
         }, this.executor);
         return result.thenApply(x -> {

--- a/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ModelHelper.java
@@ -462,7 +462,14 @@ public final class ModelHelper {
     }
 
 
-    public static final Controller.ReaderGroupConfiguration decode(String scope, String groupName, final ReaderGroupConfig config) {
+    public static final Controller.ReaderGroupConfiguration decode(String scope, String groupName,
+                                                                   final ReaderGroupConfig config) {
+        return decode(scope, groupName, config, config.getReaderGroupId());
+    }
+
+    public static final Controller.ReaderGroupConfiguration decode(String scope, String groupName,
+                                                                   final ReaderGroupConfig config,
+                                                                   final UUID readerGroupId) {
         Preconditions.checkNotNull(scope, "ReaderGroup scope is null");
         Preconditions.checkNotNull(groupName, "ReaderGroup name is null");
         Preconditions.checkNotNull(config, "ReaderGroupConfig is null");
@@ -485,7 +492,7 @@ public final class ModelHelper {
                 .setMaxOutstandingCheckpointRequest(config.getMaxOutstandingCheckpointRequest())
                 .setRetentionType(config.getRetentionType().ordinal())
                 .setGeneration(config.getGeneration())
-                .setReaderGroupId(config.getReaderGroupId().toString())
+                .setReaderGroupId(readerGroupId.toString())
                 .addAllStartingStreamCuts(startStreamCuts)
                 .addAllEndingStreamCuts(endStreamCuts);
         return builder.build();

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroupConfig.java
@@ -77,7 +77,7 @@ public class ReaderGroupConfig implements Serializable {
         AUTOMATIC_RELEASE_AT_LAST_CHECKPOINT;
     }
 
-   public static class ReaderGroupConfigBuilder implements ObjectBuilder<ReaderGroupConfig> {
+    public static class ReaderGroupConfigBuilder implements ObjectBuilder<ReaderGroupConfig> {
        private long groupRefreshTimeMillis = 3000; //default value
        private long automaticCheckpointIntervalMillis = 30000; //default value
        // maximum outstanding checkpoint request that is allowed at any given time.

--- a/client/src/test/java/io/pravega/client/admin/impl/ReaderGroupManagerImplTest.java
+++ b/client/src/test/java/io/pravega/client/admin/impl/ReaderGroupManagerImplTest.java
@@ -80,7 +80,7 @@ public class ReaderGroupManagerImplTest {
         when(controller.createStream(SCOPE, getStreamForReaderGroup(GROUP_NAME), StreamConfiguration.builder()
                 .scalingPolicy(ScalingPolicy.fixed(1))
                 .build())).thenReturn(CompletableFuture.completedFuture(true));
-        when(controller.createReaderGroup(SCOPE, GROUP_NAME, config)).thenReturn(CompletableFuture.completedFuture(true));
+        when(controller.createReaderGroup(SCOPE, GROUP_NAME, config)).thenReturn(CompletableFuture.completedFuture(config));
         when(clientFactory.createStateSynchronizer(anyString(), any(Serializer.class), any(Serializer.class),
                 any(SynchronizerConfig.class))).thenReturn(synchronizer);
         // Create a ReaderGroup

--- a/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
@@ -81,7 +81,7 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteKVTableStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateSubscriberStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SubscriberStreamCut;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SubscribersResponse;
-import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupInfo;
@@ -351,25 +351,29 @@ public class ControllerImplTest {
 
             @Override
             public void createReaderGroup(ReaderGroupConfiguration request,
-                                          StreamObserver<CreateReaderGroupStatus> responseObserver) {
+                                          StreamObserver<CreateReaderGroupResponse> responseObserver) {
                 if (request.getReaderGroupName().equals("rg1")) {
-                    responseObserver.onNext(CreateReaderGroupStatus.newBuilder()
-                            .setStatus(CreateReaderGroupStatus.Status.SUCCESS)
+                    responseObserver.onNext(CreateReaderGroupResponse.newBuilder()
+                            .setReaderGroupId(UUID.randomUUID().toString())
+                            .setStatus(CreateReaderGroupResponse.Status.SUCCESS)
                             .build());
                     responseObserver.onCompleted();
                 } else if (request.getReaderGroupName().equals("rg2")) {
-                    responseObserver.onNext(CreateReaderGroupStatus.newBuilder()
-                            .setStatus(CreateReaderGroupStatus.Status.FAILURE)
+                    responseObserver.onNext(CreateReaderGroupResponse.newBuilder()
+                            .setReaderGroupId(UUID.randomUUID().toString())
+                            .setStatus(CreateReaderGroupResponse.Status.FAILURE)
                             .build());
                     responseObserver.onCompleted();
                 } else if (request.getReaderGroupName().equals("rg3")) {
-                    responseObserver.onNext(CreateReaderGroupStatus.newBuilder()
-                            .setStatus(CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND)
+                    responseObserver.onNext(CreateReaderGroupResponse.newBuilder()
+                            .setReaderGroupId(UUID.randomUUID().toString())
+                            .setStatus(CreateReaderGroupResponse.Status.SCOPE_NOT_FOUND)
                             .build());
                     responseObserver.onCompleted();
                 } else if (request.getReaderGroupName().equals("rg4")) {
-                    responseObserver.onNext(CreateReaderGroupStatus.newBuilder()
-                            .setStatus(CreateReaderGroupStatus.Status.INVALID_RG_NAME)
+                    responseObserver.onNext(CreateReaderGroupResponse.newBuilder()
+                            .setReaderGroupId(UUID.randomUUID().toString())
+                            .setStatus(CreateReaderGroupResponse.Status.INVALID_RG_NAME)
                             .build());
                     responseObserver.onCompleted();
                 }

--- a/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
@@ -354,25 +354,25 @@ public class ControllerImplTest {
                                           StreamObserver<CreateReaderGroupResponse> responseObserver) {
                 if (request.getReaderGroupName().equals("rg1")) {
                     responseObserver.onNext(CreateReaderGroupResponse.newBuilder()
-                            .setReaderGroupId(UUID.randomUUID().toString())
+                            .setConfig(request)
                             .setStatus(CreateReaderGroupResponse.Status.SUCCESS)
                             .build());
                     responseObserver.onCompleted();
                 } else if (request.getReaderGroupName().equals("rg2")) {
                     responseObserver.onNext(CreateReaderGroupResponse.newBuilder()
-                            .setReaderGroupId(UUID.randomUUID().toString())
+                            .setConfig(request)
                             .setStatus(CreateReaderGroupResponse.Status.FAILURE)
                             .build());
                     responseObserver.onCompleted();
                 } else if (request.getReaderGroupName().equals("rg3")) {
                     responseObserver.onNext(CreateReaderGroupResponse.newBuilder()
-                            .setReaderGroupId(UUID.randomUUID().toString())
+                            .setConfig(request)
                             .setStatus(CreateReaderGroupResponse.Status.SCOPE_NOT_FOUND)
                             .build());
                     responseObserver.onCompleted();
                 } else if (request.getReaderGroupName().equals("rg4")) {
                     responseObserver.onNext(CreateReaderGroupResponse.newBuilder()
-                            .setReaderGroupId(UUID.randomUUID().toString())
+                            .setConfig(request)
                             .setStatus(CreateReaderGroupResponse.Status.INVALID_RG_NAME)
                             .build());
                     responseObserver.onCompleted();
@@ -1538,7 +1538,7 @@ public class ControllerImplTest {
 
     @Test
     public void testCreateReaderGroup() throws Exception {
-        CompletableFuture<Boolean> createRGStatus;
+        CompletableFuture<ReaderGroupConfig> createRGConfig;
         final Segment seg0 = new Segment("scope1", "stream1", 0L);
         final Segment seg1 = new Segment("scope1", "stream1", 1L);
         ImmutableMap<Segment, Long> startStreamCut = ImmutableMap.of(seg0, 10L, seg1, 10L);
@@ -1556,20 +1556,21 @@ public class ControllerImplTest {
                 .readerGroupId(UUID.randomUUID())
                 .startingStreamCuts(startSC)
                 .endingStreamCuts(endSC).build();
-        createRGStatus = controllerClient.createReaderGroup("scope1", "rg1", config);
-        assertTrue(createRGStatus.get());
+        createRGConfig = controllerClient.createReaderGroup("scope1", "rg1", config);
+        assertEquals(createRGConfig.get().getReaderGroupId(), config.getReaderGroupId());
+        assertEquals(createRGConfig.get().getGeneration(), config.getGeneration());
 
-        createRGStatus = controllerClient.createReaderGroup("scope1", "rg2", config);
+        createRGConfig = controllerClient.createReaderGroup("scope1", "rg2", config);
         AssertExtensions.assertFutureThrows("Server should throw exception",
-                createRGStatus, Throwable -> true);
+                createRGConfig, Throwable -> true);
 
-        createRGStatus = controllerClient.createReaderGroup("scope1", "rg3", config);
+        createRGConfig = controllerClient.createReaderGroup("scope1", "rg3", config);
         AssertExtensions.assertFutureThrows("Server should throw exception",
-                createRGStatus, throwable -> throwable instanceof IllegalArgumentException);
+                createRGConfig, throwable -> throwable instanceof IllegalArgumentException);
 
-        createRGStatus = controllerClient.createReaderGroup("scope1", "rg4", config);
+        createRGConfig = controllerClient.createReaderGroup("scope1", "rg4", config);
         AssertExtensions.assertFutureThrows("Server should throw exception",
-                createRGStatus, throwable -> throwable instanceof IllegalArgumentException);
+                createRGConfig, throwable -> throwable instanceof IllegalArgumentException);
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/mock/MockController.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockController.java
@@ -262,9 +262,10 @@ public class MockController implements Controller {
     }
 
     @Override
-    public CompletableFuture<Boolean> createReaderGroup(String scopeName, String rgName, ReaderGroupConfig config) {
-        return createInScope(scopeName, getScopedReaderGroupName(scopeName, getStreamForReaderGroup(rgName)), config, s -> s.readerGroups,
+    public CompletableFuture<ReaderGroupConfig> createReaderGroup(String scopeName, String rgName, ReaderGroupConfig config) {
+        createInScope(scopeName, getScopedReaderGroupName(scopeName, getStreamForReaderGroup(rgName)), config, s -> s.readerGroups,
                 this::getSegmentsForReaderGroup, Segment::getScopedName, this::createSegment);
+        return CompletableFuture.completedFuture(config);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -194,7 +194,7 @@ public class LocalController implements Controller {
         return streamMetadataTasks.createReaderGroupInternal(scopeName, rgName, config, System.currentTimeMillis())
                 .thenApply(x -> {
             final String scopedRGName = NameUtils.getScopedReaderGroupName(scopeName, rgName);
-            switch (x) {
+            switch (x.getStatus()) {
                 case FAILURE:
                     throw new ControllerFailureException("Failed to create ReaderGroup: " + scopedRGName);
                 case INVALID_RG_NAME:

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -189,7 +189,7 @@ public class LocalController implements Controller {
     }
 
     @Override
-    public CompletableFuture<Boolean> createReaderGroup(String scopeName, String rgName, ReaderGroupConfig config) {
+    public CompletableFuture<ReaderGroupConfig> createReaderGroup(String scopeName, String rgName, ReaderGroupConfig config) {
         StreamMetadataTasks streamMetadataTasks = controller.getStreamMetadataTasks();
         return streamMetadataTasks.createReaderGroupInternal(scopeName, rgName, config, System.currentTimeMillis())
                 .thenApply(x -> {
@@ -202,7 +202,7 @@ public class LocalController implements Controller {
                 case SCOPE_NOT_FOUND:
                     throw new IllegalArgumentException("Scope does not exist: " + scopeName);
                 case SUCCESS:
-                    return true;
+                    return ModelHelper.encode(x.getConfig());
                 default:
                     throw new ControllerFailureException("Unknown return status creating ReaderGroup " + scopedRGName
                             + " " + x);

--- a/controller/src/main/java/io/pravega/controller/server/rest/ModelHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/ModelHelper.java
@@ -40,7 +40,7 @@ public class ModelHelper {
     public static final StreamConfiguration getCreateStreamConfig(final CreateStreamRequest createStreamRequest) {
         ScalingPolicy scalingPolicy;
         if (createStreamRequest.getScalingPolicy().getType() == ScalingConfig.TypeEnum.FIXED_NUM_SEGMENTS) {
-           scalingPolicy = ScalingPolicy.fixed(createStreamRequest.getScalingPolicy().getMinSegments());
+            scalingPolicy = ScalingPolicy.fixed(createStreamRequest.getScalingPolicy().getMinSegments());
         } else if (createStreamRequest.getScalingPolicy().getType() ==
                 ScalingConfig.TypeEnum.BY_RATE_IN_EVENTS_PER_SEC) {
             scalingPolicy = ScalingPolicy.byEventRate(
@@ -71,9 +71,9 @@ public class ModelHelper {
                     break;
                 case LIMITED_DAYS:
                     if (createStreamRequest.getRetentionPolicy().getMaxValue() == null
-                        && createStreamRequest.getRetentionPolicy().getMaxTimeBasedRetention() == null) {
+                            && createStreamRequest.getRetentionPolicy().getMaxTimeBasedRetention() == null) {
                         retentionPolicy = getRetentionPolicy(createStreamRequest.getRetentionPolicy().getTimeBasedRetention(),
-                                    createStreamRequest.getRetentionPolicy().getValue());
+                                createStreamRequest.getRetentionPolicy().getValue());
                     } else {
                         retentionPolicy = getRetentionPolicy(createStreamRequest.getRetentionPolicy().getTimeBasedRetention(),
                                 createStreamRequest.getRetentionPolicy().getValue(),
@@ -125,23 +125,23 @@ public class ModelHelper {
                     break;
                 case LIMITED_DAYS:
                     retentionPolicy = getRetentionPolicy(updateStreamRequest.getRetentionPolicy().getTimeBasedRetention(),
-                                                                        updateStreamRequest.getRetentionPolicy().getValue());
+                            updateStreamRequest.getRetentionPolicy().getValue());
                     break;
                 default:
                     throw new NotImplementedException("retention policy type not supported");
             }
         }
         return StreamConfiguration.builder()
-                                  .scalingPolicy(scalingPolicy)
-                                  .retentionPolicy(retentionPolicy)
-                                  .build();
+                .scalingPolicy(scalingPolicy)
+                .retentionPolicy(retentionPolicy)
+                .build();
     }
 
     /**
      * The method translates the internal object StreamConfiguration into REST response object.
      *
-     * @param scope the scope of the stream
-     * @param streamName the name of the stream
+     * @param scope               the scope of the stream
+     * @param streamName          the name of the stream
      * @param streamConfiguration The configuration of stream
      * @return Stream properties wrapped in StreamResponse object
      */
@@ -204,7 +204,7 @@ public class ModelHelper {
                 Duration.ofDays(timeRetention.getDays())
                         .plusHours(timeRetention.getHours())
                         .plusMinutes(timeRetention.getMinutes())
-                :  Duration.ofDays(retentionInDays);
+                : Duration.ofDays(retentionInDays);
         return RetentionPolicy.byTime(retentionDuration);
     }
 
@@ -214,22 +214,23 @@ public class ModelHelper {
                 Duration.ofDays(timeRetention.getDays())
                         .plusHours(timeRetention.getHours())
                         .plusMinutes(timeRetention.getMinutes())
-                :  Duration.ofDays(retentionInDays);
+                : Duration.ofDays(retentionInDays);
         Duration retentionDurationMax = (maxTimeRetention != null && maxRetentionInDays == 0) ?
                 Duration.ofDays(maxTimeRetention.getDays())
                         .plusHours(maxTimeRetention.getHours())
                         .plusMinutes(maxTimeRetention.getMinutes())
-                :  Duration.ofDays(maxRetentionInDays);
+                : Duration.ofDays(maxRetentionInDays);
         return RetentionPolicy.byTime(retentionDurationMin, retentionDurationMax);
     }
 
     /**
      * This method takes total retention duration in milliseconds and
      * computes minutes from remainder ms after subtracting (daysInMs + hoursInMs)
+     *
      * @param totalDurationInMs retention duration in milliseconds
-     * @param daysInMs milliseconds for days in the retention duration
-     * @param hours hours in the retention duration. This absolute value not in ms.
-     * */
+     * @param daysInMs          milliseconds for days in the retention duration
+     * @param hours             hours in the retention duration. This absolute value not in ms.
+     */
     private static long getMinsFromMillis(long totalDurationInMs, long daysInMs, long hours) {
         long remainderMs = 0L;
         if (hours > 0) {

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -73,7 +73,7 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.SubscriberStreamCut;
 import io.pravega.controller.stream.api.grpc.v1.Controller.StreamCut;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SubscribersResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfiguration;
-import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfigResponse;
@@ -142,7 +142,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
     }
 
     @Override
-    public void createReaderGroup(ReaderGroupConfiguration request, StreamObserver<CreateReaderGroupStatus> responseObserver) {
+    public void createReaderGroup(ReaderGroupConfiguration request, StreamObserver<CreateReaderGroupResponse> responseObserver) {
         String scope = request.getScope();
         String rgName = request.getReaderGroupName();
         RequestTag requestTag = requestTracker.initializeAndTrackRequestTag(requestIdGenerator.get(), "createReaderGroup",

--- a/controller/src/main/java/io/pravega/controller/store/PravegaTablesScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/PravegaTablesScope.java
@@ -222,7 +222,7 @@ public class PravegaTablesScope implements Scope {
                         storeHelper.addNewEntryIfAbsent(tableName, readerGroupName, getIdInBytes(readerGroupId)),
                         e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException,
                         () -> storeHelper.createTable(tableName)
-                                .thenCompose(v -> storeHelper.addNewEntry(tableName, readerGroupName,
+                                .thenCompose(v -> storeHelper.addNewEntryIfAbsent(tableName, readerGroupName,
                                         getIdInBytes(readerGroupId))))));
 
     }

--- a/controller/src/main/java/io/pravega/controller/store/PravegaTablesScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/PravegaTablesScope.java
@@ -219,10 +219,12 @@ public class PravegaTablesScope implements Scope {
     public CompletableFuture<Void> addReaderGroupToScope(String readerGroupName, UUID readerGroupId) {
         return getReaderGroupsInScopeTableName()
                 .thenCompose(tableName -> Futures.toVoid(Futures.exceptionallyComposeExpecting(
-                        storeHelper.addNewEntry(tableName, readerGroupName, getIdInBytes(readerGroupId)),
+                        storeHelper.addNewEntryIfAbsent(tableName, readerGroupName, getIdInBytes(readerGroupId)),
                         e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException,
                         () -> storeHelper.createTable(tableName)
-                                .thenCompose(v -> storeHelper.addNewEntry(tableName, readerGroupName, getIdInBytes(readerGroupId))))));
+                                .thenCompose(v -> storeHelper.addNewEntry(tableName, readerGroupName,
+                                        getIdInBytes(readerGroupId))))));
+
     }
 
     public CompletableFuture<Void> removeReaderGroupFromScope(String readerGroup) {

--- a/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PravegaTablesStreamMetadataStore.java
@@ -310,7 +310,8 @@ public class PravegaTablesStreamMetadataStore extends AbstractStreamMetadataStor
     @Override
     public CompletableFuture<Void> addReaderGroupToScope(final String scope,
                                                          final String name, final UUID readerGroupId) {
-        return Futures.completeOn(((PravegaTablesScope) getScope(scope)).addReaderGroupToScope(name, readerGroupId), executor);
+        return Futures.completeOn(((PravegaTablesScope) getScope(scope))
+                .addReaderGroupToScope(name, readerGroupId), executor);
     }
 
     @Override

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -353,14 +353,18 @@ public class StreamMetadataTasks extends TaskBase {
                                  () -> streamMetadataStore.addReaderGroupToScope(scope, rgName, config.getReaderGroupId()))
                                          .thenCompose(x -> eventHelper.checkDone(() -> isRGCreated(scope, rgName, executor))
                                          .thenCompose(done -> streamMetadataStore.getReaderGroupId(scope, rgName)
-                                         .thenApply(rgId -> Controller.CreateReaderGroupResponse.newBuilder()
+                                         .thenCompose(rgId -> streamMetadataStore.getReaderGroupConfigRecord(scope, rgName, null, executor)
+                                                 .thenApply(cfgRecord -> CreateReaderGroupResponse.newBuilder()
                                                          .setReaderGroupId(rgId.toString())
-                                                         .setStatus(CreateReaderGroupResponse.Status.SUCCESS).build())));
+                                                         .setGeneration(cfgRecord.getObject().getGeneration())
+                                                         .setStatus(CreateReaderGroupResponse.Status.SUCCESS).build()))));
                      }
                      return streamMetadataStore.getReaderGroupId(scope, rgName)
-                             .thenApply(rgId -> Controller.CreateReaderGroupResponse.newBuilder()
+                             .thenCompose(rgId -> streamMetadataStore.getReaderGroupConfigRecord(scope, rgName, null, executor)
+                                     .thenApply(cfgRecord -> Controller.CreateReaderGroupResponse.newBuilder()
                                      .setReaderGroupId(rgId.toString())
-                                     .setStatus(CreateReaderGroupResponse.Status.SUCCESS).build());
+                                     .setGeneration(cfgRecord.getObject().getGeneration())
+                                     .setStatus(CreateReaderGroupResponse.Status.SUCCESS).build()));
                  });
          });
         }, e -> Exceptions.unwrap(e) instanceof RetryableException, READER_GROUP_OPERATION_MAX_RETRIES, executor);
@@ -443,14 +447,19 @@ public class StreamMetadataTasks extends TaskBase {
                                         return streamMetadataStore.addReaderGroupToScope(scope, rgName, config.getReaderGroupId())
                                                 .thenCompose(x -> createReaderGroupTasks(scope, rgName, config, createTimestamp))
                                                 .thenCompose(status -> streamMetadataStore.getReaderGroupId(scope, rgName)
-                                                .thenApply(rgId -> CreateReaderGroupResponse.newBuilder()
+                                                .thenCompose(rgId -> streamMetadataStore.getReaderGroupConfigRecord(scope, rgName, null, executor)
+                                                        .thenApply(cfgRecord ->
+                                                        CreateReaderGroupResponse.newBuilder()
                                                         .setReaderGroupId(rgId.toString())
-                                                        .setStatus(CreateReaderGroupResponse.Status.SUCCESS).build()));
+                                                        .setGeneration(cfgRecord.getObject().getGeneration())
+                                                        .setStatus(CreateReaderGroupResponse.Status.SUCCESS).build())));
                                     }
                                     return streamMetadataStore.getReaderGroupId(scope, rgName)
-                                            .thenApply(rgId -> CreateReaderGroupResponse.newBuilder()
+                                            .thenCompose(rgId -> streamMetadataStore.getReaderGroupConfigRecord(scope, rgName, null, executor)
+                                                    .thenApply(cfgRecord -> CreateReaderGroupResponse.newBuilder()
                                                     .setReaderGroupId(rgId.toString())
-                                                    .setStatus(CreateReaderGroupResponse.Status.SUCCESS).build());
+                                                    .setGeneration(cfgRecord.getObject().getGeneration())
+                                                    .setStatus(CreateReaderGroupResponse.Status.SUCCESS).build()));
                                 });
                     });
         }, e -> Exceptions.unwrap(e) instanceof RetryableException, 10, executor);

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithStreamTest.java
@@ -370,15 +370,15 @@ public abstract class ControllerServiceWithStreamTest {
                 .readerGroupId(UUID.randomUUID())
                 .startingStreamCuts(startSC)
                 .endingStreamCuts(endSC).build();
-        Controller.CreateReaderGroupStatus rgStatus =  consumer.createReaderGroup(SCOPE, "rg1",
+        Controller.CreateReaderGroupResponse rgStatus =  consumer.createReaderGroup(SCOPE, "rg1",
                                                         rgConfig, System.currentTimeMillis()).get();
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, rgStatus.getStatus());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, rgStatus.getStatus());
 
         // there should be 1 invocation
         verify(streamStore, times(1)).createReaderGroup(anyString(), anyString(), any(), anyLong(), any(), any());
 
         rgStatus = consumer.createReaderGroup(SCOPE, "rg1", rgConfig, System.currentTimeMillis()).get();
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, rgStatus.getStatus());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, rgStatus.getStatus());
 
         // verify that create readergroup is not called again
         verify(streamStore, times(1)).createReaderGroup(anyString(), anyString(), any(), anyLong(), any(), any());

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -285,7 +285,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
         final String scope = "scope";
         final String rgName = "subscriber";
         when(this.mockControllerService.getStreamMetadataTasks()).thenReturn(mockStreamMetaTasks);
-        Controller.ReaderGroupConfiguration expectedConfig = ModelHelper.decode(scope, rgName, config, config.getReaderGroupId());
+        Controller.ReaderGroupConfiguration expectedConfig = ModelHelper.decode(scope, rgName, config);
         when(mockStreamMetaTasks.createReaderGroupInternal(anyString(), any(), any(), anyLong()))
                 .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupResponse.newBuilder()
                         .setConfig(expectedConfig)
@@ -353,7 +353,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 .endingStreamCuts(endSC).build();
 
         final String rgName = "subscriber";
-        Controller.ReaderGroupConfiguration expectedConfig = ModelHelper.decode(scope, rgName, config, config.getReaderGroupId());
+        Controller.ReaderGroupConfiguration expectedConfig = ModelHelper.decode(scope, rgName, config);
         when(this.mockControllerService.getReaderGroupConfig(anyString(), anyString())).thenReturn(
                 CompletableFuture.completedFuture(Controller.ReaderGroupConfigResponse.newBuilder()
                         .setStatus(Controller.ReaderGroupConfigResponse.Status.SUCCESS)

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -283,30 +283,38 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
         StreamMetadataTasks mockStreamMetaTasks = mock(StreamMetadataTasks.class);
         when(this.mockControllerService.getStreamMetadataTasks()).thenReturn(mockStreamMetaTasks);
         when(mockStreamMetaTasks.createReaderGroupInternal(anyString(), any(), any(), anyLong()))
-                .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupStatus.Status.SUCCESS));
+                .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupResponse.newBuilder()
+                        .setReaderGroupId(config.getReaderGroupId().toString())
+                        .setStatus(Controller.CreateReaderGroupResponse.Status.SUCCESS).build()));
         Assert.assertTrue(this.testController.createReaderGroup("scope", "subscriber", config).join());
 
         when(mockStreamMetaTasks.createReaderGroupInternal(anyString(), any(), any(), anyLong()))
-                .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupStatus.Status.FAILURE));
+                .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupResponse.newBuilder()
+                                .setReaderGroupId(config.getReaderGroupId().toString())
+                                .setStatus(Controller.CreateReaderGroupResponse.Status.FAILURE).build()));
         assertThrows("Expected ControllerFailureException",
                 () -> this.testController.createReaderGroup("scope", "subscriber", config).join(),
                 ex -> ex instanceof ControllerFailureException);
 
         when(mockStreamMetaTasks.createReaderGroupInternal(anyString(), any(), any(), anyLong()))
-                .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupStatus.Status.INVALID_RG_NAME));
+                .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupResponse.newBuilder()
+                        .setReaderGroupId(config.getReaderGroupId().toString())
+                        .setStatus(Controller.CreateReaderGroupResponse.Status.INVALID_RG_NAME).build()));
         assertThrows("Expected IllegalArgumentException",
                 () -> this.testController.createReaderGroup("scope", "subscriber", config).join(),
                 ex -> ex instanceof IllegalArgumentException);
 
         when(mockStreamMetaTasks.createReaderGroupInternal(anyString(), any(), any(), anyLong()))
-                .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND));
+                .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupResponse.newBuilder()
+                        .setReaderGroupId(config.getReaderGroupId().toString())
+                        .setStatus(Controller.CreateReaderGroupResponse.Status.SCOPE_NOT_FOUND).build()));
         assertThrows("Expected IllegalArgumentException",
                 () -> this.testController.createReaderGroup("scope", "subscriber", config).join(),
                 ex -> ex instanceof IllegalArgumentException);
 
         when(mockStreamMetaTasks.createReaderGroupInternal(anyString(), any(), any(), anyLong()))
-                .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupStatus.newBuilder()
-                        .setStatusValue(-1).build().getStatus()));
+                .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupResponse.newBuilder()
+                        .setStatusValue(-1).build()));
         assertThrows("Expected ControllerFailureException",
                 () -> this.testController.createReaderGroup("scope", "subscriber", config).join(),
                 ex -> ex instanceof ControllerFailureException);

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -290,7 +290,13 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupResponse.newBuilder()
                         .setConfig(expectedConfig)
                         .setStatus(Controller.CreateReaderGroupResponse.Status.SUCCESS).build()));
-        Assert.assertEquals(expectedConfig, this.testController.createReaderGroup(scope, rgName, config).join());
+        ReaderGroupConfig responseCfg = this.testController.createReaderGroup(scope, rgName, config).join();
+        Assert.assertEquals(UUID.fromString(expectedConfig.getReaderGroupId()), responseCfg.getReaderGroupId());
+        Assert.assertEquals(expectedConfig.getRetentionType(), responseCfg.getRetentionType().ordinal());
+        Assert.assertEquals(expectedConfig.getGeneration(), responseCfg.getGeneration());
+        Assert.assertEquals(expectedConfig.getGroupRefreshTimeMillis(), responseCfg.getGroupRefreshTimeMillis());
+        Assert.assertEquals(expectedConfig.getAutomaticCheckpointIntervalMillis(), responseCfg.getAutomaticCheckpointIntervalMillis());
+        Assert.assertEquals(expectedConfig.getMaxOutstandingCheckpointRequest(), responseCfg.getMaxOutstandingCheckpointRequest());
 
         when(mockStreamMetaTasks.createReaderGroupInternal(anyString(), any(), any(), anyLong()))
                 .thenReturn(CompletableFuture.completedFuture(Controller.CreateReaderGroupResponse.newBuilder()

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -310,10 +310,10 @@ public class ControllerGrpcAuthFocusedTest {
         Controller.ReaderGroupConfiguration config = ModelHelper.decode(scope, "group", ReaderGroupConfig.builder().stream(NameUtils.getScopedStreamName(scope, stream)).build());
 
         //Act
-        Controller.CreateReaderGroupStatus status = blockingStub.createReaderGroup(config);
+        Controller.CreateReaderGroupResponse status = blockingStub.createReaderGroup(config);
 
         //Verify
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, status.getStatus());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, status.getStatus());
     }
 
     @Test
@@ -327,10 +327,10 @@ public class ControllerGrpcAuthFocusedTest {
         Controller.ReaderGroupConfiguration config = ModelHelper.decode(scope, "group", ReaderGroupConfig.builder().stream(NameUtils.getScopedStreamName(scope, stream)).build());
 
         //Act
-        Controller.CreateReaderGroupStatus status = blockingStub.createReaderGroup(config);
+        Controller.CreateReaderGroupResponse status = blockingStub.createReaderGroup(config);
 
         //Verify
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, status.getStatus());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, status.getStatus());
     }
 
     @Test
@@ -348,7 +348,7 @@ public class ControllerGrpcAuthFocusedTest {
         thrown.expectMessage("PERMISSION_DENIED");
 
         //Act
-        Controller.CreateReaderGroupStatus status = blockingStub.createReaderGroup(config);
+        Controller.CreateReaderGroupResponse status = blockingStub.createReaderGroup(config);
     }
 
     @Test
@@ -366,7 +366,7 @@ public class ControllerGrpcAuthFocusedTest {
         thrown.expectMessage("PERMISSION_DENIED");
 
         //Act
-        Controller.CreateReaderGroupStatus status = blockingStub.createReaderGroup(config);
+        Controller.CreateReaderGroupResponse status = blockingStub.createReaderGroup(config);
     }
 
     @Test
@@ -384,7 +384,7 @@ public class ControllerGrpcAuthFocusedTest {
         thrown.expectMessage("UNAUTHENTICATED");
 
         //Act
-        Controller.CreateReaderGroupStatus status = blockingStub.createReaderGroup(config);
+        Controller.CreateReaderGroupResponse status = blockingStub.createReaderGroup(config);
     }
 
     @Test
@@ -1044,8 +1044,8 @@ public class ControllerGrpcAuthFocusedTest {
         ControllerServiceBlockingStub stub =
                 prepareBlockingCallStub(UserNames.ADMIN, DEFAULT_PASSWORD);
 
-        Controller.CreateReaderGroupStatus status = stub.createReaderGroup(ModelHelper.decode(scope, group, config));
-        if (!status.getStatus().equals(Controller.CreateReaderGroupStatus.Status.SUCCESS)) {
+        Controller.CreateReaderGroupResponse status = stub.createReaderGroup(ModelHelper.decode(scope, group, config));
+        if (!status.getStatus().equals(Controller.CreateReaderGroupResponse.Status.SUCCESS)) {
             throw new RuntimeException("Failed to create reader-group");
         }
     }
@@ -1057,8 +1057,8 @@ public class ControllerGrpcAuthFocusedTest {
         ControllerServiceBlockingStub stub =
                 prepareBlockingCallStubStrict(UserNames.ADMIN, DEFAULT_PASSWORD);
 
-        Controller.CreateReaderGroupStatus status = stub.createReaderGroup(ModelHelper.decode(scope, group, config));
-        if (!status.getStatus().equals(Controller.CreateReaderGroupStatus.Status.SUCCESS)) {
+        Controller.CreateReaderGroupResponse status = stub.createReaderGroup(ModelHelper.decode(scope, group, config));
+        if (!status.getStatus().equals(Controller.CreateReaderGroupResponse.Status.SUCCESS)) {
             throw new RuntimeException("Failed to create reader-group");
         }
     }

--- a/controller/src/test/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImplTest.java
@@ -51,7 +51,7 @@ import io.pravega.controller.stream.api.grpc.v1.Controller.SuccessorResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateStreamStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateKeyValueTableStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteKVTableStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateSubscriberStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupResponse;
@@ -572,17 +572,17 @@ public abstract class ControllerServiceImplTest {
                 .readerGroupId(UUID.randomUUID())
                 .startingStreamCuts(startSC)
                 .endingStreamCuts(endSC).build();
-        ResultObserver<CreateReaderGroupStatus> result = new ResultObserver<>();
+        ResultObserver<CreateReaderGroupResponse> result = new ResultObserver<>();
         String rgName = "rg_1";
         this.controllerService.createReaderGroup(ModelHelper.decode(SCOPE1, rgName, config), result);
-        CreateReaderGroupStatus createRGStatus = result.get();
-        assertEquals("Create Reader Group Invalid RG Name", CreateReaderGroupStatus.Status.INVALID_RG_NAME, createRGStatus.getStatus());
+        CreateReaderGroupResponse createRGStatus = result.get();
+        assertEquals("Create Reader Group Invalid RG Name", CreateReaderGroupResponse.Status.INVALID_RG_NAME, createRGStatus.getStatus());
 
-        ResultObserver<CreateReaderGroupStatus> result1 = new ResultObserver<>();
+        ResultObserver<CreateReaderGroupResponse> result1 = new ResultObserver<>();
         rgName = "rg1";
         this.controllerService.createReaderGroup(ModelHelper.decode("somescope", rgName, config), result1);
         createRGStatus = result1.get();
-        assertEquals("Create Reader Group Scope not found", CreateReaderGroupStatus.Status.SCOPE_NOT_FOUND, createRGStatus.getStatus());
+        assertEquals("Create Reader Group Scope not found", CreateReaderGroupResponse.Status.SCOPE_NOT_FOUND, createRGStatus.getStatus());
     }
 
     @Test
@@ -1192,11 +1192,11 @@ public abstract class ControllerServiceImplTest {
                 .readerGroupId(rgId)
                 .startingStreamCuts(startSC)
                 .endingStreamCuts(endSC).build();
-        ResultObserver<CreateReaderGroupStatus> result = new ResultObserver<>();
+        ResultObserver<CreateReaderGroupResponse> result = new ResultObserver<>();
 
         this.controllerService.createReaderGroup(ModelHelper.decode(scope, rgName, config), result);
-        CreateReaderGroupStatus createRGStatus = result.get();
-        assertEquals("Create Reader Group", CreateReaderGroupStatus.Status.SUCCESS, createRGStatus.getStatus());
+        CreateReaderGroupResponse createRGStatus = result.get();
+        assertEquals("Create Reader Group", CreateReaderGroupResponse.Status.SUCCESS, createRGStatus.getStatus());
     }
 
     @Test(timeout = 30000L)

--- a/controller/src/test/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImplTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImplTest.java
@@ -574,13 +574,13 @@ public abstract class ControllerServiceImplTest {
                 .endingStreamCuts(endSC).build();
         ResultObserver<CreateReaderGroupResponse> result = new ResultObserver<>();
         String rgName = "rg_1";
-        this.controllerService.createReaderGroup(ModelHelper.decode(SCOPE1, rgName, config), result);
+        this.controllerService.createReaderGroup(ModelHelper.decode(SCOPE1, rgName, config, config.getReaderGroupId()), result);
         CreateReaderGroupResponse createRGStatus = result.get();
         assertEquals("Create Reader Group Invalid RG Name", CreateReaderGroupResponse.Status.INVALID_RG_NAME, createRGStatus.getStatus());
 
         ResultObserver<CreateReaderGroupResponse> result1 = new ResultObserver<>();
         rgName = "rg1";
-        this.controllerService.createReaderGroup(ModelHelper.decode("somescope", rgName, config), result1);
+        this.controllerService.createReaderGroup(ModelHelper.decode("somescope", rgName, config, config.getReaderGroupId()), result1);
         createRGStatus = result1.get();
         assertEquals("Create Reader Group Scope not found", CreateReaderGroupResponse.Status.SCOPE_NOT_FOUND, createRGStatus.getStatus());
     }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -399,23 +399,23 @@ public abstract class StreamMetadataTasksTest {
         streamMetadataTasks.setRequestEventWriter(requestEventWriter);
 
         // Create ReaderGroup 1
-        CompletableFuture<Controller.CreateReaderGroupStatus.Status> createFuture =
+        CompletableFuture<Controller.CreateReaderGroupResponse> createFuture =
         streamMetadataTasks.createReaderGroup(SCOPE, "rg1", rgConfigSubscriber1, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createFuture.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createFuture.join().getStatus());
 
         // Create ReaderGroup 2
         createFuture = streamMetadataTasks.createReaderGroup(SCOPE, "rg2", rgConfigSubscriber2, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createFuture.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createFuture.join().getStatus());
 
         // Create ReaderGroup 3
         createFuture = streamMetadataTasks.createReaderGroupInternal(SCOPE, "rg3", rgConfigSubscriber3, System.currentTimeMillis());
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createFuture.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createFuture.join().getStatus());
 
         // Create ReaderGroup 4
         createFuture = streamMetadataTasks.createReaderGroupInternal(SCOPE, "rg4", rgConfigNonSubscriber, System.currentTimeMillis());
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createFuture.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createFuture.join().getStatus());
 
         // LIst all subscriber ReaderGroup, there should be 3
         listSubscribersResponse = streamMetadataTasks.listSubscribers(SCOPE, stream1, null).get();
@@ -572,15 +572,15 @@ public abstract class StreamMetadataTasksTest {
         streamMetadataTasks.setRequestEventWriter(requestEventWriter);
 
         String subscriber1 = "subscriber1";
-        CompletableFuture<Controller.CreateReaderGroupStatus.Status> createStatus
+        CompletableFuture<Controller.CreateReaderGroupResponse> createStatus
         = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, rgConfigSubscriber, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, rgConfigSubscriber, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         SubscribersResponse listSubscribersResponse = streamMetadataTasks.listSubscribers(SCOPE, stream1, null).get();
         assertEquals(SubscribersResponse.Status.SUCCESS, listSubscribersResponse.getStatus());
@@ -1217,14 +1217,14 @@ public abstract class StreamMetadataTasksTest {
         // region case 1: basic retention
 
         String subscriber1 = "subscriber1";
-        CompletableFuture<Controller.CreateReaderGroupStatus.Status> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
+        CompletableFuture<Controller.CreateReaderGroupResponse> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         final String subscriber1Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber1);
         streamMetadataTasks.updateSubscriberStreamCut(SCOPE, stream1, subscriber1Name, consumpRGConfig.getReaderGroupId().toString(), 0L, ImmutableMap.of(0L, 2L, 1L, 1L), null).join();
@@ -1375,14 +1375,14 @@ public abstract class StreamMetadataTasksTest {
         doReturn(CompletableFuture.completedFuture(Controller.CreateStreamStatus.Status.SUCCESS))
                 .when(streamMetadataTasks).createRGStream(anyString(), anyString(), any(), anyLong(), anyInt());
         String subscriber1 = "subscriber1";
-        CompletableFuture<Controller.CreateReaderGroupStatus.Status> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
+        CompletableFuture<Controller.CreateReaderGroupResponse> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         final String subscriber1Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber1);
         final String subscriber2Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber2);
@@ -1613,14 +1613,14 @@ public abstract class StreamMetadataTasksTest {
         streamMetadataTasks.setRequestEventWriter(requestEventWriter);
 
         String subscriber1 = "subscriber1";
-        CompletableFuture<Controller.CreateReaderGroupStatus.Status> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
+        CompletableFuture<Controller.CreateReaderGroupResponse> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         final String subscriber1Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber1);
         final String subscriber2Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber2);
@@ -1709,14 +1709,14 @@ public abstract class StreamMetadataTasksTest {
         streamMetadataTasks.setRequestEventWriter(requestEventWriter);
 
         String subscriber1 = "subscriber1";
-        CompletableFuture<Controller.CreateReaderGroupStatus.Status> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
+        CompletableFuture<Controller.CreateReaderGroupResponse> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         final String subscriber1Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber1);
         final String subscriber2Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber2);
@@ -1822,14 +1822,14 @@ public abstract class StreamMetadataTasksTest {
         streamMetadataTasks.setRequestEventWriter(requestEventWriter);
 
         String subscriber1 = "subscriber1";
-        CompletableFuture<Controller.CreateReaderGroupStatus.Status> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
+        CompletableFuture<Controller.CreateReaderGroupResponse> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupStatus.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
 
         final String subscriber1Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber1);
         final String subscriber2Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber2);

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -409,6 +409,20 @@ public abstract class StreamMetadataTasksTest {
         assertTrue(Futures.await(processEvent(requestEventWriter)));
         assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createFuture.join().getStatus());
 
+        // Create ReaderGroup 2 again, and check that it returns success, but RG is not re-created
+        createFuture = streamMetadataTasks.createReaderGroup(SCOPE, "rg2", rgConfigSubscriber3, System.currentTimeMillis());
+        assertTrue(Futures.await(processEvent(requestEventWriter)));
+        Controller.CreateReaderGroupResponse createResponse = createFuture.join();
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createResponse.getStatus());
+        assertEquals(rgIdSub2, createResponse.getConfig().getReaderGroupId());
+        assertEquals(rgConfigSubscriber2.getRetentionType().ordinal(), createResponse.getConfig().getRetentionType());
+
+        createFuture = streamMetadataTasks.createReaderGroupInternal(SCOPE, "bad_rg_name", rgConfigSubscriber3, System.currentTimeMillis());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.INVALID_RG_NAME, createFuture.join().getStatus());
+
+        createFuture = streamMetadataTasks.createReaderGroupInternal("badscope", "rg3", rgConfigSubscriber3, System.currentTimeMillis());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SCOPE_NOT_FOUND, createFuture.join().getStatus());
+
         // Create ReaderGroup 3
         createFuture = streamMetadataTasks.createReaderGroupInternal(SCOPE, "rg3", rgConfigSubscriber3, System.currentTimeMillis());
         assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createFuture.join().getStatus());

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -411,10 +411,9 @@ public abstract class StreamMetadataTasksTest {
 
         // Create ReaderGroup 2 again, and check that it returns success, but RG is not re-created
         createFuture = streamMetadataTasks.createReaderGroup(SCOPE, "rg2", rgConfigSubscriber3, System.currentTimeMillis());
-        assertTrue(Futures.await(processEvent(requestEventWriter)));
         Controller.CreateReaderGroupResponse createResponse = createFuture.join();
         assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createResponse.getStatus());
-        assertEquals(rgIdSub2, createResponse.getConfig().getReaderGroupId());
+        assertEquals(rgIdSub2, UUID.fromString(createResponse.getConfig().getReaderGroupId()));
         assertEquals(rgConfigSubscriber2.getRetentionType().ordinal(), createResponse.getConfig().getRetentionType());
 
         createFuture = streamMetadataTasks.createReaderGroupInternal(SCOPE, "bad_rg_name", rgConfigSubscriber3, System.currentTimeMillis());
@@ -431,7 +430,7 @@ public abstract class StreamMetadataTasksTest {
         createFuture = streamMetadataTasks.createReaderGroupInternal(SCOPE, "rg4", rgConfigNonSubscriber, System.currentTimeMillis());
         assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createFuture.join().getStatus());
 
-        // LIst all subscriber ReaderGroup, there should be 3
+        // List all subscriber ReaderGroup, there should be 3
         listSubscribersResponse = streamMetadataTasks.listSubscribers(SCOPE, stream1, null).get();
         assertEquals(SubscribersResponse.Status.SUCCESS, listSubscribersResponse.getStatus());
         assertEquals(3, listSubscribersResponse.getSubscribersList().size());

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -575,12 +575,12 @@ public abstract class StreamMetadataTasksTest {
         CompletableFuture<Controller.CreateReaderGroupResponse> createStatus
         = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, rgConfigSubscriber, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, rgConfigSubscriber, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         SubscribersResponse listSubscribersResponse = streamMetadataTasks.listSubscribers(SCOPE, stream1, null).get();
         assertEquals(SubscribersResponse.Status.SUCCESS, listSubscribersResponse.getStatus());
@@ -1219,12 +1219,12 @@ public abstract class StreamMetadataTasksTest {
         String subscriber1 = "subscriber1";
         CompletableFuture<Controller.CreateReaderGroupResponse> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         final String subscriber1Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber1);
         streamMetadataTasks.updateSubscriberStreamCut(SCOPE, stream1, subscriber1Name, consumpRGConfig.getReaderGroupId().toString(), 0L, ImmutableMap.of(0L, 2L, 1L, 1L), null).join();
@@ -1377,12 +1377,12 @@ public abstract class StreamMetadataTasksTest {
         String subscriber1 = "subscriber1";
         CompletableFuture<Controller.CreateReaderGroupResponse> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         final String subscriber1Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber1);
         final String subscriber2Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber2);
@@ -1615,12 +1615,12 @@ public abstract class StreamMetadataTasksTest {
         String subscriber1 = "subscriber1";
         CompletableFuture<Controller.CreateReaderGroupResponse> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         final String subscriber1Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber1);
         final String subscriber2Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber2);
@@ -1711,12 +1711,12 @@ public abstract class StreamMetadataTasksTest {
         String subscriber1 = "subscriber1";
         CompletableFuture<Controller.CreateReaderGroupResponse> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         final String subscriber1Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber1);
         final String subscriber2Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber2);
@@ -1824,12 +1824,12 @@ public abstract class StreamMetadataTasksTest {
         String subscriber1 = "subscriber1";
         CompletableFuture<Controller.CreateReaderGroupResponse> createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber1, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         String subscriber2 = "subscriber2";
         createStatus = streamMetadataTasks.createReaderGroup(SCOPE, subscriber2, consumpRGConfig, System.currentTimeMillis());
         assertTrue(Futures.await(processEvent(requestEventWriter)));
-        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join());
+        assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, createStatus.join().getStatus());
 
         final String subscriber1Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber1);
         final String subscriber2Name = NameUtils.getScopedReaderGroupName(SCOPE, subscriber2);

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -55,7 +55,7 @@ service ControllerService {
     rpc deleteKeyValueTable(KeyValueTableInfo) returns (DeleteKVTableStatus);
     rpc listSubscribers(StreamInfo) returns (SubscribersResponse);
     rpc updateSubscriberStreamCut(SubscriberStreamCut) returns (UpdateSubscriberStatus);
-    rpc createReaderGroup(ReaderGroupConfiguration) returns (CreateReaderGroupStatus);
+    rpc createReaderGroup(ReaderGroupConfiguration) returns (CreateReaderGroupResponse);
     rpc getReaderGroupConfig(ReaderGroupInfo) returns (ReaderGroupConfigResponse);
     rpc deleteReaderGroup(ReaderGroupInfo) returns (DeleteReaderGroupStatus);
     rpc updateReaderGroup(ReaderGroupConfiguration) returns (UpdateReaderGroupResponse);
@@ -103,7 +103,7 @@ message ReaderGroupInfo {
     int64 generation = 4;
 }
 
-message CreateReaderGroupStatus {
+message CreateReaderGroupResponse {
     enum Status {
         SUCCESS = 0;
         FAILURE = 1;
@@ -111,6 +111,7 @@ message CreateReaderGroupStatus {
         INVALID_RG_NAME = 3;
     }
     Status status = 1;
+    string readerGroupId = 2;
 }
 
 message DeleteReaderGroupStatus {

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -112,6 +112,7 @@ message CreateReaderGroupResponse {
     }
     Status status = 1;
     string readerGroupId = 2;
+    int64 generation = 3;
 }
 
 message DeleteReaderGroupStatus {

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -111,8 +111,7 @@ message CreateReaderGroupResponse {
         INVALID_RG_NAME = 3;
     }
     Status status = 1;
-    string readerGroupId = 2;
-    int64 generation = 3;
+    ReaderGroupConfiguration config = 2;
 }
 
 message DeleteReaderGroupStatus {

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -32,7 +32,7 @@ import io.pravega.segmentstore.server.host.stat.AutoScaleMonitor;
 import io.pravega.segmentstore.server.host.stat.AutoScalerConfig;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
-import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupResponse;
 import io.pravega.shared.MetricsNames;
 import io.pravega.shared.NameUtils;
 import io.pravega.shared.metrics.MetricRegistryUtils;
@@ -182,8 +182,8 @@ public class StreamMetricsTest {
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.globalMetricName(MetricsNames.UPDATE_STREAM)).count());
 
         final String subscriber = "subscriber1";
-        CreateReaderGroupStatus createRGStatus = controllerWrapper.getControllerService().createReaderGroup(scopeName, subscriber, rgConfig, System.currentTimeMillis()).get();
-        assertEquals(CreateReaderGroupStatus.Status.SUCCESS, createRGStatus.getStatus());
+        CreateReaderGroupResponse createRGStatus = controllerWrapper.getControllerService().createReaderGroup(scopeName, subscriber, rgConfig, System.currentTimeMillis()).get();
+        assertEquals(CreateReaderGroupResponse.Status.SUCCESS, createRGStatus.getStatus());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.globalMetricName(MetricsNames.CREATE_READER_GROUP)).count());
 
         final String subscriberScopedName = NameUtils.getScopedReaderGroupName(scopeName, subscriber);

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -340,10 +340,10 @@ public class ControllerServiceTest {
                 .readerGroupId(UUID.randomUUID())
                 .endingStreamCuts(endSC).build();
 
-        CompletableFuture<Boolean> createRG = controller.createReaderGroup(scope, "rg1", rgConfig);
-        assertTrue(createRG.get());
+        CompletableFuture<ReaderGroupConfig> createRG = controller.createReaderGroup(scope, "rg1", rgConfig);
+        assertEquals(rgConfig.getReaderGroupId(), createRG.get().getReaderGroupId());
 
-        assertTrue(controller.createReaderGroup(scope, "rg2", rgConfig).get());
+        assertEquals(rgConfig.getReaderGroupId(), controller.createReaderGroup(scope, "rg2", rgConfig).get());
 
         assertThrows(IllegalArgumentException.class, () -> controller.createReaderGroup(scope, "bad_rg_name", rgConfig).get());
         assertThrows(IllegalArgumentException.class, () -> controller.createReaderGroup("badscope", "rg3", rgConfig).get());
@@ -399,7 +399,7 @@ public class ControllerServiceTest {
         final ReaderGroupConfig rgConfig1 = ReaderGroupConfig.builder().disableAutomaticCheckpoints()
                 .stream(scopedStreamName3).retentionType(ReaderGroupConfig.StreamDataRetention.AUTOMATIC_RELEASE_AT_LAST_CHECKPOINT)
                 .build();
-        assertTrue(controller.createReaderGroup(scope, "rg2", rgConfig1).get());
+        assertEquals(rgConfig1.getReaderGroupId(), controller.createReaderGroup(scope, "rg2", rgConfig1).get().getReaderGroupId());
 
         // Update a ReaderGroup from Subscriber to Non-subscriber
         String scopedStreamName = NameUtils.getScopedStreamName(scope, stream1);
@@ -409,7 +409,7 @@ public class ControllerServiceTest {
         ReaderGroupConfig rgConfigNonSubscriber = ReaderGroupConfig.builder().disableAutomaticCheckpoints()
                 .stream(scopedStreamName).readerGroupId(rgConfigSubscriber.getReaderGroupId()).generation(rgConfigSubscriber.getGeneration())
                 .build();
-        assertTrue(controller.createReaderGroup(scope, "group", rgConfigSubscriber).join());
+        assertEquals(rgConfigSubscriber.getReaderGroupId(), controller.createReaderGroup(scope, "group", rgConfigSubscriber).join().getReaderGroupId());
         subscribers = controller.listSubscribers(scope, stream1).get();
         assertEquals(1, subscribers.size());
         assertNotNull(controller.updateReaderGroup(scope, "group", rgConfigNonSubscriber).join());
@@ -455,8 +455,8 @@ public class ControllerServiceTest {
                 .endingStreamCuts(endSC).build();
 
         final String rg1 = "rg1";
-        CompletableFuture<Boolean> createRG = controller.createReaderGroup(scope, rg1, rgConfig);
-        assertTrue(createRG.get());
+        CompletableFuture<ReaderGroupConfig> createRG = controller.createReaderGroup(scope, rg1, rgConfig);
+        assertEquals(rgConfig.getReaderGroupId(), createRG.get().getReaderGroupId());
 
         List<String> subs = controller.listSubscribers(scope, stream).get();
         assertEquals(1, subs.size());

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -340,10 +340,11 @@ public class ControllerServiceTest {
                 .readerGroupId(UUID.randomUUID())
                 .endingStreamCuts(endSC).build();
 
-        CompletableFuture<ReaderGroupConfig> createRG = controller.createReaderGroup(scope, "rg1", rgConfig);
-        assertEquals(rgConfig.getReaderGroupId(), createRG.get().getReaderGroupId());
+        ReaderGroupConfig createRGResult = controller.createReaderGroup(scope, "rg1", rgConfig).get();
+        assertEquals(rgConfig.getReaderGroupId(), createRGResult.getReaderGroupId());
 
-        assertEquals(rgConfig.getReaderGroupId(), controller.createReaderGroup(scope, "rg2", rgConfig).get());
+        createRGResult = controller.createReaderGroup(scope, "rg2", rgConfig).get();
+        assertEquals(rgConfig.getReaderGroupId(), createRGResult.getReaderGroupId());
 
         assertThrows(IllegalArgumentException.class, () -> controller.createReaderGroup(scope, "bad_rg_name", rgConfig).get());
         assertThrows(IllegalArgumentException.class, () -> controller.createReaderGroup("badscope", "rg3", rgConfig).get());


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
createReaderGroup API in Controller is not idempotent when trying to recreate a partially created ReaderGroup

**Purpose of the change**  
Fixes #5650

**What the code does**  
Makes createReaderGroup() API Idempotent and it would now return the `ReaderGroupId` and `Generation` for the existing/new Reader Group so that State-Synchronizer can persist these values on client.

**How to verify it**  
All Unit and Integration Tests should pass.
