### PR TITLE
Issue 5776: resetReaderGroup fails if there are pending updates

### DIFF
--- a/client/src/main/java/io/pravega/client/control/impl/Controller.java
+++ b/client/src/main/java/io/pravega/client/control/impl/Controller.java
@@ -138,6 +138,7 @@ public interface Controller extends AutoCloseable {
      * @param rgName Stream name.
      * @param config ReaderGroup configuration.
      * @throws IllegalArgumentException if Stream does not exist.
+     * @throws ReaderGroupConfigRejectedException if the provided ReaderGroupConfig is invalid
      * @return A future which will throw if the operation fails, otherwise
      *         the subscriber was updated in Stream Metadata and a long indicating
      *         the updated config generation is returned.

--- a/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
@@ -1583,8 +1583,8 @@ public class ControllerImpl implements Controller {
                     log.warn(requestId, "Failed to create reader group: {}", rgName);
                     throw new ControllerFailureException("Failed to create readergroup: " + rgName);
                 case INVALID_CONFIG:
-                    log.warn(requestId, "Illegal Reader Group Name: {}", rgName);
-                    throw new IllegalArgumentException("Illegal readergroup name: " + rgName);
+                    log.warn(requestId, "Illegal Reader Group Config for reader group {}: {}", rgName, rgConfig);
+                    throw new ReaderGroupConfigRejectedException("Invalid Reader Group Config: " + rgConfig.toString());
                 case RG_NOT_FOUND:
                     log.warn(requestId, "Scope not found: {}", scope);
                     throw new IllegalArgumentException("Scope does not exist: " + scope);

--- a/client/src/main/java/io/pravega/client/control/impl/ReaderGroupConfigRejectedException.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ReaderGroupConfigRejectedException.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.client.control.impl;
+
+/**
+ * The {@link io.pravega.client.stream.ReaderGroupConfig} sent to be updated on the controller is invalid.
+ * This is likely due to the {@link io.pravega.client.stream.ReaderGroupConfig#generation} being invalid.
+ */
+public class ReaderGroupConfigRejectedException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ReaderGroupConfigRejectedException(String s) {
+        super(s);
+    }
+}

--- a/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
@@ -1606,7 +1606,7 @@ public class ControllerImplTest {
 
         updateRGStatus = controllerClient.updateReaderGroup("scope1", "rg4", config);
         AssertExtensions.assertFutureThrows("Server should throw exception",
-                updateRGStatus, throwable -> throwable instanceof IllegalArgumentException);
+                updateRGStatus, throwable -> throwable instanceof ReaderGroupConfigRejectedException);
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -16,6 +16,7 @@ import io.pravega.client.admin.impl.ReaderGroupManagerImpl.ReaderGroupStateInitS
 import io.pravega.client.admin.impl.ReaderGroupManagerImpl.ReaderGroupStateUpdatesSerializer;
 import io.pravega.client.connection.impl.ConnectionPool;
 import io.pravega.client.control.impl.Controller;
+import io.pravega.client.control.impl.ReaderGroupConfigRejectedException;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.state.InitialUpdate;
 import io.pravega.client.state.StateSynchronizer;
@@ -28,6 +29,7 @@ import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.ReaderGroupState.ClearCheckpointsBefore;
+import io.pravega.common.concurrent.Futures;
 import io.pravega.shared.NameUtils;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.InlineExecutor;
@@ -43,6 +45,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
@@ -60,6 +64,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -148,6 +153,114 @@ public class ReaderGroupImplTest {
         verify(synchronizer, times(1)).fetchUpdates();
         verify(controller, times(1)).updateReaderGroup(SCOPE, GROUP_NAME, config);
         verify(synchronizer, times(2)).updateState(any(StateSynchronizer.UpdateGenerator.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void laggingResetReaderGroup() {
+        UUID rgId = UUID.randomUUID();
+        ReaderGroupConfig config1 = ReaderGroupConfig.builder().startFromStreamCuts(ImmutableMap.<Stream,
+                StreamCut>builder()
+                .put(createStream("s1"), createStreamCut("s1", 2))
+                .put(createStream("s2"), createStreamCut("s2", 3)).build())
+                .readerGroupId(rgId)
+                .build();
+        ReaderGroupConfig config2 = ReaderGroupConfig.builder().startFromStreamCuts(ImmutableMap.<Stream,
+                StreamCut>builder()
+                .put(createStream("s3"), createStreamCut("s3", 2))
+                .put(createStream("s4"), createStreamCut("s4", 3)).build())
+                .readerGroupId(rgId)
+                .generation(1L)
+                .build();
+        when(state.getConfig()).thenReturn(config1, config2);
+        when(synchronizer.getState()).thenReturn(state);
+
+        CompletableFuture<Long> badFuture = new CompletableFuture<>();
+        badFuture.completeExceptionally(new ReaderGroupConfigRejectedException("handle"));
+        // The controller has config2
+        when(controller.updateReaderGroup(SCOPE, GROUP_NAME, config1)).thenReturn(badFuture);
+        when(controller.updateReaderGroup(SCOPE, GROUP_NAME, config1.toBuilder().generation(config2.getGeneration()).build()))
+                .thenReturn(CompletableFuture.completedFuture(2L));
+        when(controller.getReaderGroupConfig(SCOPE, GROUP_NAME)).thenReturn(CompletableFuture.completedFuture(config2));
+
+        readerGroup.resetReaderGroup(config1);
+
+        verify(synchronizer, times(1)).fetchUpdates();
+        verify(controller, times(1)).updateReaderGroup(SCOPE, GROUP_NAME, config1);
+        verify(controller, times(1)).updateReaderGroup(SCOPE, GROUP_NAME, config1.toBuilder().generation(config2.getGeneration()).build());
+        verify(controller, times(1)).getReaderGroupConfig(SCOPE, GROUP_NAME);
+        verify(synchronizer, times(4)).updateState(any(StateSynchronizer.UpdateGenerator.class));
+    }
+
+    @Test(timeout = 10000L)
+    @SuppressWarnings("unchecked")
+    public void testAsyncResetReaderGroup() {
+        UUID rgId = UUID.randomUUID();
+        ReaderGroupConfig config1 = ReaderGroupConfig.builder().startFromStreamCuts(ImmutableMap.<Stream, StreamCut>builder()
+                .put(createStream("s1"), createStreamCut("s1", 2)).build())
+                .readerGroupId(rgId)
+                .build();
+        ReaderGroupConfig config2 = ReaderGroupConfig.builder().startFromStreamCuts(ImmutableMap.<Stream, StreamCut>builder()
+                .put(createStream("s2"), createStreamCut("s2", 2)).build())
+                .readerGroupId(rgId)
+                .build();
+        ReaderGroupConfig config3 = ReaderGroupConfig.builder().startFromStreamCuts(ImmutableMap.<Stream, StreamCut>builder()
+                .put(createStream("s3"), createStreamCut("s3", 2)).build())
+                .readerGroupId(rgId)
+                .build();
+        AtomicInteger x = new AtomicInteger(0);
+        CompletableFuture<Void> wait = new CompletableFuture<>();
+        CompletableFuture<Void> signal = new CompletableFuture<>();
+        // The client's config.
+        AtomicReference<ReaderGroupConfig> atomicConfig = new AtomicReference<>(config1);
+        // The controller's config.
+        AtomicReference<ReaderGroupConfig> atomicConfigController = new AtomicReference<>(config1);
+        // return the client's config when calling state.getConfig.
+        doAnswer(a -> atomicConfig.get()).when(state).getConfig();
+        when(synchronizer.getState()).thenReturn(state);
+        // return controllerConfig when calling getReaderGroupConfig.
+        doAnswer(a -> CompletableFuture.completedFuture(atomicConfigController.get())).when(controller).getReaderGroupConfig(anyString(), anyString());
+        // update the client config to the controller config whenever we update the StateSync.
+        doAnswer(a -> {
+            atomicConfig.set(atomicConfigController.get());
+            return null;
+        }).when(synchronizer).updateState(any(StateSynchronizer.UpdateGenerator.class));
+        // update the controller config with the incremented generation if the generations match.
+        doAnswer(a -> {
+            ReaderGroupConfig c = a.getArgument(2);
+            // the first one to call needs to wait until the second call has been completed.
+            if (x.getAndIncrement() == 0) {
+                signal.complete(null);
+                wait.join();
+            }
+            if (c.getGeneration() == atomicConfigController.get().getGeneration()) {
+                long incGen = c.getGeneration() + 1;
+                atomicConfigController.set(c.toBuilder().generation(incGen).build());
+                return CompletableFuture.completedFuture(incGen);
+            } else {
+                CompletableFuture<Long> badFuture = new CompletableFuture<>();
+                badFuture.completeExceptionally(new ReaderGroupConfigRejectedException("handle"));
+                return badFuture;
+            }
+        }).when(controller).updateReaderGroup(anyString(), anyString(), any(ReaderGroupConfig.class));
+
+        // run the first call async.
+        CompletableFuture<Void> future = CompletableFuture.runAsync(() -> readerGroup.resetReaderGroup(config2));
+        // Once the first call has reached the controller.updateReaderGroup step then signal so he waits.
+        signal.join();
+        // start the second call.
+        readerGroup.resetReaderGroup(config3);
+        // Once the second is completed stop the wait so the first call can go ahead.
+        wait.complete(null);
+        // wait for the first call to complete.
+        assertTrue(Futures.await(future));
+
+        // assert the generation was incremented twice due to two updates.
+        assertEquals(2L, atomicConfig.get().getGeneration());
+        assertEquals(2L, atomicConfigController.get().getGeneration());
+        // assert the first call happened last and the streams are s2.
+        assertTrue(atomicConfig.get().getStartingStreamCuts().keySet().stream().anyMatch(s -> s.getStreamName().equals("s2")));
+        assertTrue(atomicConfigController.get().getStartingStreamCuts().keySet().stream().anyMatch(s -> s.getStreamName().equals("s2")));
     }
 
     @Test

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -11,6 +11,7 @@ package io.pravega.controller.server.eventProcessor;
 
 import com.google.common.base.Preconditions;
 import io.pravega.client.admin.KeyValueTableInfo;
+import io.pravega.client.control.impl.ReaderGroupConfigRejectedException;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.PingFailedException;
 import io.pravega.client.stream.Stream;
@@ -218,7 +219,7 @@ public class LocalController implements Controller {
                 case FAILURE:
                     throw new ControllerFailureException("Failed to create ReaderGroup: " + scopedRGName);
                 case INVALID_CONFIG:
-                    throw new IllegalArgumentException("Invalid Reader Group Config: " + scopedRGName);
+                    throw new ReaderGroupConfigRejectedException("Invalid Reader Group Config: " + config.toString());
                 case RG_NOT_FOUND:
                     throw new IllegalArgumentException("Scope does not exist: " + scopedRGName);
                 case SUCCESS:

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -14,6 +14,7 @@ import com.google.common.collect.Lists;
 import io.pravega.client.admin.KeyValueTableInfo;
 import io.pravega.client.control.impl.ControllerFailureException;
 import io.pravega.client.control.impl.ModelHelper;
+import io.pravega.client.control.impl.ReaderGroupConfigRejectedException;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
@@ -459,9 +460,9 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
         when(this.mockControllerService.updateReaderGroup(anyString(), anyString(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.UpdateReaderGroupResponse.newBuilder()
                         .setStatus(Controller.UpdateReaderGroupResponse.Status.INVALID_CONFIG).build()));
-        assertThrows("Expected IllegalArgumentException",
+        assertThrows("Expected ReaderGroupConfigRejectedException",
                 () -> this.testController.updateReaderGroup("scope", "subscriber", config).join(),
-                ex -> ex instanceof IllegalArgumentException);
+                ex -> ex instanceof ReaderGroupConfigRejectedException);
 
         when(this.mockControllerService.updateReaderGroup(anyString(), anyString(), any())).thenReturn(
                 CompletableFuture.completedFuture(Controller.UpdateReaderGroupResponse.newBuilder()

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -240,6 +241,37 @@ public class EndToEndReaderGroupTest extends AbstractEndToEndTest {
 
         subs = controller.listSubscribers("test", "test").get();
         assertTrue("Subscriber list does not contain required reader group", subs.contains("test/group"));
+    }
+
+    @Test
+    public void testLaggingResetReaderGroup() throws Exception {
+        StreamConfiguration config = getStreamConfig();
+        LocalController controller = (LocalController) controllerWrapper.getController();
+        controllerWrapper.getControllerService().createScope("test").get();
+        controller.createStream("test", "test", config).get();
+        controller.createStream("test", "test2", config).get();
+        @Cleanup
+        ConnectionFactory connectionFactory = new SocketConnectionFactoryImpl(ClientConfig.builder()
+                .controllerURI(URI.create("tcp://" + serviceHost))
+                .build());
+        @Cleanup
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl("test", controller, connectionFactory);
+
+        @Cleanup
+        ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory);
+
+        UUID rgId = UUID.randomUUID();
+
+        // Create a ReaderGroup
+        groupManager.createReaderGroup("group", ReaderGroupConfig.builder().disableAutomaticCheckpoints()
+                .stream("test/test").retentionType(ReaderGroupConfig.StreamDataRetention.NONE).readerGroupId(rgId).build());
+
+        // Update from the controller end
+        controller.updateReaderGroup("test", "group", ReaderGroupConfig.builder().disableAutomaticCheckpoints()
+                .stream("test/test2").retentionType(ReaderGroupConfig.StreamDataRetention.NONE).readerGroupId(rgId).build()).join();
+        ReaderGroup group = groupManager.getReaderGroup("group");
+        // Reset from client end
+        group.resetReaderGroup(ReaderGroupConfig.builder().disableAutomaticCheckpoints().stream("test/test").build());
     }
 
     @Test(timeout = 30000)


### PR DESCRIPTION
Signed-off-by: anirudhkovuru <anirudhkovuru@gmail.com>

**Change log description**  
`resetReaderGroup` now makes sure to update the `ReaderGroupState` when necessary in order to keep consistent with the controller.   

**Purpose of the change**  
Fixes #5776 

**What the code does**  
- Added new exception `ReaderGroupConfigRejectedException` to indicate when the controller returns an `INVALD_CONFIG`.
- When this new exception is encountered, the code updates its config to the one on the controller and then tries the update again.

**How to verify it**  
All tests pass and build should succeed.
