### PR TITLE
Issue 5729: Add LICENSE and NOTICE files into javadoc distribution #5731

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1280,6 +1280,8 @@ distributions {
         baseName = "pravega-javadoc"
         contents {
             from (javadocs)
+            from 'LICENSE'
+            from 'NOTICE'
         }
     }
 }


### PR DESCRIPTION
Modifies javadoc tasks by adding license files into a set of files to be packaged as a distribution bundle

Signed-off-by: Igor Medvedev <medvedevigorek@gmail.com>

**Change log description**  
Cherry-picks #5729 into `r0.9` branch

**Purpose of the change**  
Fixes #5733

**What the code does**  
See details in PR #5731 

**How to verify it**  
See details in PR #5731 
