### PR TITLE
Cherry-pick #5712 into r0.9 branc

### DIFF
--- a/client/src/main/java/io/pravega/client/connection/impl/RawClient.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/RawClient.java
@@ -124,6 +124,8 @@ public class RawClient implements AutoCloseable {
         }
         if (future != null) {
             future.complete(reply);
+        } else {
+            log.info("Could not find any matching request for {}. Ignoring.", reply);
         }
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -324,6 +324,7 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
     private void releaseSealedSegments() throws ReaderNotInReaderGroupException {
         for (Iterator<Entry<Segment, Long>> iterator = sealedSegments.entrySet().iterator(); iterator.hasNext();) {
             Segment oldSegment = iterator.next().getKey();
+            log.info("{} releasing sealed segment {}", this, oldSegment);
             Range range = ranges.get(oldSegment);
             if (groupState.handleEndOfSegment(new SegmentWithRange(oldSegment, range))) {
                 ranges.remove(oldSegment);

--- a/client/src/test/java/io/pravega/client/connection/impl/RawClientTest.java
+++ b/client/src/test/java/io/pravega/client/connection/impl/RawClientTest.java
@@ -79,9 +79,28 @@ public class RawClientTest {
         assertTrue(future.isDone());
         assertEquals(reply, future.get());
     }
+    
+    @Test
+    public void testReplyWithoutRequest() {
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", -1);
+        @Cleanup
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        @Cleanup
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, true);
+        ClientConnection connection = Mockito.mock(ClientConnection.class);
+        connectionFactory.provideConnection(endpoint, connection);
+        @Cleanup
+        RawClient rawClient = new RawClient(controller, connectionFactory, new Segment("scope", "testHello", 0));
+
+        UUID id = UUID.randomUUID();
+        ReplyProcessor processor = connectionFactory.getProcessor(endpoint);
+        DataAppended reply = new DataAppended(requestId, id, 1, 0, -1);
+        processor.process(reply);
+        assertFalse(rawClient.isClosed());
+    }
 
     @Test
-    public void testRecvErrorMessage() throws InterruptedException, ExecutionException, ConnectionFailedException {
+    public void testRecvErrorMessage() {
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", -1);
         @Cleanup
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();

--- a/common/src/main/java/io/pravega/common/util/Retry.java
+++ b/common/src/main/java/io/pravega/common/util/Retry.java
@@ -187,7 +187,11 @@ public final class Retry {
                     Exceptions.handleInterrupted(() -> Thread.sleep(sleepFor));
 
                     delay = Math.min(params.maxDelay, params.multiplier * delay);
-                    log.debug("Retrying command {} Retry #{}, timestamp={}", r.toString(), attemptNumber, Instant.now());
+                    log.debug("Retrying command {} due to \"{}\" Retry #{}, timestamp={}",
+                              r.toString(),
+                              last.getMessage(),
+                              attemptNumber,
+                              Instant.now());
                 }
             }
             throw new RetriesExhaustedException(last);


### PR DESCRIPTION
Pulls #5712 into the r0.9 branch.

Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
Allows ConditionalOutputStream to internally retry InvalidEventNumber exceptions
Changes reader group updates to double check the assumptions they make before updating the reader group.
