### PR TITLE
Issue 5627: Speed up RestoreBackUpDataRecoveryTest

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -466,12 +466,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
         pravegaRunner.controllerRunner.close(); // Shut down the controller
 
         // Flush DurableLog to Long Term Storage
-        ServiceBuilder.ComponentSetup componentSetup = new ServiceBuilder.ComponentSetup(pravegaRunner.segmentStoreRunner.serviceBuilder);
-        ArrayList<CompletableFuture<Void>> futures = new ArrayList<>();
-        for (int containerId = 0; containerId < containerCount; containerId++) {
-            futures.add(componentSetup.getContainerRegistry().getContainer(containerId).flushToStorage(TIMEOUT));
-        }
-        Futures.allOf(futures).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        flushToStorage(pravegaRunner.segmentStoreRunner.serviceBuilder);
 
         pravegaRunner.segmentStoreRunner.close(); // Shutdown SegmentStore
         pravegaRunner.bookKeeperRunner.close(); // Shutdown BookKeeper & ZooKeeper
@@ -503,6 +498,15 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
             readEventsFromStream(clientRunner.clientFactory, clientRunner.readerGroupManager);
             log.info("Read all events again to verify that segments were recovered.");
         }
+    }
+
+    private void flushToStorage(ServiceBuilder serviceBuilder) throws Exception {
+        ServiceBuilder.ComponentSetup componentSetup = new ServiceBuilder.ComponentSetup(serviceBuilder);
+        ArrayList<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (int containerId = 0; containerId < componentSetup.getContainerRegistry().getContainerCount(); containerId++) {
+            futures.add(componentSetup.getContainerRegistry().getContainer(containerId).flushToStorage(TIMEOUT));
+        }
+        Futures.allOf(futures).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     private void createBookKeeperLogFactory() throws DurableDataLogException {
@@ -622,12 +626,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
         pravegaRunner.controllerRunner.close(); // Shut down the controller
 
         // Flush DurableLog to Long Term Storage
-        ServiceBuilder.ComponentSetup componentSetup = new ServiceBuilder.ComponentSetup(pravegaRunner.segmentStoreRunner.serviceBuilder);
-        ArrayList<CompletableFuture<Void>> futures = new ArrayList<>();
-        for (int containerId = 0; containerId < containerCount; containerId++) {
-            futures.add(componentSetup.getContainerRegistry().getContainer(containerId).flushToStorage(TIMEOUT));
-        }
-        Futures.allOf(futures).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        flushToStorage(pravegaRunner.segmentStoreRunner.serviceBuilder);
 
         // Get the long term storage from the running pravega instance
         @Cleanup
@@ -754,12 +753,7 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
         pravegaRunner.controllerRunner.close(); // Shut down the controller
 
         // Flush DurableLog to Long Term Storage
-        ServiceBuilder.ComponentSetup componentSetup = new ServiceBuilder.ComponentSetup(pravegaRunner.segmentStoreRunner.serviceBuilder);
-        ArrayList<CompletableFuture<Void>> futures = new ArrayList<>();
-        for (int containerId = 0; containerId < containerCount; containerId++) {
-            futures.add(componentSetup.getContainerRegistry().getContainer(containerId).flushToStorage(TIMEOUT));
-        }
-        Futures.allOf(futures).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        flushToStorage(pravegaRunner.segmentStoreRunner.serviceBuilder);
 
         // Get the long term storage from the running pravega instance
         @Cleanup

--- a/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/RestoreBackUpDataRecoveryTest.java
@@ -537,14 +537,10 @@ public class RestoreBackUpDataRecoveryTest extends ThreadPooledTestSuite {
 
     // Closes the debug segment container instances in the given map after waiting for the metadata segment to be flushed to
     // the given storage.
-    private void stopDebugSegmentContainers(int containerCount, Map<Integer, DebugStreamSegmentContainer> debugStreamSegmentContainerMap)
-            throws Exception {
-        ArrayList<CompletableFuture<Void>> futures = new ArrayList<>();
+    private void stopDebugSegmentContainers(int containerCount, Map<Integer, DebugStreamSegmentContainer> debugStreamSegmentContainerMap) {
         for (int containerId = 0; containerId < containerCount; containerId++) {
-            int finalContainerId = containerId;
-            futures.add(debugStreamSegmentContainerMap.get(finalContainerId).close());
+            debugStreamSegmentContainerMap.get(containerId).close();
         }
-        Futures.allOf(futures).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     // Writes events to the streams with/without transactions.


### PR DESCRIPTION
**Change log description**  
`FlushToStorage` is parallelized for multiple containers to flush in parallel.
 Using `InMemoryDurableDataLog`.

**Purpose of the change**  
Fixes #5627 

**What the code does**  
Improves test time of execution.

**How to verify it**  
Time should be reduced.