### PR TITLE
Issue 5653 : Ensure SegmentStore responds to the KeepAlive wirecommand from Client.

### DIFF
--- a/client/src/main/java/io/pravega/client/connection/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/FlowHandler.java
@@ -253,8 +253,8 @@ public class FlowHandler extends FailingReplyProcessor implements AutoCloseable 
     private ReplyProcessor getReplyProcessor(Reply cmd) {
         int flowId = disableFlow.get() ? FLOW_DISABLED : Flow.toFlowID(cmd.getRequestId());
         final ReplyProcessor processor = flowIdReplyProcessorMap.get(flowId);
-        if (processor == null ) {
-            log.warn("No ReplyProcessor found for the provided flowId {} and reply {}. Ignoring response", flowId, cmd);
+        if (processor == null) {
+            log.warn("No ReplyProcessor found for the provided flowId {}. Ignoring response", flowId);
             if (cmd instanceof WireCommands.ReleasableCommand) {
                 ((WireCommands.ReleasableCommand) cmd).release();
             }

--- a/client/src/main/java/io/pravega/client/connection/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/FlowHandler.java
@@ -147,6 +147,12 @@ public class FlowHandler extends FailingReplyProcessor implements AutoCloseable 
             return;
         }
 
+        if (cmd instanceof WireCommands.KeepAlive) {
+            // The SegmentStore responds to a KeepAlive WireCommand, this ensures the client can detect unresponsive
+            // SegmentStores due to network glitches. No action is required for the client on receiving this WireCommand.
+            return;
+        }
+
         // Obtain ReplyProcessor and process the reply.
         ReplyProcessor processor = getReplyProcessor(cmd);
         if (processor != null) {
@@ -247,8 +253,8 @@ public class FlowHandler extends FailingReplyProcessor implements AutoCloseable 
     private ReplyProcessor getReplyProcessor(Reply cmd) {
         int flowId = disableFlow.get() ? FLOW_DISABLED : Flow.toFlowID(cmd.getRequestId());
         final ReplyProcessor processor = flowIdReplyProcessorMap.get(flowId);
-        if (processor == null) {
-            log.warn("No ReplyProcessor found for the provided flowId {}. Ignoring response", flowId);
+        if (processor == null ) {
+            log.warn("No ReplyProcessor found for the provided flowId {} and reply {}. Ignoring response", flowId, cmd);
             if (cmd instanceof WireCommands.ReleasableCommand) {
                 ((WireCommands.ReleasableCommand) cmd).release();
             }

--- a/client/src/test/java/io/pravega/client/connection/impl/FlowHandlerTest.java
+++ b/client/src/test/java/io/pravega/client/connection/impl/FlowHandlerTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -229,6 +230,14 @@ public class FlowHandlerTest {
         flowHandler.process(msg);
         verify(processor).hello(msg);
         verify(errorProcessor).hello(msg);
+    }
+
+    @Test
+    public void testKeepAlive() {
+        final WireCommands.KeepAlive msg = new WireCommands.KeepAlive();
+        flowHandler.process(msg);
+        // ensure none of the Replyprocessors are bothered with this msg.
+        verifyNoInteractions(processor);
     }
 
     @Test

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -130,6 +130,12 @@ public class AppendProcessor extends DelegatingRequestProcessor {
         }
     }
 
+    @Override
+    public void keepAlive(WireCommands.KeepAlive keepAlive) {
+        log.debug("Received a keepAlive from connection: {}", connection);
+        connection.send(keepAlive);
+    }
+
     /**
      * Setup an append so that subsequent append calls can occur.
      * This requires validating that the segment exists.

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -106,6 +106,22 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
     }
 
     @Test
+    public void testKeepAlive() {
+        ServerConnection connection = mock(ServerConnection.class);
+        AppendProcessor processor = AppendProcessor.defaultBuilder()
+                .store(mock(StreamSegmentStore.class))
+                .connection(connection)
+                .connectionTracker(mock(ConnectionTracker.class))
+                .statsRecorder(Mockito.mock(SegmentStatsRecorder.class))
+                .build();
+
+
+        WireCommands.KeepAlive keepAliveCommand = new WireCommands.KeepAlive();
+        processor.keepAlive(keepAliveCommand);
+        verify(connection).send(new WireCommands.KeepAlive());
+    }
+
+    @Test
     public void testAppend() {
         String streamSegmentName = "scope/stream/0.#epoch.0";
         UUID clientId = UUID.randomUUID();

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -115,7 +115,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
                 .statsRecorder(Mockito.mock(SegmentStatsRecorder.class))
                 .build();
 
-
         WireCommands.KeepAlive keepAliveCommand = new WireCommands.KeepAlive();
         processor.keepAlive(keepAliveCommand);
         verify(connection).send(new WireCommands.KeepAlive());

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -177,7 +177,7 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
 
     @Override
     public void keepAlive(KeepAlive keepAlive) {
-        throw new IllegalStateException("Unexpected operation: " + keepAlive);
+        log.info("KeepAlive received");
     }
 
     @Override

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -177,7 +177,7 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
 
     @Override
     public void keepAlive(KeepAlive keepAlive) {
-        log.info("KeepAlive received");
+        log.trace("KeepAlive received");
     }
 
     @Override

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/FailingReplyProcessorTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/FailingReplyProcessorTest.java
@@ -14,7 +14,6 @@ import io.pravega.shared.protocol.netty.WireCommands.AuthTokenCheckFailed;
 import io.pravega.shared.protocol.netty.WireCommands.ConditionalCheckFailed;
 import io.pravega.shared.protocol.netty.WireCommands.DataAppended;
 import io.pravega.shared.protocol.netty.WireCommands.InvalidEventNumber;
-import io.pravega.shared.protocol.netty.WireCommands.KeepAlive;
 import io.pravega.shared.protocol.netty.WireCommands.NoSuchSegment;
 import io.pravega.shared.protocol.netty.WireCommands.OperationUnsupported;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentAlreadyExists;
@@ -64,7 +63,6 @@ public class FailingReplyProcessorTest {
         assertThrows(IllegalStateException.class, () -> rp.conditionalCheckFailed(new ConditionalCheckFailed(null, 1, 2)));
         assertThrows(IllegalStateException.class, () -> rp.dataAppended(new DataAppended(1, null, 0, -1, 2)));
         assertThrows(IllegalStateException.class, () -> rp.invalidEventNumber(new InvalidEventNumber(null, 0, "")));
-        assertThrows(IllegalStateException.class, () -> rp.keepAlive(new KeepAlive()));
         assertThrows(IllegalStateException.class, () -> rp.noSuchSegment(new NoSuchSegment(0, "", "", 2)));
         assertThrows(UnsupportedOperationException.class, () -> rp.operationUnsupported(new OperationUnsupported(0, "", "")));
         assertThrows(IllegalStateException.class, () -> rp.segmentAlreadyExists(new SegmentAlreadyExists(1, "", "")));


### PR DESCRIPTION
**Change log description**  
Ensure the SegmentStore responds to the KeepAlive messages from the Client. 

**Purpose of the change**  
Fixes #5653 

**What the code does**  
The client currently configures a socket timeout of 3 mins. This implies that if there is no data received on a socket for more than 3 mins the client drops the connection and tries to re-establish a connection. 
It should be noted that the SegmentStore does not respond to `READ_SEGMENT `call unless it has data. This can leads to a situation where a given socket has no traffic being recieved from the Segmentstore . This is a rare occurence given that connection pooling is enabled by default.
In a scenario where there is no data recieved by the client for 3 mins a `SocketTimeOutException` is thrown by the Socket and the client retries establishing a connection with the SegmentStore. If this `SocketTimeoutException ` happens for more than max retry configuration times then the client gives up and throws a `RetriesExhaustedException`.

This PR ensures we do not land in this scenario by ensuring the SegmentStore responds to the KeepALive wirecommand which is sent by the client on Idle connections.

**How to verify it**  
All the existing tests should continue to work. The longetivity tests should pass with this change.
