### PR TITLE
Issue 5771: (SegmentStore) Reducing the amount of heap memory used when doing Table Segment Reads.

### DIFF
--- a/common/src/main/java/io/pravega/common/util/AbstractBufferView.java
+++ b/common/src/main/java/io/pravega/common/util/AbstractBufferView.java
@@ -167,6 +167,11 @@ public abstract class AbstractBufferView implements BufferView {
         }
 
         @Override
+        public int getAllocatedLength() {
+            return 0;
+        }
+
+        @Override
         public InputStream getReader(int offset, int length) {
             return slice(offset, length).getReader();
         }

--- a/common/src/main/java/io/pravega/common/util/BufferView.java
+++ b/common/src/main/java/io/pravega/common/util/BufferView.java
@@ -38,6 +38,13 @@ public interface BufferView {
     int getLength();
 
     /**
+     * Gets a value indicating the amount of memory (in bytes) allocated for this {@link BufferView}.
+     *
+     * @return The allocated memory size.
+     */
+    int getAllocatedLength();
+
+    /**
      * Creates a new {@link BufferView.Reader} that can be used to read this {@link BufferView}. This reader is
      * preferable to {@link #getReader()} that returns an {@link InputStream} as it contains optimized methods for copying
      * directly into other {@link BufferView} instances, such as {@link ByteArraySegment}s.
@@ -87,7 +94,7 @@ public interface BufferView {
     /**
      * Returns a copy of the contents of this {@link BufferView}.
      *
-     * @return A byte array with the same length as this ArrayView, containing a copy of the data within it.
+     * @return A byte array with the same length as this {@link BufferView}, containing a copy of the data within it.
      */
     byte[] getCopy();
 

--- a/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
+++ b/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
@@ -77,6 +77,11 @@ public class ByteArraySegment extends AbstractBufferView implements ArrayView {
     //region ArrayView Implementation
 
     @Override
+    public int getAllocatedLength() {
+        return this.array().length;
+    }
+
+    @Override
     public byte get(int index) {
         return this.buffer.get(this.buffer.position() + index);
     }

--- a/common/src/main/java/io/pravega/common/util/CompositeBufferView.java
+++ b/common/src/main/java/io/pravega/common/util/CompositeBufferView.java
@@ -35,6 +35,7 @@ class CompositeBufferView extends AbstractBufferView implements BufferView {
     private final List<BufferView> components;
     @Getter
     private final int length;
+    private volatile int allocatedLength = -1;
 
     //endregion
 
@@ -65,6 +66,15 @@ class CompositeBufferView extends AbstractBufferView implements BufferView {
     //endregion
 
     //region BufferView implementation
+
+    @Override
+    public int getAllocatedLength() {
+        if (this.allocatedLength < 0) {
+            this.allocatedLength = this.components.stream().mapToInt(BufferView::getAllocatedLength).sum();
+        }
+
+        return this.allocatedLength;
+    }
 
     @Override
     public Reader getBufferViewReader() {

--- a/common/src/main/java/io/pravega/common/util/CompositeByteArraySegment.java
+++ b/common/src/main/java/io/pravega/common/util/CompositeByteArraySegment.java
@@ -183,6 +183,11 @@ public class CompositeByteArraySegment extends AbstractBufferView implements Com
     }
 
     @Override
+    public int getAllocatedLength() {
+        return getAllocatedArrayCount() * this.bufferLayout.bufferSize;
+    }
+
+    @Override
     public CompositeReader getBufferViewReader() {
         return new CompositeReader();
     }

--- a/common/src/test/java/io/pravega/common/util/AbstractBufferViewTests.java
+++ b/common/src/test/java/io/pravega/common/util/AbstractBufferViewTests.java
@@ -81,6 +81,7 @@ public class AbstractBufferViewTests {
         val e = BufferView.empty();
         Assert.assertSame("Expecting same instance.", e, BufferView.empty());
         Assert.assertEquals(0, e.getLength());
+        Assert.assertEquals(0, e.getAllocatedLength());
         Assert.assertEquals(0, e.getCopy().length);
         Assert.assertSame(e, e.slice(0, 0));
         AssertExtensions.assertThrows("", () -> e.slice(0, 1), ex -> ex instanceof IndexOutOfBoundsException);

--- a/common/src/test/java/io/pravega/common/util/BufferViewTestBase.java
+++ b/common/src/test/java/io/pravega/common/util/BufferViewTestBase.java
@@ -304,7 +304,10 @@ public abstract class BufferViewTestBase {
             for (int length = 0; length < data.getLength() - offset; length += 11) {
                 val expected = new byte[length];
                 System.arraycopy(data.array(), data.arrayOffset() + offset, expected, 0, length);
-                val slice = bufferView.slice(offset, length).getCopy();
+                val sliceBuffer = bufferView.slice(offset, length);
+                checkAllocatedSize(sliceBuffer, bufferView);
+
+                val slice = sliceBuffer.getCopy();
                 Assert.assertArrayEquals("Unexpected slice() result for offset " + offset + ", length " + length, expected, slice);
                 if (length == 0) {
                     Assert.assertEquals("Unexpected getReader() result for offset " + offset + ", length " + length,
@@ -338,6 +341,12 @@ public abstract class BufferViewTestBase {
 
     protected List<ByteBuffer> getContents(BufferView bufferView) {
         return Lists.newArrayList(bufferView.iterateBuffers());
+    }
+
+    protected void checkAllocatedSize(BufferView slice, BufferView base) {
+        Assert.assertEquals("Unexpected allocated length for slice.", slice.getAllocatedLength(), base.getLength());
+        AssertExtensions.assertGreaterThanOrEqual("Expected slice length to be at most the allocated length.",
+                slice.getLength(), slice.getAllocatedLength());
     }
 
     protected abstract BufferView toBufferView(ArrayView data);

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResult.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResult.java
@@ -86,10 +86,25 @@ public interface ReadResult extends Iterator<ReadResultEntry>, AutoCloseable {
     void setCopyOnRead(boolean value);
 
     /**
+     * Gets a value indicating the maximum number of bytes to read at once with every invocation of {@link #next()}.
+     *
+     * @return The maximum number of bytes to read at once.
+     */
+    int getMaxReadAtOnce();
+
+    /**
+     * Sets the maximum number of bytes to read at once with every invocation of {@link #next()}.
+     *
+     * @param value The value to set. If not positive or exceeds {@link #getMaxResultLength()}, this will be set to
+     *              {@link #getMaxResultLength()}.
+     */
+    void setMaxReadAtOnce(int value);
+
+    /**
      * Gets a value indicating whether this ReadResult is fully consumed (either because it was read in its entirety
      * or because it was closed externally).
      *
-     * @return true if ReadResult is fully consumed or closed externally, otherwise false
+     * @return true if ReadResult is fully consumed or closed externally, otherwise false.
      */
     boolean isClosed();
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultHandler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultHandler.java
@@ -66,7 +66,7 @@ public interface AsyncReadResultHandler {
      * Gets a value indicating the maximum number of bytes to process at any time. See {@link ReadResult#getMaxReadAtOnce()}.
      *
      * @return The maximum number of bytes to process at any time. Default value is {@link Integer#MAX_VALUE}, which
-     * means the underlying read result as absolute freedom in choosing the read size.
+     * means the underlying read result has absolute freedom in choosing the read size.
      */
     default int getMaxReadAtOnce() {
         return Integer.MAX_VALUE;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultHandler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultHandler.java
@@ -9,9 +9,9 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.ReadResultEntry;
 import io.pravega.segmentstore.contracts.ReadResultEntryType;
-
 import java.time.Duration;
 
 /**
@@ -61,4 +61,14 @@ public interface AsyncReadResultHandler {
      * @return The timeout.
      */
     Duration getRequestContentTimeout();
+
+    /**
+     * Gets a value indicating the maximum number of bytes to process at any time. See {@link ReadResult#getMaxReadAtOnce()}.
+     *
+     * @return The maximum number of bytes to process at any time. Default value is {@link Integer#MAX_VALUE}, which
+     * means the underlying read result as absolute freedom in choosing the read size.
+     */
+    default int getMaxReadAtOnce() {
+        return Integer.MAX_VALUE;
+    }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
@@ -66,6 +66,7 @@ public class AsyncReadResultProcessor implements AutoCloseable {
         this.readResult = readResult;
         this.entryHandler = entryHandler;
         this.closed = new AtomicBoolean();
+        this.readResult.setMaxReadAtOnce(this.entryHandler.getMaxReadAtOnce());
     }
 
     /**
@@ -141,6 +142,7 @@ public class AsyncReadResultProcessor implements AutoCloseable {
                         resultEntry -> {
                             if (resultEntry != null) {
                                 shouldContinue.set(this.entryHandler.processEntry(resultEntry));
+                                this.readResult.setMaxReadAtOnce(this.entryHandler.getMaxReadAtOnce());
                             }
                         },
                         executor)

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
@@ -56,7 +56,7 @@ public class StreamSegmentReadResultTests {
     }
 
     /**
-     * Tests the ability to properly set Copy-on-Read.
+     * Tests the ability to handle {@link StreamSegmentReadResult#setMaxReadAtOnce(int)}.
      */
     @Test
     public void testMaxReadAtOnce() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StreamSegmentReadResultTests.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import lombok.Cleanup;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,6 +53,36 @@ public class StreamSegmentReadResultTests {
         r2.setCopyOnRead(false);
         expectedMakeCopy.set(false);
         r2.next();
+    }
+
+    /**
+     * Tests the ability to properly set Copy-on-Read.
+     */
+    @Test
+    public void testMaxReadAtOnce() {
+        final int maxReadAtOnce = 10;
+        StreamSegmentReadResult.NextEntrySupplier nes = (offset, length, makeCopy) -> TestReadResultEntry.endOfSegment(offset, length);
+
+        // Set it to a small value.
+        @Cleanup
+        StreamSegmentReadResult r1 = new StreamSegmentReadResult(START_OFFSET, MAX_RESULT_LENGTH, nes, "");
+        r1.setMaxReadAtOnce(maxReadAtOnce);
+        val r11 = r1.next();
+        Assert.assertEquals(maxReadAtOnce, r11.getRequestedReadLength());
+
+        // Set it to 0.
+        @Cleanup
+        StreamSegmentReadResult r2 = new StreamSegmentReadResult(START_OFFSET, MAX_RESULT_LENGTH, nes, "");
+        r2.setMaxReadAtOnce(0);
+        val r21 = r2.next();
+        Assert.assertEquals(MAX_RESULT_LENGTH, r21.getRequestedReadLength());
+
+        // Set it to more than max result length.
+        @Cleanup
+        StreamSegmentReadResult r3 = new StreamSegmentReadResult(START_OFFSET, MAX_RESULT_LENGTH, nes, "");
+        r3.setMaxReadAtOnce(MAX_RESULT_LENGTH + 123);
+        val r31 = r3.next();
+        Assert.assertEquals(MAX_RESULT_LENGTH, r31.getRequestedReadLength());
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ReadResultMock.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ReadResultMock.java
@@ -70,6 +70,7 @@ class ReadResultMock extends StreamSegmentReadResult implements ReadResult {
         Preconditions.checkState(isCopyOnRead(), "Copy-on-read required for all Table Segment read requests.");
         int relativeOffset = this.consumedLength;
         int length = Math.min(this.entryLength, Math.min(this.data.getLength(), getMaxResultLength()) - relativeOffset);
+        length = Math.min(length, getMaxReadAtOnce());
         this.consumedLength += length;
         return new Entry(relativeOffset, length);
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ByteBufWrapper.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ByteBufWrapper.java
@@ -101,6 +101,7 @@ public class ByteBufWrapper extends AbstractBufferView implements BufferView {
 
     @Override
     public int getAllocatedLength() {
+        // TODO: This won't give us what we want. Unfortunately ByteBuf does not expose this information and there's no way to get it otherwise.
         return this.buf.capacity();
     }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ByteBufWrapper.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ByteBufWrapper.java
@@ -100,6 +100,11 @@ public class ByteBufWrapper extends AbstractBufferView implements BufferView {
     }
 
     @Override
+    public int getAllocatedLength() {
+        return this.buf.capacity();
+    }
+
+    @Override
     public Reader getBufferViewReader() {
         return new ByteBufReader(this.buf.duplicate());
     }

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/ByteBufWrapperTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/ByteBufWrapperTests.java
@@ -99,6 +99,24 @@ public class ByteBufWrapperTests extends BufferViewTestBase {
         AssertExtensions.assertListEquals("", expectedBuffers, actualBuffers, ByteBuffer::equals);
     }
 
+    @Test
+    public void testAllocatedLength() {
+        val b1 = Unpooled.wrappedBuffer(new byte[100]).slice(10, 20);
+        val b2 = Unpooled.directBuffer(100).slice(10, 20);
+        val b3 = Unpooled.wrappedUnmodifiableBuffer(b1, b2);
+        System.out.println("100 " + b1.capacity() + " " + new ByteBufWrapper(b1).getAllocatedLength());
+        System.out.println("100 " + b2.capacity() + " " + new ByteBufWrapper(b2).getAllocatedLength());
+        System.out.println("200 " + b3.capacity() + " " + new ByteBufWrapper(b3).getAllocatedLength());
+    }
+
+    @Override
+    protected void checkAllocatedSize(BufferView slice, BufferView base) {
+        // We don't have a good way to extract the actual allocated size from a ByteBuf, so we can only verify that the
+        // allocated length is at least what the length of the buffer is.
+        AssertExtensions.assertGreaterThanOrEqual("Expected slice length to be at most the allocated length.",
+                slice.getLength(), slice.getAllocatedLength());
+    }
+
     @Override
     protected BufferView toBufferView(ArrayView data) {
         return new ByteBufWrapper(Unpooled.wrappedBuffer(data.array(), data.arrayOffset(), data.getLength()));

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/TruncateableArray.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/TruncateableArray.java
@@ -98,6 +98,11 @@ public class TruncateableArray implements ArrayView {
     }
 
     @Override
+    public int getAllocatedLength() {
+        return this.length;
+    }
+
+    @Override
     public byte[] array() {
         throw new UnsupportedOperationException("array() not supported.");
     }


### PR DESCRIPTION
**Change log description**  
Reduced memory consumption when reading from Table Segments by making more focused reads.

**Purpose of the change**  
Fixes #5771.

**What the code does**  
SInce we do not know the size of the Table Entry to read (keys or values), we usually request to read 1MB of data from the Segment at the Table Entry offset, and then slice the Key and the Value out of that buffer. This poses two problems: 1) slicing still points to the whole buffer, even if we use a small portion of it and 2) most keys/values are much, much smaller than 1MB, which means we're reading and loading extra data into the heap for no good reason.

Added the ability to `ReadResult` to fine-tune the amount of data that an invocation to `next()` would fetch.  Wired this into `AsyncReadResultProcessor` to be set after that processor handles the result from a `next()` call. 

In `AsyncTableEntryReader` (a handler for `AsyncReadResultProcessor`), we first request about 8KB - the maximum size of the key + header, and then, based on what we read from that, request exactly the amount of data that we need for the value (if anything at all).

Also, if this still results in keys or values which are small slices of their underlying buffers, the `AsyncTableEntryReader` has a heuristic to compact them (replace them with a `byte[]` copy) if they occupy less than 50% of their buffer.

Details:
- `ReadResult`: added a `MaxReadAtOnce` to limit the size of any returned `ReadResultEntries`. Wired through `AsyncReadResultProcessor`.
- `BufferView`: added `BufferView.getAllocatedLength` that estimates the amount of memory used by the underlying `BufferView`.
- `AsyncTableEntryReader`: limiting the amount of data read for fetching Keys and Values; compacting results if needed (50% or less of actual allocated size).


**How to verify it**  
New unit test added. Build must pass.
