### PR TITLE
Issue 5763: System test custom config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1065,8 +1065,7 @@ project('test:system') {
         systemProperty "logLevel", System.getProperty("log.level", "DEBUG")
 
         if (System.getProperty("configFile") != null) {
-            String configs = new File(System.getProperty("configFile")).text
-            System.setProperty("configs", configs)
+            systemProperty "configs", new File(System.getProperty("configFile")).text
         }
         maxParallelForks = 1
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1064,6 +1064,11 @@ project('test:system') {
         systemProperty "tlsEnabled", System.getProperty("tlsEnabled", "false")
         systemProperty "logLevel", System.getProperty("log.level", "DEBUG")
 
+        configFilePath = System.getProperty("configFile")
+        if (configFilePath != null) {
+            String configs = new File(configFilePath).text
+            System.setProperty("configs", configs)
+        }
         maxParallelForks = 1
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1064,9 +1064,8 @@ project('test:system') {
         systemProperty "tlsEnabled", System.getProperty("tlsEnabled", "false")
         systemProperty "logLevel", System.getProperty("log.level", "DEBUG")
 
-        configFilePath = System.getProperty("configFile")
-        if (configFilePath != null) {
-            String configs = new File(configFilePath).text
+        if (System.getProperty("configFile") != null) {
+            String configs = new File(System.getProperty("configFile")).text
             System.setProperty("configs", configs)
         }
         maxParallelForks = 1

--- a/test/system/src/main/java/io/pravega/test/system/framework/Utils.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/Utils.java
@@ -28,6 +28,7 @@ import io.pravega.test.system.framework.services.marathon.PravegaSegmentStoreSer
 import io.pravega.test.system.framework.services.marathon.ZookeeperService;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 
@@ -57,6 +58,7 @@ public class Utils {
     public static final ImmutableMap<String, String> PRAVEGA_PROPERTIES = readPravegaProperties();
     public static final String DEFAULT_TRUSTSTORE_PATH = TLS_MOUNT_PATH + "/tls.crt";
     public static final boolean VALIDATE_HOSTNAME = false;
+    public static final String CONFIGS = "configs";
 
     /**
      * Get Configuration from environment or system property.
@@ -146,6 +148,13 @@ public class Utils {
             resourceName = PROPERTIES_FILE_WITH_TLS;
         }
         Properties props = new Properties();
+        if (System.getProperty(CONFIGS) != null) {
+            try {
+                props.load(new StringReader(System.getProperty(CONFIGS)));
+            } catch (IOException e) {
+                log.error("Error reading custom config file.", e);
+            }
+        }
         try {
             props.load(Utils.class.getClassLoader().getResourceAsStream(resourceName));
         } catch (IOException e) {


### PR DESCRIPTION
**Change log description**  
This PR allows user to pass customized Pravega configs. The configs are in a line separated file, e.g., a file called `pravegaConfigs` and the file content looks like below
```
pravegaservice.storage.layout=CHUNKED_STORAGE
storage.appends.enable=false
```
Run `./gradlew startK8SystemTests -DconfigFile=/path/to/pravegaConfigs` will run system tests using this config file.

**Purpose of the change**  
Fix #5763 

**What the code does**  
Gradle parses the file into a string and pass to the test as a system property. Test framwork reads this property if it exists and put it into the option section of the Pravega manifest and use it to deploy Pravega cluster.

**How to verify it**  
Manual test passed
