### PR TITLE
Issue 5659: Sporadic test failure in ReadWriteTest.readWriteTest

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/ReadWriteTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ReadWriteTest.java
@@ -67,8 +67,8 @@ public class ReadWriteTest {
     private static final String STREAM_NAME = "testMultiReaderWriterStream" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final int NUM_WRITERS = 20;
     private static final int NUM_READERS = 20;
-    private static final long TOTAL_NUM_EVENTS = 20000;
-    private static final int NUM_EVENTS_BY_WRITER = 1000;
+    private static final int NUM_EVENTS_BY_WRITER = 500;
+    private static final long TOTAL_NUM_EVENTS = NUM_WRITERS * NUM_EVENTS_BY_WRITER;
     private AtomicLong eventData;
     private AtomicLong eventReadCount;
     private AtomicBoolean stopReadFlag;
@@ -242,7 +242,7 @@ public class ReadWriteTest {
                     EventWriterConfig.builder().build());
             for (int i = 0; i < NUM_EVENTS_BY_WRITER; i++) {
                 long value = data.incrementAndGet();
-                log.info("Writing event {}", value);
+                log.debug("Writing event {}", value);
                 writer.writeEvent(String.valueOf(value), value);
                 writer.flush();
             }
@@ -263,7 +263,7 @@ public class ReadWriteTest {
                     ReaderConfig.builder().build());
             while (!(exitFlag.get() && readCount.get() == writeCount.get())) {
                 final Long longEvent = reader.readNextEvent(SECONDS.toMillis(2)).getEvent();
-                log.info("Reading event {}", longEvent);
+                log.debug("Reading event {}", longEvent);
                 if (longEvent != null) {
                     //update if event read is not null.
                     readResult.add(longEvent);


### PR DESCRIPTION
**Change log description**  
Reduced the number of events written and read in the test, as well as do not log per-event messages.

**Purpose of the change**  
Fixes #5659.

**What the code does**  
The main reason for this test to fail sporadically is the load it imposes, which may be too much for low CPU instances, considering the 60s timeout set. Due to this reason, the `TimeoutException`s seen in this tests could come from any point during of after the IO phase. To prevent this type of issues, this PR does the following:
- It reduces the number of written events to the half (20K -> 10K).
- It changes the log level of per-event messages from `info` to `debug`, so we do not overload the system with logging activity without need. This makes things worse in slow/small instances..

**How to verify it**  
Without this change, I could get `TimeoutException` consistently in my VM. With this change, I have executed the test 5 times without issues.