### PR TITLE
Issue 5712: Internally idempotent conditional append 

### DIFF
--- a/client/src/main/java/io/pravega/client/connection/impl/RawClient.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/RawClient.java
@@ -124,6 +124,8 @@ public class RawClient implements AutoCloseable {
         }
         if (future != null) {
             future.complete(reply);
+        } else {
+            log.info("Could not find any matching request for {}. Ignoring.", reply);
         }
     }
 

--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
@@ -15,22 +15,23 @@ import io.pravega.auth.AuthenticationException;
 import io.pravega.auth.TokenExpiredException;
 import io.pravega.client.connection.impl.ConnectionPool;
 import io.pravega.client.connection.impl.RawClient;
-import io.pravega.client.security.auth.DelegationTokenProvider;
 import io.pravega.client.control.impl.Controller;
+import io.pravega.client.security.auth.DelegationTokenProvider;
 import io.pravega.common.Exceptions;
 import io.pravega.common.util.Retry.RetryWithBackoff;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.Reply;
 import io.pravega.shared.protocol.netty.WireCommands;
 import io.pravega.shared.protocol.netty.WireCommands.AppendSetup;
+import io.pravega.shared.protocol.netty.WireCommands.AuthTokenCheckFailed;
 import io.pravega.shared.protocol.netty.WireCommands.ConditionalAppend;
 import io.pravega.shared.protocol.netty.WireCommands.ConditionalCheckFailed;
 import io.pravega.shared.protocol.netty.WireCommands.DataAppended;
 import io.pravega.shared.protocol.netty.WireCommands.Event;
+import io.pravega.shared.protocol.netty.WireCommands.InvalidEventNumber;
 import io.pravega.shared.protocol.netty.WireCommands.SegmentIsSealed;
 import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
 import io.pravega.shared.protocol.netty.WireCommands.WrongHost;
-import io.pravega.shared.protocol.netty.WireCommands.AuthTokenCheckFailed;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -116,7 +117,7 @@ class ConditionalOutputStreamImpl implements ConditionalOutputStream {
         if (reply instanceof AppendSetup) {
             return (AppendSetup) reply;
         } else {
-            throw handleUnexpectedReply(reply);
+            throw handleUnexpectedReply(reply, "AppendSetup");
         }
     }
 
@@ -126,12 +127,12 @@ class ConditionalOutputStreamImpl implements ConditionalOutputStream {
         } else if (reply instanceof ConditionalCheckFailed) {
             return false;
         } else {
-            throw handleUnexpectedReply(reply);
+            throw handleUnexpectedReply(reply, "DataAppended");
         }
     }
 
     @VisibleForTesting
