### PR TITLE
Issue 5664: (SLTS)  fix possible thread visibility issues..

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -463,7 +464,7 @@ public class ChunkedSegmentStorage implements Storage {
     public CompletableFuture<Void> defrag(MetadataTransaction txn, SegmentMetadata segmentMetadata,
                                            String startChunkName,
                                            String lastChunkName,
-                                           ArrayList<String> chunksToDelete) {
+                                           List<String> chunksToDelete) {
         return new DefragmentOperation(this, txn, segmentMetadata, startChunkName, lastChunkName, chunksToDelete).call();
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
@@ -25,6 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -42,7 +44,7 @@ class ConcatOperation implements Callable<CompletableFuture<Void>> {
     private final long offset;
     private final String sourceSegment;
     private final ChunkedSegmentStorage chunkedSegmentStorage;
-    private final ArrayList<String> chunksToDelete = new ArrayList<>();
+    private final List<String> chunksToDelete = Collections.synchronizedList(new ArrayList<>());
     private final Timer timer;
 
     private volatile SegmentMetadata targetSegmentMetadata;

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/DefragmentOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/DefragmentOperation.java
@@ -19,6 +19,8 @@ import lombok.val;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -101,10 +103,10 @@ class DefragmentOperation implements Callable<CompletableFuture<Void>> {
     private final SegmentMetadata segmentMetadata;
     private final String startChunkName;
     private final String lastChunkName;
-    private final ArrayList<String> chunksToDelete;
+    private final List<String> chunksToDelete;
     private final ChunkedSegmentStorage chunkedSegmentStorage;
 
-    private volatile ArrayList<ChunkInfo> chunksToConcat = new ArrayList<>();
+    private volatile List<ChunkInfo> chunksToConcat = Collections.synchronizedList(new ArrayList<>());
 
     private volatile ChunkMetadata target;
     private volatile String targetChunkName;
@@ -119,7 +121,7 @@ class DefragmentOperation implements Callable<CompletableFuture<Void>> {
     private final AtomicLong bytesToRead = new AtomicLong();
     private final AtomicInteger currentArgIndex = new AtomicInteger();
 
-    DefragmentOperation(ChunkedSegmentStorage chunkedSegmentStorage, MetadataTransaction txn, SegmentMetadata segmentMetadata, String startChunkName, String lastChunkName, ArrayList<String> chunksToDelete) {
+    DefragmentOperation(ChunkedSegmentStorage chunkedSegmentStorage, MetadataTransaction txn, SegmentMetadata segmentMetadata, String startChunkName, String lastChunkName, List<String> chunksToDelete) {
         this.txn = txn;
         this.segmentMetadata = segmentMetadata;
         this.startChunkName = startChunkName;
@@ -226,7 +228,7 @@ class DefragmentOperation implements Callable<CompletableFuture<Void>> {
                                     ((ChunkMetadata) metadata).setActive(false);
                                     txn.update(metadata);
                                 }, chunkedSegmentStorage.getExecutor()));
-                segmentMetadata.decrementChunkCount();
+                segmentMetadata.setChunkCount(segmentMetadata.getChunkCount() - 1);
             }
             return Futures.allOf(futures).thenRunAsync(() -> {
                 txn.update(target);
@@ -241,7 +243,7 @@ class DefragmentOperation implements Callable<CompletableFuture<Void>> {
         return txn.get(targetChunkName)
                 .thenComposeAsync(storageMetadata -> {
                     target = (ChunkMetadata) storageMetadata;
-                    chunksToConcat = new ArrayList<>();
+                    chunksToConcat = Collections.synchronizedList(new ArrayList<>());
                     targetSizeAfterConcat.set(target.getLength());
 
                     // Add target to the list of chunks

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -469,7 +469,7 @@ public class SystemJournal {
                 ChunkMetadata chunkToDelete = (ChunkMetadata) txn.get(toDelete).get();
                 txn.delete(toDelete);
                 toDelete = chunkToDelete.getNextChunk();
-                segmentMetadata.decrementChunkCount();
+                segmentMetadata.setChunkCount(segmentMetadata.getChunkCount() - 1);
             }
 
             // Set next chunk
@@ -486,7 +486,7 @@ public class SystemJournal {
         }
         segmentMetadata.setLastChunk(newChunkName);
         segmentMetadata.setLastChunkStartOffset(offset);
-        segmentMetadata.incrementChunkCount();
+        segmentMetadata.setChunkCount(segmentMetadata.getChunkCount() + 1);
         segmentMetadata.checkInvariants();
         // Save the segment metadata.
         txn.update(segmentMetadata);
@@ -520,7 +520,7 @@ public class SystemJournal {
             // move to next chunk
             currentChunkName = currentMetadata.getNextChunk();
             txn.delete(currentMetadata.getName());
-            segmentMetadata.decrementChunkCount();
+            segmentMetadata.setChunkCount(segmentMetadata.getChunkCount() - 1);
         }
         Preconditions.checkState(firstChunkStartsAt == startOffset);
         segmentMetadata.setFirstChunk(currentChunkName);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
@@ -24,6 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -40,7 +42,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
     private final SegmentHandle handle;
     private final long offset;
     private final ChunkedSegmentStorage chunkedSegmentStorage;
-    private final ArrayList<String> chunksToDelete = new ArrayList<>();
+    private final List<String> chunksToDelete = Collections.synchronizedList(new ArrayList<>());
     private final long traceId;
     private final Timer timer;
     private volatile String currentChunkName;
@@ -170,7 +172,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
 
                             startOffset.addAndGet(currentMetadata.getLength());
                             chunksToDelete.add(currentMetadata.getName());
-                            segmentMetadata.decrementChunkCount();
+                            segmentMetadata.setChunkCount(segmentMetadata.getChunkCount() - 1);
 
                             // move to next chunk
                             currentChunkName = currentMetadata.getNextChunk();

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadata.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadata.java
@@ -30,6 +30,7 @@ import static com.google.common.base.Strings.nullToEmpty;
  * <li>Name of the chunk.</li>
  * <li>Length of the chunk.</li>
  * <li>Name of the next chunk in list.</li>
+ * <li>Status flags.</li>
  * </ul>
  */
 @Builder(toBuilder = true)
@@ -45,17 +46,17 @@ public class ChunkMetadata extends StorageMetadata {
     /**
      * Length of the chunk.
      */
-    private long length;
+    private volatile long length;
 
     /**
      * Name of the next chunk.
      */
-    private String nextChunk;
+    private volatile String nextChunk;
 
     /**
      * Status bit flags.
      */
-    private int status;
+    private volatile int status;
 
     /**
      * Retrieves the key associated with the metadata, which is the name of the chunk.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/SegmentMetadata.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/SegmentMetadata.java
@@ -54,42 +54,42 @@ public class SegmentMetadata extends StorageMetadata {
     /**
      * Length of the segment.
      */
-    private long length;
+    private volatile long length;
 
     /**
      * Number of chunks.
      */
-    private int chunkCount;
+    private volatile int chunkCount;
 
     /**
      * Start offset of the segment. This is offset of the first byte available for read.
      */
-    private long startOffset;
+    private volatile long startOffset;
 
     /**
      * Status bit flags.
      */
-    private int status;
+    private volatile int status;
 
     /**
      * Maximum Rolling length of the segment.
      */
-    private long maxRollinglength;
+    private volatile long maxRollinglength;
 
     /**
      * Name of the first chunk.
      */
-    private String firstChunk;
+    private volatile String firstChunk;
 
     /**
      * Name of the last chunk.
      */
-    private String lastChunk;
+    private volatile String lastChunk;
 
     /**
      * Last modified time.
      */
-    private long lastModified;
+    private volatile long lastModified;
 
     /**
      * Offset of the first byte of the first chunk.
@@ -97,17 +97,17 @@ public class SegmentMetadata extends StorageMetadata {
      * With arbitrary truncates the effective start offset might be in the middle of the first chunk.
      *
      */
-    private long firstChunkStartOffset;
+    private volatile long firstChunkStartOffset;
 
     /**
      * Offset of the first byte of the last chunk.
      */
-    private long lastChunkStartOffset;
+    private volatile long lastChunkStartOffset;
 
     /**
      * Epoch of the container that last owned it.
      */
-    private long ownerEpoch;
+    private volatile long ownerEpoch;
 
     /**
      * Retrieves the key associated with the metadata, which is the name of the segment.
@@ -223,22 +223,6 @@ public class SegmentMetadata extends StorageMetadata {
             Preconditions.checkState(firstChunkStartOffset == lastChunkStartOffset, "firstChunkStartOffset must equal lastChunkStartOffset when there is only one chunk.");
             Preconditions.checkState(chunkCount == 1, "chunkCount should be 1.");
         }
-    }
-
-    /**
-     * Increment chunk count.
-     */
-    public void incrementChunkCount() {
-        chunkCount++;
-        Preconditions.checkState(chunkCount >= 0, "chunkCount should be non-negative.");
-    }
-
-    /**
-     * Decrement chunk count.
-     */
-    public void decrementChunkCount() {
-        chunkCount--;
-        Preconditions.checkState(chunkCount >= 0, "chunkCount should be non-negative.");
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Use Collections.synchronized /synchronized to force memory barrier
Use volatile for mutable variables

**Purpose of the change**  
Fixes #5664 

**What the code does**  
There are couple of places in SLTS code where arrays and other data structures are protected from concurrent modifications yet could still potentially show thread visibility issue.

**How to verify it**  
Use Collections.synchronized /synchronized to force memory barrier
Use volatile for mutable variables
