### PR TITLE
Issue 5767: Ensure the WriterState object contains the updated last event number for the given writer.

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -173,7 +173,16 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                                 } else {
                                     // Last event number stored according to Segment store.
                                     long eventNumber = attributes.getOrDefault(writer, Attributes.NULL_ATTRIBUTE_VALUE);
-                                    this.writerStates.putIfAbsent(Pair.of(newSegment, writer), new WriterState(eventNumber));
+
+                                    // Create a new WriterState object based on the attribute value for the last event number for the writer.
+                                    // It should be noted that only one connection for a given segment writer is created by the client.
+                                    // The event number sent by the AppendSetup command is an implicit ack, the writer acks all events
+                                    // below the specified event number.
+                                    WriterState current = this.writerStates.put(Pair.of(newSegment, writer), new WriterState(eventNumber));
+                                    if (current != null) {
+                                        log.info("SetupAppend invoked again for writer {}. Last event number from store is {}. Prev writer state {}",
+                                                writer, eventNumber, current);
+                                    }
                                     connection.send(new AppendSetup(setupAppend.getRequestId(), newSegment, writer, eventNumber));
                                 }
                             } catch (Throwable e) {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -171,8 +171,16 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                                 if (u != null) {
                                     handleException(writer, setupAppend.getRequestId(), newSegment, "setting up append", u);
                                 } else {
+                                    // Last event number stored according to Segment store.
                                     long eventNumber = attributes.getOrDefault(writer, Attributes.NULL_ATTRIBUTE_VALUE);
-                                    this.writerStates.putIfAbsent(Pair.of(newSegment, writer), new WriterState(eventNumber));
+                                    final WriterState writerState = this.writerStates.putIfAbsent(Pair.of(newSegment, writer), new WriterState(eventNumber));
+                                    if (writerState != null) {
+                                        // Writer state already exists for this writer.
+                                        long lastEventNumber = writerState.getLastAckedEventNumber();
+                                        eventNumber = Math.max(lastEventNumber, eventNumber);
+                                        log.debug("Setting up Appends for writerId {}, last event number from attributes is {} from writer state is {}",
+                                                writer, eventNumber, lastEventNumber);
+                                    }
                                     connection.send(new AppendSetup(setupAppend.getRequestId(), newSegment, writer, eventNumber));
                                 }
                             } catch (Throwable e) {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -173,14 +173,7 @@ public class AppendProcessor extends DelegatingRequestProcessor {
                                 } else {
                                     // Last event number stored according to Segment store.
                                     long eventNumber = attributes.getOrDefault(writer, Attributes.NULL_ATTRIBUTE_VALUE);
-                                    final WriterState writerState = this.writerStates.putIfAbsent(Pair.of(newSegment, writer), new WriterState(eventNumber));
-                                    if (writerState != null) {
-                                        // Writer state already exists for this writer.
-                                        long lastEventNumber = writerState.getLastAckedEventNumber();
-                                        eventNumber = Math.max(lastEventNumber, eventNumber);
-                                        log.debug("Setting up Appends for writerId {}, last event number from attributes is {} from writer state is {}",
-                                                writer, eventNumber, lastEventNumber);
-                                    }
+                                    this.writerStates.putIfAbsent(Pair.of(newSegment, writer), new WriterState(eventNumber));
                                     connection.send(new AppendSetup(setupAppend.getRequestId(), newSegment, writer, eventNumber));
                                 }
                             } catch (Throwable e) {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/WriterState.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/WriterState.java
@@ -178,6 +178,15 @@ class WriterState {
     }
 
     /**
+     * Gets the Event Number of the last Event that was Acked to the Client.
+     *
+     * @return The last event number that was acked to the client by the store.
+     */
+    synchronized long getLastAckedEventNumber() {
+        return this.lastAckedEventNumber;
+    }
+
+    /**
      * Gets a {@link DelayedErrorHandler} based on the following rules:
      * - If no call has been made to {@link #appendFailed}, this will return null.
      * - If {@link #appendFailed} has been invoked at least once, this will return a {@link DelayedErrorHandler} with

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/WriterState.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/WriterState.java
@@ -178,15 +178,6 @@ class WriterState {
     }
 
     /**
-     * Gets the Event Number of the last Event that was Acked to the Client.
-     *
-     * @return The last event number that was acked to the client by the store.
-     */
-    synchronized long getLastAckedEventNumber() {
-        return this.lastAckedEventNumber;
-    }
-
-    /**
      * Gets a {@link DelayedErrorHandler} based on the following rules:
      * - If no call has been made to {@link #appendFailed}, this will return null.
      * - If {@link #appendFailed} has been invoked at least once, this will return a {@link DelayedErrorHandler} with

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -420,7 +420,7 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         val ac1 = interceptAppend(store, streamSegmentName, 0, updateEventNumber(clientId, 1), CompletableFuture.completedFuture((long) data.length));
         // First conditional Append.
         processor.setupAppend(new SetupAppend(1, clientId, streamSegmentName, ""));
-        processor.append(new Append(streamSegmentName, clientId, 1, 1, Unpooled.wrappedBuffer(data), 0L, requestId));
+        processor.append(new Append(streamSegmentName, clientId, 1, 1, Unpooled.wrappedBuffer(data), 0L, 1L));
 
         //Simulate a connection drop on the client side and the client resends a SetupAppend followed by conditional Append.
         val ac2 = interceptAppend(store, streamSegmentName, data.length, updateEventNumber(clientId, 2, 1, 1),

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -396,7 +396,52 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verifyNoMoreInteractions(store);
         verify(mockedRecorder).recordAppend(eq(streamSegmentName), eq(8L), eq(1), any());
     }
-    
+
+    @Test
+    public void testMultipleSetupAppendDueToConnectionFailure() {
+        String streamSegmentName = "scope/stream/testMultipleSetupAppend";
+        UUID clientId = UUID.randomUUID();
+        byte[] data = new byte[]{1, 2, 3, 4, 6, 7, 8, 9};
+        StreamSegmentStore store = mock(StreamSegmentStore.class);
+        ServerConnection connection = mock(ServerConnection.class);
+        val mockedRecorder = Mockito.mock(SegmentStatsRecorder.class);
+        ConnectionTracker tracker = mock(ConnectionTracker.class);
+        AppendProcessor processor = AppendProcessor.defaultBuilder()
+                .store(store)
+                .connection(connection)
+                .connectionTracker(tracker)
+                .statsRecorder(mockedRecorder)
+                .build();
+        // Setup mock to enusure both the SetupAppends return the newer values.
+        when(store.getAttributes(streamSegmentName, Collections.singleton(clientId), true, AppendProcessor.TIMEOUT))
+                .thenReturn(CompletableFuture.completedFuture(Collections.singletonMap(clientId, 0L)))
+                .thenReturn(CompletableFuture.completedFuture(Collections.singletonMap(clientId, 1L)));
+
+        val ac1 = interceptAppend(store, streamSegmentName, 0, updateEventNumber(clientId, 1), CompletableFuture.completedFuture((long) data.length));
+        // First conditional Append.
+        processor.setupAppend(new SetupAppend(1, clientId, streamSegmentName, ""));
+        processor.append(new Append(streamSegmentName, clientId, 1, 1, Unpooled.wrappedBuffer(data), 0L, requestId));
+
+        //Simulate a connection drop on the client side and the client resends a SetupAppend followed by conditional Append.
+        val ac2 = interceptAppend(store, streamSegmentName, data.length, updateEventNumber(clientId, 2, 1, 1),
+                CompletableFuture.completedFuture((long) data.length * 2));
+        processor.setupAppend(new SetupAppend(2, clientId, streamSegmentName, ""));
+        processor.append(new Append(streamSegmentName, clientId, 2, 1, Unpooled.wrappedBuffer(data), (long) data.length, 2));
+
+        verify(store, times(2)).getAttributes(anyString(), eq(Collections.singleton(clientId)), eq(true), eq(AppendProcessor.TIMEOUT));
+        verifyStoreAppend(ac1, data);
+        verifyStoreAppend(ac2, data);
+        verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 0));
+        verify(tracker, times(2)).updateOutstandingBytes(connection, data.length, data.length);
+        verify(connection).send(new DataAppended(1, clientId, 1, 0, data.length));
+        // verify that the second SetupAppend is responded by the AppendProcessor.
+        verify(connection).send(new AppendSetup(2, streamSegmentName, clientId, 1));
+        verify(connection).send(new DataAppended(2, clientId, 2, 1, data.length * 2));
+        verifyNoMoreInteractions(connection);
+        verifyNoMoreInteractions(store);
+        verify(mockedRecorder, times(2)).recordAppend(eq(streamSegmentName), eq(8L), eq(1), any());
+    }
+
     @Test
     public void testConditionalAppendFailureOnUnconditionalAppend() {
         String streamSegmentName = "scope/stream/testConditionalAppendFailureOnUnconditionalAppend";


### PR DESCRIPTION
**Change log description**  
Ensure the WriterState object contains the updated last event number for the given writer.

**Purpose of the change**  
Fixes #5767 

**What the code does** 
The segment writers reconnect to the SegmentStore on a connection drop. Post a connection drop the writers perform a setup append operation. As part of the setup append operation the data from the segment attributes are used to return the last store event number. In the current code, since this is a reconnect, the `WriterState `for this writer already exists;  this WriterState is used to fetch the `lasteventnumber` for the attribute update operation via `io.pravega.segmentstore.contracts.StreamSegmentStore#append`. Since this event number need not be the latest event number the SSS returns an exception due to bad attributes. This is retried again by the client.

This PR ensures the SSS attributes are used as the source of truth for the last event number and uses it for the WriterState updation too. This ensures we avoid redundant retries from the client.

**How to verify it**  
All the existing and newly added tests should continue to pass.