### PR TITLE
Issue 5679: (SegmentStore) (BugFix) Appends may be erroneously rejected with BadOffsetException

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -273,18 +273,19 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
         if (!this.recoveryMode) {
             // Offset check (if append-with-offset).
             long operationOffset = operation.getStreamSegmentOffset();
-            if (operationOffset >= 0) {
+            if (operationOffset >= 0 && operationOffset != this.length) {
                 // If the Operation already has an offset assigned, verify that it matches the current end offset of the Segment.
-                if (operationOffset != this.length) {
-                    throw new BadOffsetException(this.name, this.length, operationOffset);
-                }
-            } else {
-                // No pre-assigned offset. Put the Append at the end of the Segment.
-                operation.setStreamSegmentOffset(this.length);
+                throw new BadOffsetException(this.name, this.length, operationOffset);
             }
 
             // Attribute validation.
             preProcessAttributes(operation.getAttributeUpdates());
+
+            // Only assign the offset after all validations passed. Otherwise we will modify the operation and a
+            // subsequent retry may fail with an unexpected exception.
+            if (operationOffset < 0) {
+                operation.setStreamSegmentOffset(this.length);
+            }
         }
     }
 

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -19,7 +19,6 @@ import java.util.Random;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -103,6 +102,16 @@ public class TestUtils {
         modifiersField.setAccessible(true);
         modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
         field.set(null, newValue);
+    }
+
+    /**
+     * A no-op {@link java.util.function.Consumer<T>} that does nothing.
+     *
+     * @param ignored Arg.
+     * @param <T>     Type.
+     */
+    public static <T> void doNothing(T ignored) {
+        // Does nothing.
     }
 
 }


### PR DESCRIPTION
**Change log description**  
Fixed a bug in SegmentMetadataUpdateTransaction where the StreamSegmentAppendOperation's offset would be inadvertently updated if that operation was rejected for other reasons.

**Purpose of the change**  
Fixes #5679.

**What the code does**  
See #5679 for a scenario where this can occur.

The `SegmentMetadataUpdateTransaction` is responsible for validating (`preProcess****`) any operations for a segment and incorporating (`accept****`) their effects into the segment's metadata.

For `StreamSegmentAppendOperation` validation, there was a a bug where the given operation would be modified (`setStreamSegmentOffset`) even if it was about to be rejected (for another reason). In case of an internal retry (with the same operation), that append would actually be treated as an offset-conditional append (due to it having the offset set) and it may be rejected if another append got accepted in the pipeline in the meantime.

**How to verify it**  
Unit test updated to verify no side effects.
