### PR TITLE
Issue 5777: Remove generation parameter from Controller deleteReaderGroup API

### DIFF
--- a/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
@@ -21,12 +21,7 @@ import io.pravega.client.state.InitialUpdate;
 import io.pravega.client.state.StateSynchronizer;
 import io.pravega.client.state.SynchronizerConfig;
 import io.pravega.client.state.Update;
-import io.pravega.client.stream.ReaderGroup;
-import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.ScalingPolicy;
-import io.pravega.client.stream.Serializer;
-import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.*;
 import io.pravega.client.stream.impl.AbstractClientFactoryImpl;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.ReaderGroupImpl;
@@ -101,13 +96,20 @@ public class ReaderGroupManagerImpl implements ReaderGroupManager {
 
     @Override
     public void deleteReaderGroup(String groupName) {
-        @Cleanup
-        StateSynchronizer<ReaderGroupState> synchronizer = clientFactory.createStateSynchronizer(NameUtils.getStreamForReaderGroup(groupName),
-                new ReaderGroupStateUpdatesSerializer(), new ReaderGroupStateInitSerializer(), SynchronizerConfig.builder().build());
-        synchronizer.fetchUpdates();
-        UUID groupId = synchronizer.getState().getConfig().getReaderGroupId();
-        long generation = synchronizer.getState().getConfig().getGeneration();
-        getAndHandleExceptions(controller.deleteReaderGroup(scope, groupName, groupId, generation),
+        UUID groupId = null;
+        try {
+            @Cleanup
+            StateSynchronizer<ReaderGroupState> synchronizer = clientFactory.createStateSynchronizer(NameUtils.getStreamForReaderGroup(groupName),
+                    new ReaderGroupStateUpdatesSerializer(), new ReaderGroupStateInitSerializer(), SynchronizerConfig.builder().build());
+            synchronizer.fetchUpdates();
+            groupId = synchronizer.getState().getConfig().getReaderGroupId();
+        } catch (InvalidStreamException ex) {
+            log.warn("State-Synchronizer Stream for ReaderGroup {} was not found.", NameUtils.getScopedReaderGroupName(scope, groupName));
+            // if the State Synchronizer Stream was deleted, but the RG still exists, get Id from Controller
+            groupId = getAndHandleExceptions(controller.getReaderGroupConfig(scope, groupName),
+                    RuntimeException::new).getReaderGroupId();
+        }
+        getAndHandleExceptions(controller.deleteReaderGroup(scope, groupName, groupId),
                 RuntimeException::new);
     }
 

--- a/client/src/main/java/io/pravega/client/control/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/control/impl/Controller.java
@@ -158,10 +158,9 @@ public interface Controller extends AutoCloseable {
      * @param scope Scope name for Reader Group.
      * @param rgName Reader Group name.
      * @param readerGroupId Unique Id for this readerGroup.
-     * @param generation generation number for this readerGroup.
      * @return A future which will throw if the operation fails, otherwise returns configuration of the Reader Group.
      */
-    CompletableFuture<Boolean> deleteReaderGroup(final String scope, final String rgName, final UUID readerGroupId, final long generation);
+    CompletableFuture<Boolean> deleteReaderGroup(final String scope, final String rgName, final UUID readerGroupId);
 
     /**
      * Get list of Subscribers for the Stream.

--- a/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
@@ -1644,12 +1644,11 @@ public class ControllerImpl implements Controller {
 
     @Override
     public CompletableFuture<Boolean> deleteReaderGroup(final String scope, final String rgName,
-                                                        final UUID readerGroupId, final long generation) {
+                                                        final UUID readerGroupId) {
         Exceptions.checkNotClosed(closed.get(), this);
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Exceptions.checkNotNullOrEmpty(rgName, "rgName");
         Preconditions.checkNotNull(readerGroupId, "rgId");
-        Preconditions.checkArgument( generation >= 0 );
         final long requestId = requestIdGenerator.get();
         long traceId = LoggerHelpers.traceEnter(log, "deleteReaderGroup", scope, rgName, requestId);
         final String scopedRGName = NameUtils.getScopedReaderGroupName(scope, rgName);
@@ -1657,7 +1656,7 @@ public class ControllerImpl implements Controller {
         final CompletableFuture<DeleteReaderGroupStatus> result = this.retryConfig.runAsync(() -> {
             RPCAsyncCallback<DeleteReaderGroupStatus> callback = new RPCAsyncCallback<>(requestId, "deleteReaderGroup", scope, rgName);
             new ControllerClientTagger(client, timeoutMillis).withTag(requestId, "deleteReaderGroup", scope, rgName)
-                    .deleteReaderGroup(ModelHelper.createReaderGroupInfo(scope, rgName, readerGroupId.toString(), generation), callback);
+                    .deleteReaderGroup(ModelHelper.createReaderGroupInfo(scope, rgName, readerGroupId.toString(), 0L), callback);
             return callback.getFuture();
         }, this.executor);
         return result.thenApply(x -> {

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -207,13 +207,12 @@ public class ControllerService {
         return streamMetadataTasks.getReaderGroupConfig(scope, rgName, null);
     }
 
-    public CompletableFuture<DeleteReaderGroupStatus> deleteReaderGroup(String scope, String rgName, String readerGroupId, final long generation) {
+    public CompletableFuture<DeleteReaderGroupStatus> deleteReaderGroup(String scope, String rgName, String readerGroupId) {
         Preconditions.checkNotNull(scope, "ReaderGroup scope is null");
         Preconditions.checkNotNull(rgName, "ReaderGroup name is null");
         Preconditions.checkNotNull(readerGroupId, "ReaderGroup Id is null");
-        Preconditions.checkArgument(generation >= 0 );
         Timer timer = new Timer();
-        return streamMetadataTasks.deleteReaderGroup(scope, rgName, readerGroupId, generation, null)
+        return streamMetadataTasks.deleteReaderGroup(scope, rgName, readerGroupId, null)
                 .thenApplyAsync(status -> {
                     reportDeleteReaderGroupMetrics(scope, rgName, status, timer.getElapsed());
                     return DeleteReaderGroupStatus.newBuilder().setStatus(status).build();

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -250,8 +250,8 @@ public class LocalController implements Controller {
 
     @Override
     public CompletableFuture<Boolean> deleteReaderGroup(final String scopeName, final String rgName,
-                                                        final UUID readerGroupId, final long generation) {
-        return this.controller.deleteReaderGroup(scopeName, rgName, readerGroupId.toString(), generation).thenApply(x -> {
+                                                        final UUID readerGroupId) {
+        return this.controller.deleteReaderGroup(scopeName, rgName, readerGroupId.toString()).thenApply(x -> {
             final String scopedRGName = NameUtils.getScopedReaderGroupName(scopeName, rgName);
             switch (x.getStatus()) {
                 case FAILURE:

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/DeleteReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/DeleteReaderGroupTask.java
@@ -53,7 +53,6 @@ public class DeleteReaderGroupTask implements ReaderGroupTask<DeleteReaderGroupE
       String readerGroup = request.getRgName();
       long requestId = request.getRequestId();
       UUID readerGroupId = request.getReaderGroupId();
-      long generation = request.getGeneration();
       final RGOperationContext context = streamMetadataStore.createRGContext(scope, readerGroup);
       return streamMetadataStore.getReaderGroupId(scope, readerGroup)
               .thenCompose(id -> {
@@ -63,10 +62,6 @@ public class DeleteReaderGroupTask implements ReaderGroupTask<DeleteReaderGroupE
                }
                return streamMetadataStore.getReaderGroupConfigRecord(scope, readerGroup, context, executor)
                        .thenCompose(configRecord -> {
-                       if (configRecord.getObject().getGeneration() != generation) {
-                           log.warn("Skipping processing of Reader Group delete request {} as generation did not match.", requestId);
-                           return CompletableFuture.completedFuture(null);
-                       }
                        if (!ReaderGroupConfig.StreamDataRetention.values()[configRecord.getObject().getRetentionTypeOrdinal()]
                               .equals(ReaderGroupConfig.StreamDataRetention.NONE)) {
                               String scopedRGName = NameUtils.getScopedReaderGroupName(scope, readerGroup);

--- a/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rpc/grpc/v1/ControllerServiceImpl.java
@@ -201,7 +201,7 @@ public class ControllerServiceImpl extends ControllerServiceGrpc.ControllerServi
 
         authenticateExecuteAndProcessResults(() -> this.grpcAuthHelper.checkAuthorizationAndCreateToken(
                 authorizationResource.ofReaderGroupsInScope(scope), requiredPermission),
-                delegationToken -> controllerService.deleteReaderGroup(scope, rgName, rgId, generation),
+                delegationToken -> controllerService.deleteReaderGroup(scope, rgName, rgId),
                 responseObserver, requestTag);
     }
 

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -393,35 +393,35 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
     @Test
     public void testDeleteReaderGroup() throws ExecutionException, InterruptedException {
         final  UUID someUUID = UUID.randomUUID();
-        when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any(), anyLong())).thenReturn(
+        when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteReaderGroupStatus.newBuilder()
                         .setStatus(Controller.DeleteReaderGroupStatus.Status.SUCCESS).build()));
-        Assert.assertTrue(this.testController.deleteReaderGroup("scope", "subscriber", someUUID, 0L).join());
+        Assert.assertTrue(this.testController.deleteReaderGroup("scope", "subscriber", someUUID).join());
 
-        when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any(), anyLong())).thenReturn(
+        when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteReaderGroupStatus.newBuilder()
                         .setStatus(Controller.DeleteReaderGroupStatus.Status.FAILURE).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.deleteReaderGroup("scope", "subscriber", someUUID, 0L).join(),
+                () -> this.testController.deleteReaderGroup("scope", "subscriber", someUUID).join(),
                 ex -> ex instanceof ControllerFailureException);
 
-        when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any(), anyLong())).thenReturn(
+        when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteReaderGroupStatus.newBuilder()
                         .setStatus(Controller.DeleteReaderGroupStatus.Status.RG_NOT_FOUND).build()));
         assertThrows("Expected IllegalArgumentException",
-                () -> this.testController.deleteReaderGroup("scope", "stream", someUUID, 0L).join(),
+                () -> this.testController.deleteReaderGroup("scope", "stream", someUUID).join(),
                 ex -> ex instanceof IllegalArgumentException);
 
-        when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any(), anyLong())).thenReturn(
+        when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteReaderGroupStatus.newBuilder()
                         .setStatus(Controller.DeleteReaderGroupStatus.Status.SUCCESS).build()));
-        Assert.assertTrue(this.testController.deleteReaderGroup("scope", "subscriber", someUUID, 0L).join());
+        Assert.assertTrue(this.testController.deleteReaderGroup("scope", "subscriber", someUUID).join());
         
-        when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any(), anyLong())).thenReturn(
+        when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteReaderGroupStatus.newBuilder()
                         .setStatusValue(-1).build()));
         assertThrows("Expected ControllerFailureException",
-                () -> this.testController.deleteReaderGroup("scope", "subscriber", someUUID, 0L).join(),
+                () -> this.testController.deleteReaderGroup("scope", "subscriber", someUUID).join(),
                 ex -> ex instanceof ControllerFailureException);
     }
 

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -519,7 +519,7 @@ public abstract class StreamMetadataTasksTest {
         assertEquals(3, listSubscribersResponse.getSubscribersCount());
 
         CompletableFuture<DeleteReaderGroupStatus.Status> deleteStatus = streamMetadataTasks.deleteReaderGroup(SCOPE, "rg2",
-                rgIdSub2.toString(), responseRG2.getConfig().getGeneration(), null);
+                rgIdSub2.toString(), null);
         assertTrue(Futures.await(processEvent(requestEventWriter)));
         assertEquals(DeleteReaderGroupStatus.Status.SUCCESS, deleteStatus.join());
 

--- a/shared/controller-api/src/main/java/io/pravega/shared/controller/event/DeleteReaderGroupEvent.java
+++ b/shared/controller-api/src/main/java/io/pravega/shared/controller/event/DeleteReaderGroupEvent.java
@@ -30,7 +30,6 @@ public class DeleteReaderGroupEvent implements ControllerEvent {
     private final String rgName;
     private final long requestId;
     private UUID readerGroupId;
-    private long generation;
 
     @Override
     public String getKey() {
@@ -67,7 +66,6 @@ public class DeleteReaderGroupEvent implements ControllerEvent {
             target.writeUTF(e.rgName);
             target.writeLong(e.requestId);
             target.writeUUID(e.readerGroupId);
-            target.writeLong(e.generation);
         }
 
         private void read00(RevisionDataInput source, DeleteReaderGroupEventBuilder b) throws IOException {
@@ -75,7 +73,6 @@ public class DeleteReaderGroupEvent implements ControllerEvent {
             b.rgName(source.readUTF());
             b.requestId(source.readLong());
             b.readerGroupId(source.readUUID());
-            b.generation(source.readLong());
         }
     }
     //endregion


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
This PR removes the generation param from deleteReaderGroup API on Controller.

**Purpose of the change**  
Fixes #5777

**What the code does**  
Remove generation parameter from Controller deleteReaderGroup API
Changed deleteReaderGroup() API on ReaderGroupManager (Client), such that if StateSynchronizer Stream for a ReaderGroup is not found, ReaderGroupId from Controller is fetched and deleteReaderGroup is issued on Controller.

**How to verify it**  
All unit, intergration and system tests should pass.