### PR TITLE
Issue 5729: Add LICENSE and NOTICE files into javadoc distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1277,6 +1277,8 @@ distributions {
         baseName = "pravega-javadoc"
         contents {
             from (javadocs)
+	    from 'LICENSE'
+	    from 'NOTICE'
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1277,8 +1277,8 @@ distributions {
         baseName = "pravega-javadoc"
         contents {
             from (javadocs)
-	    from 'LICENSE'
-	    from 'NOTICE'
+            from 'LICENSE'
+            from 'NOTICE'
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Igor Medvedev <medvedevigorek@gmail.com>

**Change log description**  
Modifies javadoc tasks by adding license files into a set of files to be packaged as a distribution bundle

**Purpose of the change**  
Fixes #5729

**What the code does**  
javadocDistZip and javadocDistTar gradle tasks are modified to include license files into a resulting distribution bundle

**How to verify it**  
Verify that upon unpacking the javadoc distribution LICENSE and NOTICE files are present