-    RuntimeException handleUnexpectedReply(Reply reply) {
+    RuntimeException handleUnexpectedReply(Reply reply, String expectation) {
         closeConnection(reply.toString());
         if (reply instanceof WireCommands.NoSuchSegment) {
             throw new NoSuchSegmentException(reply.toString());
@@ -139,6 +140,9 @@ class ConditionalOutputStreamImpl implements ConditionalOutputStream {
             throw Exceptions.sneakyThrow(new SegmentSealedException(reply.toString()));
         } else if (reply instanceof WrongHost) {
             throw Exceptions.sneakyThrow(new ConnectionFailedException(reply.toString()));
+        } else if (reply instanceof InvalidEventNumber) {
+            throw Exceptions.sneakyThrow(new ConnectionFailedException(
+                    "Got stale data from setupAppend on segment " + segmentId + " for ConditionalOutputStream."));
         } else if (reply instanceof AuthTokenCheckFailed) {
             AuthTokenCheckFailed authTokenCheckFailed = (WireCommands.AuthTokenCheckFailed) reply;
             if (authTokenCheckFailed.isTokenExpired()) {
@@ -148,7 +152,7 @@ class ConditionalOutputStreamImpl implements ConditionalOutputStream {
                 throw Exceptions.sneakyThrow(new AuthenticationException(authTokenCheckFailed.toString()));
             }
         } else {
-            throw Exceptions.sneakyThrow(new ConnectionFailedException("Unexpected reply of " + reply + " when expecting an AppendSetup"));
+            throw Exceptions.sneakyThrow(new ConnectionFailedException("Unexpected reply of " + reply + " when expecting an " + expectation));
         }
     }
     

--- a/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/ConditionalOutputStreamImpl.java
@@ -141,8 +141,9 @@ class ConditionalOutputStreamImpl implements ConditionalOutputStream {
         } else if (reply instanceof WrongHost) {
             throw Exceptions.sneakyThrow(new ConnectionFailedException(reply.toString()));
         } else if (reply instanceof InvalidEventNumber) {
-            throw Exceptions.sneakyThrow(new ConnectionFailedException(
-                    "Got stale data from setupAppend on segment " + segmentId + " for ConditionalOutputStream."));
+            InvalidEventNumber ien = (InvalidEventNumber) reply;
+            throw Exceptions.sneakyThrow(new ConnectionFailedException(ien.getWriterId() + 
+                    "Got stale data from setupAppend on segment " + segmentId + " for ConditionalOutputStream. Event number was " + ien.getEventNumber()));
         } else if (reply instanceof AuthTokenCheckFailed) {
             AuthTokenCheckFailed authTokenCheckFailed = (WireCommands.AuthTokenCheckFailed) reply;
             if (authTokenCheckFailed.isTokenExpired()) {

--- a/client/src/main/java/io/pravega/client/state/SynchronizerConfig.java
+++ b/client/src/main/java/io/pravega/client/state/SynchronizerConfig.java
@@ -22,11 +22,21 @@ import lombok.Data;
 public class SynchronizerConfig implements Serializable {
 
     private static final long serialVersionUID = 2L;
+
+    /**
+     * This writer config is used by the segment writers in the StateSyncrhonizer. The default values
+     * enable connection pooling and ensures the background connection retry attempts continue until the StateSyncrhonizer
+     * is closed.
+     */
     EventWriterConfig eventWriterConfig;
+    /**
+     * This size is used to allocate buffer space for the bytes the reader in the StateSyncrhonizer reads from the
+     * segment. The default buffer size is 256KB.
+     */
     int readBufferSize;
     
     public static class SynchronizerConfigBuilder {
-        private EventWriterConfig eventWriterConfig = EventWriterConfig.builder().enableConnectionPooling(true).build();
+        private EventWriterConfig eventWriterConfig = EventWriterConfig.builder().retryAttempts(Integer.MAX_VALUE).enableConnectionPooling(true).build();
         private int readBufferSize = 256 * 1024;
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -324,6 +324,7 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
     private void releaseSealedSegments() throws ReaderNotInReaderGroupException {
         for (Iterator<Entry<Segment, Long>> iterator = sealedSegments.entrySet().iterator(); iterator.hasNext();) {
             Segment oldSegment = iterator.next().getKey();
+            log.info("{} releasing sealed segment {}", this, oldSegment);
             Range range = ranges.get(oldSegment);
             if (groupState.handleEndOfSegment(new SegmentWithRange(oldSegment, range))) {
                 ranges.remove(oldSegment);

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -498,7 +498,7 @@ public class ReaderGroupStateManager {
             } else {
                 reinitRequired.set(false);
                 String cpName = state.getCheckpointForReader(readerId);
-                if (cpName.equals(checkpointName)) {
+                if (checkpointName.equals(cpName)) {
                     updates.add(new CheckpointReader(checkpointName, readerId, lastPosition.getOwnedSegmentsWithOffsets()));
                 } else {
                     log.warn("{} was asked to checkpoint for {} but the state says its next checkpoint should be {}", readerId, checkpointName, cpName);

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -187,16 +187,23 @@ public class ReaderGroupStateManager {
         AtomicBoolean reinitRequired = new AtomicBoolean(false);
         boolean result = sync.updateState((state, updates) -> {
             if (!state.isReaderOnline(readerId)) {
+                log.error("Reader " + readerId + " is offline according to the state but is attempting to update it.");
                 reinitRequired.set(true);
-            } else {
-                log.debug("Marking segment {} as completed in reader group. CurrentState is: {}", segmentCompleted, state);
-                reinitRequired.set(false);
-                //This check guards against another checkpoint having started.
-                if (state.getCheckpointForReader(readerId) == null) {
-                    updates.add(new SegmentCompleted(readerId, segmentCompleted, segmentToPredecessor));
-                    return true;
-                }
+                return false;
+            } 
+            if (!state.getSegments(readerId).contains(segmentCompleted.getSegment())) {
+                log.error("Reader " + readerId + " is does not own the segment " + segmentCompleted + "but is attempting to release it.");
+                reinitRequired.set(true);
+                return false;
             }
+            
+            log.debug("Marking segment {} as completed in reader group. CurrentState is: {}", segmentCompleted, state);
+            reinitRequired.set(false);
+            //This check guards against another checkpoint having started.
+            if (state.getCheckpointForReader(readerId) == null) {
+                updates.add(new SegmentCompleted(readerId, segmentCompleted, segmentToPredecessor));
+                return true;
+            } 
             return false;
         });
         if (reinitRequired.get()) {
@@ -490,7 +497,12 @@ public class ReaderGroupStateManager {
                 reinitRequired.set(true);
             } else {
                 reinitRequired.set(false);
-                updates.add(new CheckpointReader(checkpointName, readerId, lastPosition.getOwnedSegmentsWithOffsets()));
+                String cpName = state.getCheckpointForReader(readerId);
+                if (cpName.equals(checkpointName)) {
+                    updates.add(new CheckpointReader(checkpointName, readerId, lastPosition.getOwnedSegmentsWithOffsets()));
+                } else {
+                    log.error("{} was asked to checkpoint for {} but the state says its next checkpoint should be {}", readerId, checkpointName, cpName);
+                }
             }
         });
         if (reinitRequired.get()) {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupStateManager.java
@@ -501,7 +501,7 @@ public class ReaderGroupStateManager {
                 if (cpName.equals(checkpointName)) {
                     updates.add(new CheckpointReader(checkpointName, readerId, lastPosition.getOwnedSegmentsWithOffsets()));
                 } else {
-                    log.error("{} was asked to checkpoint for {} but the state says its next checkpoint should be {}", readerId, checkpointName, cpName);
+                    log.warn("{} was asked to checkpoint for {} but the state says its next checkpoint should be {}", readerId, checkpointName, cpName);
                 }
             }
         });

--- a/client/src/test/java/io/pravega/client/connection/impl/RawClientTest.java
+++ b/client/src/test/java/io/pravega/client/connection/impl/RawClientTest.java
@@ -79,9 +79,28 @@ public class RawClientTest {
         assertTrue(future.isDone());
         assertEquals(reply, future.get());
     }
+    
+    @Test
+    public void testReplyWithoutRequest() {
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", -1);
+        @Cleanup
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        @Cleanup
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
+        ClientConnection connection = Mockito.mock(ClientConnection.class);
+        connectionFactory.provideConnection(endpoint, connection);
+        @Cleanup
+        RawClient rawClient = new RawClient(controller, connectionFactory, new Segment("scope", "testHello", 0));
+
+        UUID id = UUID.randomUUID();
+        ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
+        DataAppended reply = new DataAppended(requestId, id, 1, 0, -1);
+        processor.process(reply);
+        assertFalse(rawClient.isClosed());
+    }
 
     @Test
-    public void testRecvErrorMessage() throws InterruptedException, ExecutionException, ConnectionFailedException {
+    public void testRecvErrorMessage() {
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", -1);
         @Cleanup
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();

--- a/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
@@ -27,6 +27,7 @@ import io.pravega.shared.protocol.netty.WireCommands.ConditionalAppend;
 import io.pravega.shared.protocol.netty.WireCommands.SetupAppend;
 import io.pravega.test.common.AssertExtensions;
 import java.nio.ByteBuffer;
+import java.util.UUID;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -267,18 +268,22 @@ public class ConditionalOutputStreamTest {
 
         AssertExtensions.assertThrows("AuthenticationException wasn't thrown",
                 () ->  objectUnderTest.handleUnexpectedReply(new WireCommands.AuthTokenCheckFailed(1L, "SomeException",
-                        WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_CHECK_FAILED)),
+                        WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_CHECK_FAILED), "test"),
                 e -> e instanceof AuthenticationException);
 
         AssertExtensions.assertThrows("AuthenticationException wasn't thrown",
                 () ->  objectUnderTest.handleUnexpectedReply(new WireCommands.AuthTokenCheckFailed(1L, "SomeException",
-                        WireCommands.AuthTokenCheckFailed.ErrorCode.UNSPECIFIED)),
+                        WireCommands.AuthTokenCheckFailed.ErrorCode.UNSPECIFIED), "test"),
                 e -> e instanceof AuthenticationException);
 
         AssertExtensions.assertThrows("TokenExpiredException wasn't thrown",
                 () ->  objectUnderTest.handleUnexpectedReply(new WireCommands.AuthTokenCheckFailed(1L, "SomeException",
-                        WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_EXPIRED)),
+                        WireCommands.AuthTokenCheckFailed.ErrorCode.TOKEN_EXPIRED), "test"),
                 e -> e instanceof TokenExpiredException);
+        
+        AssertExtensions.assertThrows("InvalidEventNumber wasn't treated as a connection failure",
+                () ->  objectUnderTest.handleUnexpectedReply(new WireCommands.InvalidEventNumber(UUID.randomUUID(), 1, "SomeException"), "test"),
+                e -> e instanceof ConnectionFailedException);
     }
     
     /**

--- a/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
@@ -220,6 +220,46 @@ public class ConditionalOutputStreamTest {
         assertTrue(objectUnderTest.write(data, 0));
         assertEquals(3, retryCounter.get());
     }
+    
+    @SneakyThrows
+    @Test(timeout = 10000)
+    public void testRetriesOnInvalidEventNumber() {
+        @Cleanup
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        @Cleanup
+        MockController controller = new MockController("localhost", 0, connectionFactory, true);
+        ConditionalOutputStreamFactory factory = new ConditionalOutputStreamFactoryImpl(controller, connectionFactory);
+        Segment segment = new Segment("scope", "testWrite", 1);
+        @Cleanup
+        ConditionalOutputStream objectUnderTest = factory.createConditionalOutputStream(segment,
+                DelegationTokenProviderFactory.create("token", controller, segment, AccessOperation.ANY),
+                EventWriterConfig.builder().build());
+        ByteBuffer data = ByteBuffer.allocate(10);
+
+        ClientConnection clientConnection = Mockito.mock(ClientConnection.class);
+        PravegaNodeUri location = new PravegaNodeUri("localhost", 0);
+        connectionFactory.provideConnection(location, clientConnection);
+        setupAppend(connectionFactory, segment, clientConnection, location);
+
+        final AtomicLong retryCounter = new AtomicLong(0);
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                ConditionalAppend argument = (ConditionalAppend) invocation.getArgument(0);
+                ReplyProcessor processor = connectionFactory.getProcessor(location);
+
+                if (retryCounter.getAndIncrement() < 2) {
+                    processor.process(new WireCommands.InvalidEventNumber(argument.getWriterId(), argument.getRequestId(), ""));
+                } else {
+                    processor.process(new WireCommands.DataAppended(argument.getRequestId(),
+                            argument.getWriterId(), argument.getEventNumber(), 0, -1));
+                }
+                return null;
+            }
+        }).when(clientConnection).send(any(ConditionalAppend.class));
+        assertTrue(objectUnderTest.write(data, 0));
+        assertEquals(3, retryCounter.get());
+    }
 
     @Test(timeout = 10000)
     public void testNonExpiryTokenCheckFailure() throws ConnectionFailedException {

--- a/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/ConditionalOutputStreamTest.java
@@ -324,6 +324,10 @@ public class ConditionalOutputStreamTest {
         AssertExtensions.assertThrows("InvalidEventNumber wasn't treated as a connection failure",
                 () ->  objectUnderTest.handleUnexpectedReply(new WireCommands.InvalidEventNumber(UUID.randomUUID(), 1, "SomeException"), "test"),
                 e -> e instanceof ConnectionFailedException);
+        
+        AssertExtensions.assertThrows("Hello wasn't treated as a connection failure",
+                                      () ->  objectUnderTest.handleUnexpectedReply(new WireCommands.Hello(1, 1), "test"),
+                                      e -> e instanceof ConnectionFailedException);
     }
     
     /**

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -299,7 +299,7 @@ public class ReaderGroupStateManagerTest {
         assertTrue(readerState.handleEndOfSegment(segment));
     }
     
-    @Test//(timeout = 10000)
+    @Test(timeout = 10000)
     public void testReachEndInvalidState() throws ReaderNotInReaderGroupException {
         String scope = "scope";
         String stream = "stream";

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 
+import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.Assert.assertEquals;
@@ -296,6 +297,45 @@ public class ReaderGroupStateManagerTest {
         assertEquals(1, newSegments.size());
         assertTrue(newSegments.containsKey(segment));
         assertTrue(readerState.handleEndOfSegment(segment));
+    }
+    
+    @Test//(timeout = 10000)
+    public void testReachEndInvalidState() throws ReaderNotInReaderGroupException {
+        String scope = "scope";
+        String stream = "stream";
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
+        createScopeAndStream(scope, stream, controller);
+        MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
+        @Cleanup
+        SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
+        
+        @Cleanup
+        StateSynchronizer<ReaderGroupState> stateSynchronizer = createState(stream, clientFactory, SynchronizerConfig.builder().build());
+        Map<SegmentWithRange, Long> segments = new HashMap<>();
+        SegmentWithRange segment = new SegmentWithRange(new Segment(scope, stream, 0), 0.0, 1.0);
+        segments.put(segment, 1L);
+        StreamCutImpl start = new StreamCutImpl(Stream.of(scope, stream), ImmutableMap.of(segment.getSegment(), 0L));
+        StreamCutImpl end = new StreamCutImpl(Stream.of(scope, stream), ImmutableMap.of(segment.getSegment(), 100L));
+        ReaderGroupConfig config = ReaderGroupConfig.builder().stream(Stream.of(scope, stream), start, end).build();
+        stateSynchronizer.initialize(new ReaderGroupState.ReaderGroupStateInit(config, segments,
+                                                                               ReaderGroupImpl.getEndSegmentsForStreams(config), false));
+        ReaderGroupStateManager readerState = new ReaderGroupStateManager(scope, stream, "testReader",
+                stateSynchronizer,
+                controller,
+                null);
+        readerState.initializeReader(0);
+        readerState.readerShutdown(new PositionImpl(segments));
+        assertThrows(ReaderNotInReaderGroupException.class, () -> readerState.handleEndOfSegment(segment));
+
+        //restore reader without segment
+        readerState.initializeReader(0);
+        assertThrows(ReaderNotInReaderGroupException.class, () -> readerState.handleEndOfSegment(segment));
+        
+        //Test it can release if it has the segment
+        readerState.acquireNewSegmentsIfNeeded(0, new PositionImpl(segments));
+        readerState.handleEndOfSegment(segment); 
     }
     
     @Test(timeout = 10000)

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupStateManagerTest.java
@@ -804,6 +804,8 @@ public class ReaderGroupStateManagerTest {
         assertEquals("CP3", readerState.getCheckpoint());
         readerState.checkpoint("CP3", new PositionImpl(Collections.emptyMap()));
         assertNull(readerState.getCheckpoint());
+        readerState.checkpoint("CP3", new PositionImpl(Collections.emptyMap())); //Checking idempotency (state should resolved inconsistency)
+        assertNull(readerState.getCheckpoint());
     }
 
     @Test(timeout = 10000)

--- a/common/src/main/java/io/pravega/common/util/Retry.java
+++ b/common/src/main/java/io/pravega/common/util/Retry.java
@@ -187,7 +187,11 @@ public final class Retry {
                     Exceptions.handleInterrupted(() -> Thread.sleep(sleepFor));
 
                     delay = Math.min(params.maxDelay, params.multiplier * delay);
-                    log.debug("Retrying command {} Retry #{}, timestamp={}", r.toString(), attemptNumber, Instant.now());
+                    log.debug("Retrying command {} due to \"{}\" Retry #{}, timestamp={}",
+                              r.toString(),
+                              last.getMessage(),
+                              attemptNumber,
+                              Instant.now());
                 }
             }
             throw new RetriesExhaustedException(last);

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -389,7 +389,7 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(tracker, times(3)).updateOutstandingBytes(connection, data.length, data.length);
         verify(connection).send(new DataAppended(requestId, clientId, 1, 0, data.length));
         verify(connection).send(new ConditionalCheckFailed(clientId, 2, requestId));
-        verify(connection).send(new InvalidEventNumber(clientId, 1, "test"));
+        verify(connection).send(new InvalidEventNumber(clientId, requestId, "test"));
         verify(connection).close();
         verify(tracker, times(3)).updateOutstandingBytes(connection, -data.length, 0);
         verifyNoMoreInteractions(connection);


### PR DESCRIPTION
**Change log description**  
* Allows ConditionalOutputStream to internally retry InvalidEventNumber exceptions
* Changes reader group updates to double check the assumptions they make before updating the reader group.

**Purpose of the change**  
Fixes #5712

**What the code does**  
Makes ConditionalOutputStream retry InvalidEventNumber replies from the server as introduced in https://github.com/pravega/pravega/pull/5710 which will allow the retry to resolve the ambiguity of whether or not a conditional append was successful if the connection drops before an ack can be received.

