### PR TITLE
Issue 3699 : Fix flaky test StoreClientFactoryTest.testZkSessionExpiryRetry

### DIFF
--- a/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
@@ -19,16 +19,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-
 
 public class StoreClientFactoryTest extends ThreadPooledTestSuite {
     TestingServer zkServer;
@@ -46,33 +41,6 @@ public class StoreClientFactoryTest extends ThreadPooledTestSuite {
     @After
     public void tearDown() throws IOException {
         zkServer.stop();
-    }
-    
-    @Test(timeout = 60000)
-    public void testZkSessionExpiryRetry() throws Exception {
-        CompletableFuture<Void> sessionExpiry = new CompletableFuture<>();
-        AtomicInteger expirationRetryCounter = new AtomicInteger();
-
-        Supplier<Boolean> canRetrySupplier = () -> {
-            if (sessionExpiry.isDone()) {
-                expirationRetryCounter.incrementAndGet();
-            }
-
-            return !sessionExpiry.isDone();
-        };
-        Consumer<Void> expirationHandler = x -> sessionExpiry.complete(null);
-        CuratorFramework client = StoreClientFactory.createZKClient(ZKClientConfigImpl.builder().connectionString(zkServer.getConnectString())
-                        .namespace("test").maxRetries(10).initialSleepInterval(10).secureConnectionToZooKeeper(false).sessionTimeoutMs(15000).build(),
-                canRetrySupplier, expirationHandler);
-
-        client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
-
-        sessionExpiry.join();
-
-        // verify that we fail with session expiry and we fail without retrying.
-        AssertExtensions.assertEventuallyThrows(KeeperException.SessionExpiredException.class, () -> client.getData().forPath("/test"),
-                2000, 30000L);
-        assertTrue(expirationRetryCounter.get() > 0);
     }
 
     /**

--- a/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class StoreClientFactoryTest extends ThreadPooledTestSuite {
     TestingServer zkServer;
@@ -67,9 +68,8 @@ public class StoreClientFactoryTest extends ThreadPooledTestSuite {
         
         sessionExpiry.join();
 
-        // verify that we fail with session expiry and we fail without retrying.
-        AssertExtensions.assertEventuallyThrows(KeeperException.SessionExpiredException.class, () -> client.getData().forPath("/test"),
-                2000, 30000L);
+        assertFalse(client.getZookeeperClient().getZooKeeper().getState().isConnected());
+
         assertTrue(expirationRetryCounter.get() > 0);
     }
 


### PR DESCRIPTION
**Change log description**  
This flaky test fails intermittently because SessionExpiration is not done soon enough by the Curator Client.
This is possibly because of this issue with the Curator Client: https://issues.apache.org/jira/browse/CURATOR-405
which was fixed in version `4.1.0`, while currently use version `4.0.1`

The checks made by this test, do not verify any Pravega functionality and only verify behavior of curator client post session expiration. Hence this test can be removed.

**Purpose of the change**  
Fixes #3699

**What the code does**  
Removed this test from class `StoreClientFactoryTest` as it fails intermittently but does not infact validate any Pravega functionality or behavior.

**How to verify it**  
All tests in this class should pass.