### PR TITLE
Issue 5750: EventProcessor's readergroup failover fails if there are readers without a position in the zookeeper

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
@@ -80,6 +80,8 @@ class ZKCheckpointStore implements CheckpointStore {
     public Map<String, Position> getPositions(String process, String readerGroup) throws CheckpointStoreException {
         Map<String, Position> map = new HashMap<>();
         String path = getReaderGroupPath(process, readerGroup);
+        ReaderGroupData rgData = groupDataSerializer.deserialize(ByteBuffer.wrap(getData(path)));
+        rgData.getReaderIds().forEach(x -> map.put(x, null));
         for (String child : getChildren(path)) {
             Position position = null;
             byte[] data = getData(path + "/" + child);


### PR DESCRIPTION

Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fixes a bug where if RG-Data znode has the information about readers but the child znode for reader was not created then attempting to delete readergroup fails.

**Purpose of the change**  
Fixes #5750 

**What the code does**  
The readergroup's readers positions should return readers if they are part of readergroup data even if their child znode with position was not present. 

**How to verify it**  
Unit test added. 