### PR TITLE
Issue 5636: (SegmentStore) (BugFix) Excessive eviction of Extended Attributes

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataCleaner.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataCleaner.java
@@ -25,7 +25,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
-
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -169,7 +168,7 @@ class MetadataCleaner extends AbstractThreadPoolService {
                 .thenRunAsync(() -> {
                     Collection<SegmentMetadata> evictedSegments = this.metadata.cleanup(cleanupCandidates, lastSeqNo);
                     this.cleanupCallback.accept(evictedSegments);
-                    int evictedAttributes = this.metadata.cleanupExtendedAttributes(0, lastSeqNo);
+                    int evictedAttributes = this.metadata.cleanupExtendedAttributes(this.config.getMaxCachedExtendedAttributeCount(), lastSeqNo);
                     LoggerHelpers.traceLeave(log, this.traceObjectId, "metadataCleanup", traceId, evictedSegments.size(), evictedAttributes);
                 }, this.executor);
     }


### PR DESCRIPTION
**Change log description**  
Fixed a bug in MetadataCleaner where it did not respect the configuration value that was determining how many extended attributes should be kept in the memory cache.

**Purpose of the change**  
Fixes #5636.

**What the code does**  
The MetadataCleaner is responsible with both _triggering_ the eviction of segments from the memory cache and the eviction of extended attributes from segments that are still active (the actual eviction is done in the metadata itself, based on several criteria) - that's out of scope for this PR.

The MetadataCleaner is responsible with telling the Metadata eviction  how many extended attributes per segment are desired to remain in memory. Currently it was passing `0`, which meant that it would always try to evict all of them. That defeats the purpose of trying to cache them in the first place. 

This PR passes in the value that is read from the configuration as that argument. It also fixes a few unit tests to validate this happens. No other changes to production code (the eviction was working as intended).

**How to verify it**  
Build must pass. Updated 2 unit tests to ensure this config setting is respected.
