### PR TITLE
Issue 5772: (SLTS) - BaseMetadataStore does not evict entries from buffer. 

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
@@ -188,6 +188,7 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
     /**
      * Keep count of records in buffer. ConcurrentHashMap.size() is an expensive operation.
      */
+    @Getter
     private final AtomicInteger bufferCount = new AtomicInteger(0);
 
     /**
@@ -297,7 +298,6 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
                 .thenRunAsync(() -> {
                     //  Step 5 : Mark transaction as commited.
                     txn.setCommitted();
-                    txnData.clear();
                 }, executor)
                 .whenCompleteAsync((v, ex) -> {
                     if (shouldReleaseKeys.get()) {
@@ -306,6 +306,9 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
                     }
                     // Remove keys from active set.
                     txn.getData().keySet().forEach(this::removeFromActiveKeySet);
+                    if (txn.isCommitted()) {
+                        txnData.clear();
+                    }
                     COMMIT_LATENCY.reportSuccessEvent(t.getElapsed());
                 }, executor);
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 
 import static io.pravega.segmentstore.storage.metadata.StorageMetadataMetrics.COMMIT_LATENCY;
 import static io.pravega.segmentstore.storage.metadata.StorageMetadataMetrics.GET_LATENCY;
+import static io.pravega.segmentstore.storage.metadata.StorageMetadataMetrics.METADATA_BUFFER_EVICTED_COUNT;
 import static io.pravega.segmentstore.storage.metadata.StorageMetadataMetrics.METADATA_FOUND_IN_BUFFER;
 import static io.pravega.segmentstore.storage.metadata.StorageMetadataMetrics.METADATA_FOUND_IN_CACHE;
 import static io.pravega.segmentstore.storage.metadata.StorageMetadataMetrics.METADATA_FOUND_IN_TXN;
@@ -496,6 +497,7 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
                     }
                 }
                 bufferCount.addAndGet(-1 * count);
+                METADATA_BUFFER_EVICTED_COUNT.add(count);
                 log.debug("{} entries evicted from transaction buffer.", count);
             }
             isEvictionRunning.set(false);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
@@ -11,6 +11,7 @@
 package io.pravega.segmentstore.storage.metadata;
 
 import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -189,7 +190,6 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
     /**
      * Keep count of records in buffer. ConcurrentHashMap.size() is an expensive operation.
      */
