### PR TITLE
Issue 5683: Update the year and include Pravega Authors in NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
-Copyright (c) 2017-2020 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) 2021 Pravega Authors.
+Copyright (c) 2017-2021 Dell Inc., or its subsidiaries. All Rights Reserved.
 
 This software contains source code from Apache BookKeeper, distributed under
-the Apache License Version 2.0, and copyrighted to the
-Apache Software Foundation.
+the Apache License Version 2.0, and copyrighted to the Apache Software Foundation.
 http://bookkeeper.apache.org


### PR DESCRIPTION
**Change log description**  
* Updates NOTICE file the new year range `2017-2021`
* Adds Pravega Authors at the top to comply with CNCF guidelines 

**Purpose of the change**  
Fixes #5683 

**What the code does**  
No code change is done, just an update in NOTICE file 

**How to verify it**  
No special verification is required, build should pass though
