### PR TITLE
Issue 5753: Correlated system test failure due to wrong BK journal directories configuration

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -81,7 +81,7 @@ public abstract class AbstractService implements Service {
     private static final String TIER2_TYPE = System.getProperty("tier2Type", TIER2_NFS);
     private static final String BOOKKEEPER_VERSION = System.getProperty("bookkeeperImageVersion", "latest");
     private static final String ZK_SERVICE_NAME = "zookeeper-client:2181";
-    private static final String JOURNALDIRECTORIES = "bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3";
+    private static final String JOURNALDIRECTORIES = "/bk/journal/j0,/bk/journal/j1,/bk/journal/j2,/bk/journal/j3";
     private static final String LEDGERDIRECTORIES = "/bk/ledgers/l0,/bk/ledgers/l1,/bk/ledgers/l2,/bk/ledgers/l3";
 
     final K8sClient k8sClient;


### PR DESCRIPTION
**Change log description**  
Fixed Bookkeeper journal path in AbstractService class.

**Purpose of the change**  
Fixes #5753.

**What the code does**  
Fixes a wrong path for the Bookkeeper journal 0 that could lead to data loss.

**How to verify it**  
System tests are working with this PR. However, the main reason for the correlated failures in our setting needs to be fixed in https://github.com/apache/bookkeeper/issues/2612.