### PR TITLE
Issue 5667: (Bug) Ensure ByteStreamWriter attempts connecting to SSS until it is closed.

### DIFF
--- a/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/byteStream/impl/ByteStreamClientImpl.java
@@ -76,7 +76,8 @@ public class ByteStreamClientImpl implements ByteStreamClientFactory {
         Preconditions.checkState(segments.getNumberOfSegments() > 0, "Stream is sealed");
         Preconditions.checkState(segments.getNumberOfSegments() == 1, "Stream is configured with more than one segment");
         Segment segment = segments.getSegments().iterator().next();
-        EventWriterConfig config = EventWriterConfig.builder().build();
+        // The writer should not give up connecting to SegmentStore in the background until the ByteStreamWriter is closed.
+        EventWriterConfig config = EventWriterConfig.builder().retryAttempts(Integer.MAX_VALUE).build();
         DelegationTokenProvider tokenProvider =
                 DelegationTokenProviderFactory.create(controller, segment, AccessOperation.WRITE);
         return new BufferedByteStreamWriterImpl(


### PR DESCRIPTION
**Change log description**  
Ensure ByteStreamWriter attempts connecting to SSS until the writer is closed.

**Purpose of the change**  
Related to #5667 

**What the code does**  
The SegmentWriter created by the ByteStreamWriter should attempt to establish a connection with SegmentSegment store
until the ByteStreamWriter is closed.

**How to verify it**  
All the existing steps should continue to pass.