### PR TITLE
Issue 5709: (SegmentStore) Swap validation order for BadAttributeUpdateException and BadOffsetException for conditional appends

### DIFF
--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/StreamSegmentStore.java
@@ -39,11 +39,14 @@ public interface StreamSegmentStore {
      * @param attributeUpdates  A Collection of Attribute-Values to set or update. May be null (which indicates no updates).
      *                          See Notes about AttributeUpdates in the interface Javadoc.
      * @param timeout           Timeout for the operation
-     * @return A CompletableFuture that, when completed normally, will indicate the append completed
-     *         successfully and contains the new length of the segment. If the operation failed, the
-     *         future will be failed with the causing exception. (NOTE: the length is not
-     *         necessarily the same as offset immediately following the data because the append may
-     *         have been batched together with others internally.)
+     * @return A CompletableFuture that, when completed normally, will indicate the append completed successfully and
+     * contains the new length of the segment. If the operation failed, the future will be failed with the causing exception.
+     * (NOTE: the length is not necessarily the same as offset immediately following the data because the append may have
+     * been batched together with others internally.) Notable exceptions:
+     * - {@link BadAttributeUpdateException} If {@code attributeUpdates} is non-null and non-empty and at least one of
+     * the {@link AttributeUpdate} instances within that collection has {@link AttributeUpdate#getUpdateType()} equal to
+     * {@link AttributeUpdateType#ReplaceIfEquals} or {@link AttributeUpdateType#ReplaceIfGreater} and the condition for
+     * this update is rejected.
      * @throws NullPointerException If any of the arguments are null, except attributeUpdates.
      * @throws IllegalArgumentException If the StreamSegment Name is invalid (NOTE: this doesn't
      *                                  check if the StreamSegment does not exist - that exception 
@@ -65,11 +68,17 @@ public interface StreamSegmentStore {
      * @param attributeUpdates  A Collection of Attribute-Values to set or update. May be null (which indicates no updates).
      *                          See Notes about AttributeUpdates in the interface Javadoc.
      * @param timeout           Timeout for the operation
-     * @return A CompletableFuture that, when completed normally, will indicate the append completed
-     *         successfully and contains the new length of the segment. If the operation failed, the
-     *         future will be failed with the causing exception. (NOTE: the length is not
-     *         necessarily the same as offset immediately following the data because the append may
-     *         have been batched together with others internally.)
+     * @return A CompletableFuture that, when completed normally, will indicate the append completed successfully and
+     * contains the new length of the segment. If the operation failed, the future will be failed with the causing exception.
+     * (NOTE: the length is not necessarily the same as offset immediately following the data because the append may have
+     * been batched together with others internally.) Notable exceptions:
+     * - {@link BadAttributeUpdateException} If {@code attributeUpdates} is non-null and non-empty and at least one of
+     * the {@link AttributeUpdate} instances within that collection has {@link AttributeUpdate#getUpdateType()} equal to
+     * {@link AttributeUpdateType#ReplaceIfEquals} or {@link AttributeUpdateType#ReplaceIfGreater} and the condition for
+     * this update is rejected.
+     * - {@link BadOffsetException} if the current length of the given Segment does not match the given {@code offset}.
+     * IMPORTANT: If the append fails validation due to both {@link BadAttributeUpdateException} and {@link BadOffsetException},
+     * then {@link BadAttributeUpdateException} will take precedence.
      * @throws NullPointerException If any of the arguments are null, except attributeUpdates.
      * @throws IllegalArgumentException If the StreamSegment Name is invalid (NOTE: this doesn't
      *                                  check if the StreamSegment does not exist - that exception
@@ -85,7 +94,10 @@ public interface StreamSegmentStore {
      *                          See Notes about AttributeUpdates in the interface Javadoc.
      * @param timeout           Timeout for the operation
      * @return A CompletableFuture that, when completed normally, will indicate the update completed successfully.
-     * If the operation failed, the future will be failed with the causing exception.
+     * If the operation failed, the future will be failed with the causing exception. Notable exceptions:
+     * - {@link BadAttributeUpdateException} If at least one of the {@link AttributeUpdate} instances within {@code attributeUpdates}
+     * has {@link AttributeUpdate#getUpdateType()} equal to {@link AttributeUpdateType#ReplaceIfEquals} or
+     * {@link AttributeUpdateType#ReplaceIfGreater} and the condition for this update is rejected.
      * @throws NullPointerException     If any of the arguments are null.
      * @throws IllegalArgumentException If the StreamSegment Name is invalid (NOTE: this doesn't check if the StreamSegment
      *                                  does not exist - that exception will be set in the returned CompletableFuture).

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
@@ -240,6 +240,14 @@ public class ContainerMetadataUpdateTransactionTests {
                 "preProcessOperations accepted an append with the wrong offset.",
                 () -> txn.preProcessOperation(badAppendOp),
                 ex -> ex instanceof BadOffsetException);
+
+        // Append #4 (wrong offset + wrong attribute). AS PER SEGMENT STORE CONTRACT, BadAttributeUpdateException takes precedence.
+        badAppendOp.getAttributeUpdates().add(new AttributeUpdate(UUID.randomUUID(), AttributeUpdateType.ReplaceIfEquals, 1, 1234));
+        AssertExtensions.assertThrows(
+                "preProcessOperations failed with wrong exception when append has both bad offset and bad attribute.",
+                () -> txn.preProcessOperation(badAppendOp),
+                ex -> ex instanceof BadAttributeUpdateException);
+
         AssertExtensions.assertThrows(
                 "acceptOperation accepted an append that was rejected during preProcessing.",
                 () -> txn.acceptOperation(badAppendOp),


### PR DESCRIPTION
**Change log description**  
Changed validation order within SegmentMetadataUpdateTransaction.preProcessOperation(StreamSegmentAppendOperation).
`BadAttributeUpdateException` now takes precedence over `BadOffsetException` if both would be a cause for rejection.

**Purpose of the change**  
Fixes #5709.

**What the code does**  
See description.

**How to verify it**  
Build must pass.
