### PR TITLE
Issue 5656: Sporadic failure in test SecureBookKeeperLogTests.testAppendTransientBookieFailure

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperServiceRunner.java
@@ -115,6 +115,34 @@ public class BookKeeperServiceRunner implements AutoCloseable {
     }
 
     /**
+     * Suspends processing for the BookieService with the given index.
+     *
+     * @param bookieIndex The index of the bookie to stop.
+     */
+    public void suspendBookie(int bookieIndex) {
+        Preconditions.checkState(this.servers.size() > 0, "No Bookies initialized. Call startAll().");
+        Preconditions.checkState(this.servers.get(0) != null, "Bookie does not exists.");
+        val bk = this.servers.get(bookieIndex);
+        log.info("Bookie {} is suspending processing.", bookieIndex);
+        bk.suspendProcessing();
+        log.info("Bookie {} suspended processing.", bookieIndex);
+    }
+
+    /**
+     * Resumes processing for the BookieService with the given index.
+     *
+     * @param bookieIndex The index of the bookie to stop.
+     */
+    public void resumeBookie(int bookieIndex) {
+        Preconditions.checkState(this.servers.size() > 0, "No Bookies initialized. Call startAll().");
+        Preconditions.checkState(this.servers.get(0) != null, "Bookie does not exists.");
+        val bk = this.servers.get(bookieIndex);
+        log.info("Bookie {} is resuming processing.", bookieIndex);
+        bk.resumeProcessing();
+        log.info("Bookie {} resumed processing.", bookieIndex);
+    }
+
+    /**
      * Restarts the BookieService with the given index.
      *
      * @param bookieIndex The index of the bookie to restart.

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
@@ -268,6 +268,8 @@ public abstract class BookKeeperLogTests extends DurableDataLogTestBase {
             } finally {
                 // Resume the bookie with the appends still in flight.
                 resumeFirstBookie();
+                AssertExtensions.assertThrows("Bookies should be running, but they aren't",
+                        BookKeeperLogTests::restartFirstBookie, ex -> ex instanceof IllegalStateException);
             }
 
             // Wait for all writes to complete, then reassemble the data in the order set by LogAddress.
@@ -319,6 +321,10 @@ public abstract class BookKeeperLogTests extends DurableDataLogTestBase {
                                 }
                             });
                 }
+                AssertExtensions.assertThrows("Bookies shouldn't be running, but they are",
+                        BookKeeperLogTests::suspendFirstBookie, ex -> ex instanceof IllegalStateException);
+                AssertExtensions.assertThrows("Bookies shouldn't be running, but they are",
+                        BookKeeperLogTests::resumeFirstBookie, ex -> ex instanceof IllegalStateException);
             } finally {
                 // Don't forget to resume the bookie, but only AFTER we are done testing.
                 restartFirstBookie();

--- a/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
+++ b/segmentstore/storage/impl/src/test/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLogTests.java
@@ -256,7 +256,7 @@ public abstract class BookKeeperLogTests extends DurableDataLogTestBase {
 
             try {
                 // Suspend a bookie (this will trigger write errors).
-                stopFirstBookie();
+                suspendFirstBookie();
 
                 // Issue appends in parallel, without waiting for them.
                 int writeCount = getWriteCount();
@@ -267,7 +267,7 @@ public abstract class BookKeeperLogTests extends DurableDataLogTestBase {
                 }
             } finally {
                 // Resume the bookie with the appends still in flight.
-                restartFirstBookie();
+                resumeFirstBookie();
             }
 
             // Wait for all writes to complete, then reassemble the data in the order set by LogAddress.
@@ -768,6 +768,14 @@ public abstract class BookKeeperLogTests extends DurableDataLogTestBase {
 
     private static void stopFirstBookie() {
         BK_SERVICE.get().stopBookie(0);
+    }
+
+    private static void suspendFirstBookie() {
+        BK_SERVICE.get().suspendBookie(0);
+    }
+
+    private static void resumeFirstBookie() {
+        BK_SERVICE.get().resumeBookie(0);
     }
 
     @SneakyThrows


### PR DESCRIPTION
**Change log description**  
Pause and resume processing in Bookies instead of restarting the whole process to simulate transient failures in testAppendTransientBookieFailure.

**Purpose of the change**  
Fixes #5656.

**What the code does**  
This test was normally failing due to a `RetriesExhaustedException`. The reason for that could be related to a problem shutting down and restarting again a Bookie process within the test, as it could take too long sporadically, thus leading the test to fail. The fix proposed basically provides an alternative way of simulating the transient failure: instead of completely restarting the Bookie process, it uses the `suspendProcessing()` and `resumeProcessing()` methods available in the test Bookie process. With these methods we can simulate a transient failure behavior in Bookie without restarting the process.

**How to verify it**  
Executed 20+ times `gradlew --rerun-tasks :segmentstore:storage:impl:test` and the issue has not been detected locally. 
Executed 15 times a Jenkins build with this branch and I have not seen a reproduction of this problem (there have been failed builds due to unrelated tests).
Executed this test hundreds of times in a loop inside the IDE without seeing the original error.