### PR TITLE
Issue 5673: (SLTS) Fix wrong GC config

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
@@ -41,8 +41,8 @@ public class ChunkedSegmentStorageConfig {
     public static final Property<Integer> GARBAGE_COLLECTION_DELAY = Property.named("garbage.collection.delay.seconds", 60);
     public static final Property<Integer> GARBAGE_COLLECTION_MAX_CONCURRENCY = Property.named("garbage.collection.concurrency.max", 10);
     public static final Property<Integer> GARBAGE_COLLECTION_MAX_QUEUE_SIZE = Property.named("garbage.collection.queue.size.max", 16 * 1024);
-    public static final Property<Integer> GARBAGE_COLLECTION_SLEEP = Property.named("garbage.collection.sleep.seconds", 60);
-    public static final Property<Integer> GARBAGE_COLLECTION_MAX_ATTEMPS = Property.named("garbage.collection.attempts.max", 3);
+    public static final Property<Integer> GARBAGE_COLLECTION_SLEEP = Property.named("garbage.collection.sleep.millis", 10);
+    public static final Property<Integer> GARBAGE_COLLECTION_MAX_ATTEMPTS = Property.named("garbage.collection.attempts.max", 3);
 
 
     /**
@@ -63,7 +63,7 @@ public class ChunkedSegmentStorageConfig {
             .garbageCollectionDelay(Duration.ofSeconds(60))
             .garbageCollectionMaxConcurrency(10)
             .garbageCollectionMaxQueueSize(16 * 1024)
-            .garbageCollectionSleep(Duration.ofSeconds(60))
+            .garbageCollectionSleep(Duration.ofMillis(10))
             .garbageCollectionMaxAttempts(3)
             .build();
 
@@ -191,8 +191,8 @@ public class ChunkedSegmentStorageConfig {
         this.garbageCollectionDelay = Duration.ofSeconds(properties.getInt(GARBAGE_COLLECTION_DELAY));
         this.garbageCollectionMaxConcurrency = properties.getInt(GARBAGE_COLLECTION_MAX_CONCURRENCY);
         this.garbageCollectionMaxQueueSize = properties.getInt(GARBAGE_COLLECTION_MAX_QUEUE_SIZE);
-        this.garbageCollectionSleep = Duration.ofSeconds(properties.getInt(GARBAGE_COLLECTION_SLEEP));
-        this.garbageCollectionMaxAttempts = properties.getInt(GARBAGE_COLLECTION_MAX_ATTEMPS);
+        this.garbageCollectionSleep = Duration.ofMillis(properties.getInt(GARBAGE_COLLECTION_SLEEP));
+        this.garbageCollectionMaxAttempts = properties.getInt(GARBAGE_COLLECTION_MAX_ATTEMPTS);
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollector.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollector.java
@@ -168,15 +168,11 @@ public class GarbageCollector extends AbstractThreadPoolService implements AutoC
         loopFuture = Futures.loop(
                 this::canRun,
                 () -> delaySupplier.get()
-                        .thenRunAsync(() -> {
-                            log.info("{}: Iteration {} started.", traceObjectId, iterationId.get());
-                        }, executor)
                         .thenComposeAsync(v -> deleteGarbage(true, config.getGarbageCollectionMaxConcurrency()), executor)
                         .handleAsync((v, ex) -> {
                             if (null != ex) {
                                 log.error("{}: Error during doRun.", traceObjectId, ex);
                             }
-                            log.info("{}: Iteration {} ended.", traceObjectId, iterationId.getAndIncrement());
                             return null;
                         }, executor),
                 executor);
@@ -240,7 +236,7 @@ public class GarbageCollector extends AbstractThreadPoolService implements AutoC
      * @return CompletableFuture which is completed when garbage is deleted.
      */
     CompletableFuture<Boolean> deleteGarbage(boolean isBackground, int maxItems) {
-        log.debug("{}: deleteGarbage - started.", traceObjectId);
+        log.debug("{}: Iteration {} started.", traceObjectId, iterationId.get());
         // Sleep if suspended.
         if (suspended.get() && isBackground) {
             log.info("{}: deleteGarbage - suspended - sleeping for {}.", traceObjectId, config.getGarbageCollectionDelay());
@@ -352,7 +348,7 @@ public class GarbageCollector extends AbstractThreadPoolService implements AutoC
         }
         return Futures.allOf(futures)
                 .thenApplyAsync( v -> {
-                    log.debug("{}: deleteGarbage - finished.", traceObjectId);
+                    log.debug("{}: Iteration {} ended.", traceObjectId, iterationId.getAndIncrement());
                     return true;
                 }, executor);
     }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
@@ -37,7 +37,7 @@ public class ChunkedSegmentStorageConfigTests {
         props.setProperty(ChunkedSegmentStorageConfig.GARBAGE_COLLECTION_MAX_QUEUE_SIZE.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "10");
         props.setProperty(ChunkedSegmentStorageConfig.GARBAGE_COLLECTION_MAX_CONCURRENCY.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "11");
         props.setProperty(ChunkedSegmentStorageConfig.GARBAGE_COLLECTION_SLEEP.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "12");
-        props.setProperty(ChunkedSegmentStorageConfig.GARBAGE_COLLECTION_MAX_ATTEMPS.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "13");
+        props.setProperty(ChunkedSegmentStorageConfig.GARBAGE_COLLECTION_MAX_ATTEMPTS.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "13");
 
         TypedProperties typedProperties = new TypedProperties(props, "storage");
         ChunkedSegmentStorageConfig config = new ChunkedSegmentStorageConfig(typedProperties);
@@ -55,7 +55,7 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertEquals(config.getGarbageCollectionDelay().toSeconds(), 9);
         Assert.assertEquals(config.getGarbageCollectionMaxQueueSize(), 10);
         Assert.assertEquals(config.getGarbageCollectionMaxConcurrency(), 11);
-        Assert.assertEquals(config.getGarbageCollectionSleep().toSeconds(), 12);
+        Assert.assertEquals(config.getGarbageCollectionSleep().toMillis(), 12);
         Assert.assertEquals(config.getGarbageCollectionMaxAttempts(), 13);
     }
 


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Change unit from seconds to milliseconds.
Also change log.info to log.debug to reduce noise.

**Purpose of the change**  
Fixes #5673

**What the code does**  

- Change default settings from 60 seconds to 10 milliseconds. (Note that - Every 10 millisecond, new iteration starts and waits for items to be available for GC on its dedicated thread, and deletes 10 chunks max per iteration. We need small wait time between iterations.)
- Fix spelling mistake.
- Also change log.info to log.debug to reduce noise.

**How to verify it**  
No regression
