### PR TITLE
Issue 5647: (SegmentStore) (BugFix) Table Segment Conditional Updates may fail if Compaction occurrs simultaneously

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
@@ -24,7 +24,6 @@ import io.pravega.segmentstore.contracts.AttributeUpdateType;
 import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.SegmentType;
-import io.pravega.segmentstore.contracts.StreamSegmentTruncatedException;
 import io.pravega.segmentstore.contracts.tables.IteratorArgs;
 import io.pravega.segmentstore.contracts.tables.IteratorItem;
 import io.pravega.segmentstore.contracts.tables.TableAttributes;
@@ -319,27 +318,8 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
                 builder.includeResult(CompletableFuture.completedFuture(null));
             } else {
                 // Find the sought entry in the segment, based on its key.
-                // We first attempt an optimistic read, which involves fewer steps, and only invalidate the cache and read
-                // directly from the index if unable to find anything and there is a chance the sought key actually exists.
-                // Encountering a truncated Segment offset indicates that the Segment may have recently been compacted and
-                // we are using a stale cache value.
                 BufferView key = builder.getKeys().get(i);
-                builder.includeResult(Futures
-                        .exceptionallyExpecting(bucketReader.find(key, offset, timer), ex -> ex instanceof StreamSegmentTruncatedException, null)
-                        .thenComposeAsync(entry -> {
-                            if (entry != null) {
-                                // We found an entry; need to figure out if it was a deletion or not.
-                                return CompletableFuture.completedFuture(maybeDeleted(entry));
-                            } else {
-                                // We have a valid TableBucket but were unable to locate the key using the cache, either
-                                // because the cache points to a truncated offset or because we are unable to determine
-                                // if the TableBucket has been rearranged due to a compaction. The rearrangement is a rare
-                                // occurrence and can only happen if more than one Key is mapped to a bucket (collision).
-                                return this.keyIndex.getBucketOffsetDirect(segment, keyHash, timer)
-                                        .thenComposeAsync(newOffset -> bucketReader.find(key, newOffset, timer), this.executor)
-                                        .thenApply(this::maybeDeleted);
-                            }
-                        }, this.executor));
+                builder.includeResult(this.keyIndex.findBucketEntry(segment, bucketReader, key, offset, timer).thenApply(this::maybeDeleted));
             }
         }
 


### PR DESCRIPTION
**Change log description**  
Fixed a bug in ContainerKeyIndex where conditional update validation would fail if the update key has recently been relocated to a new position and the old key has been truncated away.

**Purpose of the change**  
Fixes #5647.

**What the code does**  
The steps for a table segment compaction are as follows:
1. A group of Table Entries is copied from the head of the segment to the tail.
2. (Later) Those entries are re-indexed and the index now points to the new locations.
3. The old entries are truncated away.

Sometime after 2), the SegmentKeyCache should be updated with the new location. If not, we might be trying to access the old location. The ContainerTableExtensionImpl already handles this for reads and iterators, however this functionality has not been added for conditional updates. Conditional updates may need to read the table segment in case it needs to do a proper validation of the provided key version.

This code unifies the two paths to use the same piece of code. 

**How to verify it**  
New unit test added. Build must pass.