-    @Getter
     private final AtomicInteger bufferCount = new AtomicInteger(0);
 
     /**
@@ -695,6 +695,11 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
         Preconditions.checkState(null != copyForBuffer.dbObject, "Missing tracking object");
         Preconditions.checkState(fromDb.dbObject == copyForBuffer.dbObject, "Missing tracking object");
         return copyForBuffer;
+    }
+
+    @VisibleForTesting
+    long getBufferCount() {
+        return bufferCount.get();
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataMetrics.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StorageMetadataMetrics.java
@@ -31,6 +31,7 @@ public class StorageMetadataMetrics {
     static final Counter METADATA_FOUND_IN_CACHE = STATS_LOGGER.createCounter(MetricsNames.STORAGE_METADATA_CACHE_HIT_COUNT);
     static final Counter METADATA_FOUND_IN_STORE = STATS_LOGGER.createCounter(MetricsNames.STORAGE_METADATA_STORE_HIT_COUNT);
     static final Counter METADATA_NOT_FOUND = STATS_LOGGER.createCounter(MetricsNames.STORAGE_METADATA_MISS_COUNT);
+    static final Counter METADATA_BUFFER_EVICTED_COUNT = STATS_LOGGER.createCounter(MetricsNames.STORAGE_METADATA_BUFFER_EVICTED_COUNT);
 
     static final OpStatsLogger TABLE_GET_LATENCY = STATS_LOGGER.createStats(MetricsNames.STORAGE_METADATA_TABLE_GET_LATENCY);
     static final OpStatsLogger TABLE_WRITE_LATENCY = STATS_LOGGER.createStats(MetricsNames.STORAGE_METADATA_TABLE_WRITE_LATENCY);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
@@ -922,6 +922,25 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
         }
     }
 
+    @Test
+    public void testEvictionFromBuffer() throws Exception {
+        if (metadataStore instanceof InMemoryMetadataStore) {
+            metadataStore.setMaxEntriesInCache(10);
+            metadataStore.setMaxEntriesInTxnBuffer(10);
+            for (int i=0; i < 10000; i++) {
+                try (MetadataTransaction txn = metadataStore.beginTransaction(false, "Txn" + i)) {
+                    txn.create(new MockStorageMetadata("Txn" + i, "Value" + i));
+                    txn.commit().get();
+                }
+                try (MetadataTransaction txn = metadataStore.beginTransaction(false, "Txn" + i)) {
+                    txn.delete("Txn" + i);
+                    txn.commit().get();
+                }
+            }
+            Assert.assertTrue(metadataStore.getBufferCount().get() < 10);
+        }
+    }
+
     private void assertNotNull(CompletableFuture<StorageMetadata> data) throws Exception {
         Assert.assertNotNull(data.get());
     }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
@@ -927,7 +927,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
         if (metadataStore instanceof InMemoryMetadataStore) {
             metadataStore.setMaxEntriesInCache(10);
             metadataStore.setMaxEntriesInTxnBuffer(10);
-            for (int i=0; i < 10000; i++) {
+            for (int i = 0; i < 10000; i++) {
                 try (MetadataTransaction txn = metadataStore.beginTransaction(false, "Txn" + i)) {
                     txn.create(new MockStorageMetadata("Txn" + i, "Value" + i));
                     txn.commit().get();

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
@@ -937,7 +937,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
                     txn.commit().get();
                 }
             }
-            Assert.assertTrue(metadataStore.getBufferCount().get() < 10);
+            Assert.assertTrue(metadataStore.getBufferCount() < 10);
         }
     }
 

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -150,6 +150,7 @@ public final class MetricsNames {
     public static final String STORAGE_METADATA_CACHE_HIT_COUNT = PREFIX + "segmentstore.storage.metadata_cache_hit_count";   // Counter
     public static final String STORAGE_METADATA_STORE_HIT_COUNT = PREFIX + "segmentstore.storage.metadata_store_hit_count";   // Counter
     public static final String STORAGE_METADATA_MISS_COUNT = PREFIX + "segmentstore.storage.metadata_miss_count";             // Counter
+    public static final String STORAGE_METADATA_BUFFER_EVICTED_COUNT = PREFIX + "segmentstore.storage.metadata_beuffer_evicted_count";             // Counter
 
     public static final String STORAGE_METADATA_BUFFER_SIZE = PREFIX + "segmentstore.storage.metadata_buffer_record_count";         // Gauge
     public static final String STORAGE_METADATA_CACHE_SIZE = PREFIX + "segmentstore.storage.metadata_cache_record_count";           // Gauge

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -150,7 +150,7 @@ public final class MetricsNames {
     public static final String STORAGE_METADATA_CACHE_HIT_COUNT = PREFIX + "segmentstore.storage.metadata_cache_hit_count";   // Counter
     public static final String STORAGE_METADATA_STORE_HIT_COUNT = PREFIX + "segmentstore.storage.metadata_store_hit_count";   // Counter
     public static final String STORAGE_METADATA_MISS_COUNT = PREFIX + "segmentstore.storage.metadata_miss_count";             // Counter
-    public static final String STORAGE_METADATA_BUFFER_EVICTED_COUNT = PREFIX + "segmentstore.storage.metadata_beuffer_evicted_count";             // Counter
+    public static final String STORAGE_METADATA_BUFFER_EVICTED_COUNT = PREFIX + "segmentstore.storage.metadata_buffer_evicted_count";             // Counter
 
     public static final String STORAGE_METADATA_BUFFER_SIZE = PREFIX + "segmentstore.storage.metadata_buffer_record_count";         // Gauge
     public static final String STORAGE_METADATA_CACHE_SIZE = PREFIX + "segmentstore.storage.metadata_cache_record_count";           // Gauge


### PR DESCRIPTION
**Change log description**  
Fix bug that prevented BaseMetadataStore from evicting entries from buffer. 

**Purpose of the change**  
Fix #5772 

**What the code does**  
Fix bug that prevented BaseMetadataStore from evicting entries from buffer. 

**How to verify it**  
Test should pass.
Metrics should show entries being evicted regularly.
