### PR TITLE
Issue 5726 : Fix TimeoutException in AuthEnabledInProcPravegaClusterTest

### DIFF
--- a/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
@@ -34,7 +34,7 @@ import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
 public class AuthEnabledInProcPravegaClusterTest {
 
     @ClassRule
-    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(true, false);
+    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(true, false, false);
     final String scope = "AuthTestScope";
     final String stream = "AuthTestStream";
     final String msg = "Test message on the plaintext channel with auth credentials";

--- a/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
@@ -24,6 +24,8 @@ import io.pravega.test.common.SecurityConfigDefaults;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 
+import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
+
 /**
  * This class contains tests for auth enabled in-process standalone cluster. It inherits the test methods defined
  * in the parent class.
@@ -69,7 +71,7 @@ public class AuthEnabledInProcPravegaClusterTest {
 
     @Test(timeout = 30000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        EMULATOR.testWriteAndReadAnEventWithValidClientConfig(scope, stream, msg, prepareValidClientConfig());
+        testWriteAndReadAnEvent(scope, stream, msg, prepareValidClientConfig());
     }
 
     private boolean hasAuthExceptionAsRootCause(Throwable e) {

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -10,36 +10,12 @@
 package io.pravega.local;
 
 import io.pravega.client.ClientConfig;
-import io.pravega.client.EventStreamClientFactory;
-import io.pravega.client.admin.ReaderGroupManager;
-import io.pravega.client.admin.StreamManager;
-import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.EventWriterConfig;
-import io.pravega.client.stream.ReaderConfig;
-import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.ReinitializationRequiredException;
-import io.pravega.client.stream.ScalingPolicy;
-import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.JavaSerializer;
-import io.pravega.test.common.SecurityConfigDefaults;
-import io.pravega.test.common.TestUtils;
+
 import java.net.URI;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
-import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
-
-import static io.pravega.local.LocalPravegaEmulator.LocalPravegaEmulatorBuilder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * This class contains tests for in-process standalone cluster. It also configures and runs standalone mode cluster
@@ -48,65 +24,15 @@ import static org.junit.Assert.assertTrue;
 @Slf4j
 public class InProcPravegaClusterTest {
 
-    boolean restEnabled = true;
-    boolean authEnabled = false;
-    boolean tlsEnabled = false;
-    LocalPravegaEmulator localPravega;
-
-    @Before
-    public void setUp() throws Exception {
-        LocalPravegaEmulatorBuilder emulatorBuilder = LocalPravegaEmulator.builder()
-                .controllerPort(TestUtils.getAvailableListenPort())
-                .segmentStorePort(TestUtils.getAvailableListenPort())
-                .zkPort(TestUtils.getAvailableListenPort())
-                .restServerPort(TestUtils.getAvailableListenPort())
-                .enableRestServer(restEnabled)
-                .enableAuth(authEnabled)
-                .enableTls(tlsEnabled);
-
-        // Since the server is being built right here, avoiding delegating these conditions to subclasses via factory
-        // methods. This is so that it is easy to see the difference in server configs all in one place. This is also
-        // unlike the ClientConfig preparation which is being delegated to factory methods to make their preparation
-        // explicit in the respective test classes.
-
-        if (authEnabled) {
-            emulatorBuilder.passwdFile(SecurityConfigDefaults.AUTH_HANDLER_INPUT_PATH)
-                    .userName(SecurityConfigDefaults.AUTH_ADMIN_USERNAME)
-                    .passwd(SecurityConfigDefaults.AUTH_ADMIN_PASSWORD);
-        }
-        if (tlsEnabled) {
-            emulatorBuilder.certFile(SecurityConfigDefaults.TLS_SERVER_CERT_PATH)
-                    .keyFile(SecurityConfigDefaults.TLS_SERVER_PRIVATE_KEY_PATH)
-                    .jksKeyFile(SecurityConfigDefaults.TLS_SERVER_KEYSTORE_PATH)
-                    .jksTrustFile(SecurityConfigDefaults.TLS_CLIENT_TRUSTSTORE_PATH)
-                    .keyPasswordFile(SecurityConfigDefaults.TLS_PASSWORD_PATH);
-        }
-
-        localPravega = emulatorBuilder.build();
-        localPravega.start();
-    }
-
-    //region Factory methods. These should be overridden in subclasses.
-
-    String scopeName() {
-        return "TestScope";
-    }
-
-    String streamName() {
-        return "TestStream";
-    }
-
-    String eventMessage() {
-        return "Test message on the plaintext channel";
-    }
+    @ClassRule
+    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(false, false);
+    final String msg = "Test message on the plaintext channel";
 
     ClientConfig prepareValidClientConfig() {
         return ClientConfig.builder()
-                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
+                .controllerURI(URI.create(EMULATOR.pravega.getInProcPravegaCluster().getControllerURI()))
                 .build();
     }
-
-    //endregion
 
     /**
      * Compares reads and writes to verify that an in-process Pravega cluster responds properly with
@@ -118,69 +44,7 @@ public class InProcPravegaClusterTest {
      *
      */
     @Test(timeout = 30000)
-    public void testWriteAndReadEventWithValidClientConfig() throws ExecutionException,
-            InterruptedException, ReinitializationRequiredException {
-        String scope = scopeName();
-        String streamName = streamName();
-        int numSegments = 1;
-        String message = eventMessage();
-
-        ClientConfig clientConfig = prepareValidClientConfig();
-
-        @Cleanup
-        StreamManager streamManager = StreamManager.create(clientConfig);
-        assertNotNull(streamManager);
-
-        boolean isScopeCreated = streamManager.createScope(scope);
-        assertTrue("Failed to create scope", isScopeCreated);
-
-        boolean isStreamCreated = streamManager.createStream(scope, streamName, StreamConfiguration.builder()
-                .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                .build());
-        Assert.assertTrue("Failed to create the stream ", isStreamCreated);
-
-        @Cleanup
-        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
-
-        // Write an event to the stream.
-
-        @Cleanup
-        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
-                new JavaSerializer<String>(),
-                EventWriterConfig.builder().build());
-        writer.writeEvent(message).get();
-        log.debug("Done writing message '{}' to stream '{} / {}'", message, scope, streamName);
-
-        // Now, read the event from the stream.
-
-        String readerGroup = UUID.randomUUID().toString().replace("-", "");
-        ReaderGroupConfig readerGroupConfig = ReaderGroupConfig.builder()
-                .stream(Stream.of(scope, streamName))
-                .disableAutomaticCheckpoints()
-                .build();
-
-        @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
-        readerGroupManager.createReaderGroup(readerGroup, readerGroupConfig);
-
-        @Cleanup
-        EventStreamReader<String> reader = clientFactory.createReader(
-                "readerId", readerGroup,
-                new JavaSerializer<String>(), ReaderConfig.builder().initialAllocationDelay(0).build());
-
-        // Keeping the read timeout large so that there is ample time for reading the event even in
-        // case of abnormal delays in test environments.
-        String readMessage = reader.readNextEvent(10000).getEvent();
-        log.info("Done reading event [{}]", readMessage);
-
-        assertEquals(message, readMessage);
-    }
-
-
-    @After
-    public void tearDown() throws Exception {
-        if (localPravega != null) {
-            localPravega.close();
-        }
+    public void testWriteAndReadEventWithValidClientConfig() throws Exception {
+        EMULATOR.testWriteAndReadAnEventWithValidClientConfig("TestScope", "TestStream", msg, prepareValidClientConfig());
     }
 }

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -27,7 +27,7 @@ import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
 public class InProcPravegaClusterTest {
 
     @ClassRule
-    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(false, false);
+    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(false, false, false);
     final String msg = "Test message on the plaintext channel";
 
     ClientConfig prepareValidClientConfig() {

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -17,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
+
 /**
  * This class contains tests for in-process standalone cluster. It also configures and runs standalone mode cluster
  * with appropriate configuration for itself as well as for sub-classes.
@@ -45,6 +47,6 @@ public class InProcPravegaClusterTest {
      */
     @Test(timeout = 30000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        EMULATOR.testWriteAndReadAnEventWithValidClientConfig("TestScope", "TestStream", msg, prepareValidClientConfig());
+        testWriteAndReadAnEvent("TestScope", "TestStream", msg, prepareValidClientConfig());
     }
 }

--- a/standalone/src/test/java/io/pravega/local/PravegaEmulatorResource.java
+++ b/standalone/src/test/java/io/pravega/local/PravegaEmulatorResource.java
@@ -23,18 +23,17 @@ import org.junit.rules.ExternalResource;
  * - Usage pattern to start it once for all @Test methods in a class
  *  <pre>
  *  &#64;ClassRule
- *  public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(false, false);
+ *  public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(false, false, false);
  *  </pre>
  *  - Usage pattern to start it before every @Test method.
  *  <pre>
  *  &#64;Rule
- *  public final PravegaEmulatorResource emulator = new PravegaEmulatorResource(false, false);
+ *  public final PravegaEmulatorResource emulator = new PravegaEmulatorResource(false, false, false);
  *  </pre>
  *
  */
 @Slf4j
 public class PravegaEmulatorResource extends ExternalResource {
-    final boolean restEnabled = false; // disable REST server for the current tests.
     final boolean authEnabled;
     final boolean tlsEnabled;
     final LocalPravegaEmulator pravega;
@@ -43,8 +42,9 @@ public class PravegaEmulatorResource extends ExternalResource {
      * Create an instance of Pravega Emulator resource.
      * @param authEnabled Authorisation enable flag.
      * @param tlsEnabled  Tls enable flag.
+     * @param restEnabled REST endpoint enable flag.
      */
-    public PravegaEmulatorResource(boolean authEnabled, boolean tlsEnabled) {
+    public PravegaEmulatorResource(boolean authEnabled, boolean tlsEnabled, boolean restEnabled) {
         this.authEnabled = authEnabled;
         this.tlsEnabled = tlsEnabled;
         LocalPravegaEmulator.LocalPravegaEmulatorBuilder emulatorBuilder = LocalPravegaEmulator.builder()

--- a/standalone/src/test/java/io/pravega/local/PravegaEmulatorResource.java
+++ b/standalone/src/test/java/io/pravega/local/PravegaEmulatorResource.java
@@ -9,37 +9,28 @@
  */
 package io.pravega.local;
 
-import io.pravega.client.ClientConfig;
-import io.pravega.client.EventStreamClientFactory;
-import io.pravega.client.admin.ReaderGroupManager;
-import io.pravega.client.admin.StreamManager;
-import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.EventWriterConfig;
-import io.pravega.client.stream.ReaderConfig;
-import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.ScalingPolicy;
-import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.test.common.SecurityConfigDefaults;
 import io.pravega.test.common.TestUtils;
-import lombok.Cleanup;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
 import org.junit.rules.ExternalResource;
-
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * This class contains the rules to start and stop LocalPravega / standalone.
  * This resource can be configured for a test using @ClassRule and it will ensure standalone is started once
  * for all the methods in a test and is shutdown once all the tests methods have completed execution.
+ *
+ * - Usage pattern to start it once for all @Test methods in a class
+ *  <pre>
+ *  &#64;ClassRule
+ *  public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(false, false);
+ *  </pre>
+ *  - Usage pattern to start it before every @Test method.
+ *  <pre>
+ *  &#64;Rule
+ *  public final PravegaEmulatorResource emulator = new PravegaEmulatorResource(false, false);
+ *  </pre>
+ *
  */
 @Slf4j
 public class PravegaEmulatorResource extends ExternalResource {
@@ -48,6 +39,11 @@ public class PravegaEmulatorResource extends ExternalResource {
     final boolean tlsEnabled;
     final LocalPravegaEmulator pravega;
 
+    /**
+     * Create an instance of Pravega Emulator resource.
+     * @param authEnabled Authorisation enable flag.
+     * @param tlsEnabled  Tls enable flag.
+     */
     public PravegaEmulatorResource(boolean authEnabled, boolean tlsEnabled) {
         this.authEnabled = authEnabled;
         this.tlsEnabled = tlsEnabled;
@@ -88,55 +84,6 @@ public class PravegaEmulatorResource extends ExternalResource {
     @SneakyThrows
     protected void after() {
         pravega.close();
-    }
-
-    public void testWriteAndReadAnEventWithValidClientConfig(String scope, String streamName, String message, ClientConfig clientConfig) throws Exception {
-        int numSegments = 1;
-
-        @Cleanup
-        StreamManager streamManager = StreamManager.create(clientConfig);
-        assertNotNull(streamManager);
-
-        boolean isScopeCreated = streamManager.createScope(scope);
-        assertTrue("Failed to create scope", isScopeCreated);
-        boolean isStreamCreated = streamManager.createStream(scope, streamName, StreamConfiguration.builder()
-                .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                .build());
-        Assert.assertTrue("Failed to create the stream ", isStreamCreated);
-        log.info("write event");
-        @Cleanup
-        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
-
-        // Write an event to the stream.
-        @Cleanup
-        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
-                new JavaSerializer<String>(),
-                EventWriterConfig.builder().build());
-        writer.writeEvent(message).get();
-        log.debug("Done writing message '{}' to stream '{} / {}'", message, scope, streamName);
-
-        // Now, read the event from the stream.
-
-        String readerGroup = UUID.randomUUID().toString().replace("-", "");
-        ReaderGroupConfig readerGroupConfig = ReaderGroupConfig.builder()
-                .stream(Stream.of(scope, streamName))
-                .disableAutomaticCheckpoints()
-                .build();
-
-        @Cleanup
-        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
-        readerGroupManager.createReaderGroup(readerGroup, readerGroupConfig);
-
-        @Cleanup
-        EventStreamReader<String> reader = clientFactory.createReader(
-                "readerId", readerGroup,
-                new JavaSerializer<String>(), ReaderConfig.builder().initialAllocationDelay(0).build());
-        // Keeping the read timeout large so that there is ample time for reading the event even in
-        // case of abnormal delays in test environments.
-        String readMessage = reader.readNextEvent(10000).getEvent();
-        log.info("Done reading event [{}]", readMessage);
-
-        assertEquals(message, readMessage);
     }
 }
 

--- a/standalone/src/test/java/io/pravega/local/PravegaEmulatorResource.java
+++ b/standalone/src/test/java/io/pravega/local/PravegaEmulatorResource.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.local;
+
+import io.pravega.client.ClientConfig;
+import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.test.common.SecurityConfigDefaults;
+import io.pravega.test.common.TestUtils;
+import lombok.Cleanup;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.rules.ExternalResource;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This class contains the rules to start and stop LocalPravega / standalone.
+ * This resource can be configured for a test using @ClassRule and it will ensure standalone is started once
+ * for all the methods in a test and is shutdown once all the tests methods have completed execution.
+ */
+@Slf4j
+public class PravegaEmulatorResource extends ExternalResource {
+    final boolean restEnabled = false; // disable REST server for the current tests.
+    final boolean authEnabled;
+    final boolean tlsEnabled;
+    final LocalPravegaEmulator pravega;
+
+    public PravegaEmulatorResource(boolean authEnabled, boolean tlsEnabled) {
+        this.authEnabled = authEnabled;
+        this.tlsEnabled = tlsEnabled;
+        LocalPravegaEmulator.LocalPravegaEmulatorBuilder emulatorBuilder = LocalPravegaEmulator.builder()
+                .controllerPort(TestUtils.getAvailableListenPort())
+                .segmentStorePort(TestUtils.getAvailableListenPort())
+                .zkPort(TestUtils.getAvailableListenPort())
+                .restServerPort(TestUtils.getAvailableListenPort())
+                .enableRestServer(restEnabled)
+                .enableAuth(authEnabled)
+                .enableTls(tlsEnabled);
+
+        // Since the server is being built right here, avoiding delegating these conditions to subclasses via factory
+        // methods. This is so that it is easy to see the difference in server configs all in one place. This is also
+        // unlike the ClientConfig preparation which is being delegated to factory methods to make their preparation
+        // explicit in the respective test classes.
+
+        if (authEnabled) {
+            emulatorBuilder.passwdFile(SecurityConfigDefaults.AUTH_HANDLER_INPUT_PATH)
+                    .userName(SecurityConfigDefaults.AUTH_ADMIN_USERNAME)
+                    .passwd(SecurityConfigDefaults.AUTH_ADMIN_PASSWORD);
+        }
+        if (tlsEnabled) {
+            emulatorBuilder.certFile(SecurityConfigDefaults.TLS_SERVER_CERT_PATH)
+                    .keyFile(SecurityConfigDefaults.TLS_SERVER_PRIVATE_KEY_PATH)
+                    .jksKeyFile(SecurityConfigDefaults.TLS_SERVER_KEYSTORE_PATH)
+                    .jksTrustFile(SecurityConfigDefaults.TLS_CLIENT_TRUSTSTORE_PATH)
+                    .keyPasswordFile(SecurityConfigDefaults.TLS_PASSWORD_PATH);
+        }
+
+        pravega = emulatorBuilder.build();
+    }
+
+    protected void before() throws Exception {
+        pravega.start();
+    }
+
+    @SneakyThrows
+    protected void after() {
+        pravega.close();
+    }
+
+    public void testWriteAndReadAnEventWithValidClientConfig(String scope, String streamName, String message, ClientConfig clientConfig) throws Exception {
+        int numSegments = 1;
+
+        @Cleanup
+        StreamManager streamManager = StreamManager.create(clientConfig);
+        assertNotNull(streamManager);
+
+        boolean isScopeCreated = streamManager.createScope(scope);
+        assertTrue("Failed to create scope", isScopeCreated);
+        boolean isStreamCreated = streamManager.createStream(scope, streamName, StreamConfiguration.builder()
+                .scalingPolicy(ScalingPolicy.fixed(numSegments))
+                .build());
+        Assert.assertTrue("Failed to create the stream ", isStreamCreated);
+        log.info("write event");
+        @Cleanup
+        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
+
+        // Write an event to the stream.
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName,
+                new JavaSerializer<String>(),
+                EventWriterConfig.builder().build());
+        writer.writeEvent(message).get();
+        log.debug("Done writing message '{}' to stream '{} / {}'", message, scope, streamName);
+
+        // Now, read the event from the stream.
+
+        String readerGroup = UUID.randomUUID().toString().replace("-", "");
+        ReaderGroupConfig readerGroupConfig = ReaderGroupConfig.builder()
+                .stream(Stream.of(scope, streamName))
+                .disableAutomaticCheckpoints()
+                .build();
+
+        @Cleanup
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
+        readerGroupManager.createReaderGroup(readerGroup, readerGroupConfig);
+
+        @Cleanup
+        EventStreamReader<String> reader = clientFactory.createReader(
+                "readerId", readerGroup,
+                new JavaSerializer<String>(), ReaderConfig.builder().initialAllocationDelay(0).build());
+        // Keeping the read timeout large so that there is ample time for reading the event even in
+        // case of abnormal delays in test environments.
+        String readMessage = reader.readNextEvent(10000).getEvent();
+        log.info("Done reading event [{}]", readMessage);
+
+        assertEquals(message, readMessage);
+    }
+}
+
+

--- a/standalone/src/test/java/io/pravega/local/PravegaSanityTests.java
+++ b/standalone/src/test/java/io/pravega/local/PravegaSanityTests.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.local;
+
+import io.pravega.client.ClientConfig;
+import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.JavaSerializer;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Collection of basic Pravega Sanity tests.
+ */
+@Slf4j
+public class PravegaSanityTests {
+
+    /**
+     * Method to test Pravega by writing an event to a stream and reading from it.
+     * This method creates the scope and streams too.
+     * @param scope Pravega Scope name.
+     * @param stream Pravega Stream name.
+     * @param message Message to be written.
+     * @param clientConfig ClientConfig for Pravega.
+     */
+    public static void testWriteAndReadAnEvent(String scope, String stream, String message, ClientConfig clientConfig) {
+        int numSegments = 1;
+        @Cleanup
+        StreamManager streamManager = StreamManager.create(clientConfig);
+        assertNotNull(streamManager);
+        boolean isScopeCreated = streamManager.createScope(scope);
+        assertTrue("Failed to create scope", isScopeCreated);
+        boolean isStreamCreated = streamManager.createStream(scope, stream, StreamConfiguration.builder()
+                .scalingPolicy(ScalingPolicy.fixed(numSegments))
+                .build());
+        Assert.assertTrue("Failed to create the stream ", isStreamCreated);
+        log.info("write an event");
+        @Cleanup
+        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
+
+        // Write an event to the stream.
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(stream,
+                new JavaSerializer<String>(),
+                EventWriterConfig.builder().build());
+        writer.writeEvent(message);
+        writer.flush();
+        log.debug("Done writing message '{}' to stream '{} / {}'", message, scope, stream);
+
+        // Now, read the event from the stream.
+        String readerGroup = UUID.randomUUID().toString().replace("-", "");
+        ReaderGroupConfig readerGroupConfig = ReaderGroupConfig.builder()
+                .stream(Stream.of(scope, stream))
+                .disableAutomaticCheckpoints()
+                .build();
+
+        @Cleanup
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
+        readerGroupManager.createReaderGroup(readerGroup, readerGroupConfig);
+
+        @Cleanup
+        EventStreamReader<String> reader = clientFactory.createReader(
+                "readerId", readerGroup,
+                new JavaSerializer<String>(), ReaderConfig.builder().initialAllocationDelay(0).build());
+        // Keeping the read timeout large so that there is ample time for reading the event even in
+        // case of abnormal delays in test environments.
+        String readMessage = reader.readNextEvent(10000).getEvent();
+        log.info("Done reading event [{}]", readMessage);
+
+        assertEquals(message, readMessage);
+    }
+}

--- a/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
@@ -15,42 +15,24 @@ import java.net.URI;
 
 import io.pravega.test.common.SecurityConfigDefaults;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 /**
  * This class holds tests for TLS and auth enabled in-process standalone cluster. It inherits the test methods defined
  * in the parent class.
  */
 @Slf4j
-public class SecurePravegaClusterTest extends InProcPravegaClusterTest {
-    @Before
-    @Override
-    public void setUp() throws Exception {
-        this.authEnabled = true;
-        this.tlsEnabled = true;
-        super.setUp();
-    }
+public class SecurePravegaClusterTest {
+    @ClassRule
+    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(true, true);
+    final String scope = "TlsAndAuthTestScope";
+    final String stream = "TlsAndAuthTestStream";
+    final String msg = "Test message on the encrypted channel with auth credentials";
 
-    @Override
-    String scopeName() {
-        return "TlsAndAuthTestScope";
-    }
-
-    @Override
-    String streamName() {
-        return "TlsAndAuthTestStream";
-    }
-
-    @Override
-    String eventMessage() {
-        return "Test message on the encrypted channel with auth credentials";
-    }
-
-    @Override
     ClientConfig prepareValidClientConfig() {
         return ClientConfig.builder()
-                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
+                .controllerURI(URI.create(EMULATOR.pravega.getInProcPravegaCluster().getControllerURI()))
 
                 // TLS-related
                 .trustStore(SecurityConfigDefaults.TLS_CA_CERT_PATH)
@@ -62,9 +44,8 @@ public class SecurePravegaClusterTest extends InProcPravegaClusterTest {
                 .build();
     }
 
-    @After
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
+    @Test(timeout = 30000)
+    public void testWriteAndReadEventWithValidClientConfig() throws Exception {
+        EMULATOR.testWriteAndReadAnEventWithValidClientConfig(scope, stream, msg, prepareValidClientConfig());
     }
 }

--- a/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
@@ -27,7 +27,7 @@ import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
 @Slf4j
 public class SecurePravegaClusterTest {
     @ClassRule
-    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(true, true);
+    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(true, true, false);
     final String scope = "TlsAndAuthTestScope";
     final String stream = "TlsAndAuthTestStream";
     final String msg = "Test message on the encrypted channel with auth credentials";

--- a/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
@@ -18,6 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
+
 /**
  * This class holds tests for TLS and auth enabled in-process standalone cluster. It inherits the test methods defined
  * in the parent class.
@@ -46,6 +48,6 @@ public class SecurePravegaClusterTest {
 
     @Test(timeout = 30000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        EMULATOR.testWriteAndReadAnEventWithValidClientConfig(scope, stream, msg, prepareValidClientConfig());
+        testWriteAndReadAnEvent(scope, stream, msg, prepareValidClientConfig());
     }
 }

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -24,6 +24,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
+
 /**
  * Tests for TLS enabled standalone cluster. It inherits the test methods defined in the parent class.
  */
@@ -75,7 +77,7 @@ public class TlsEnabledInProcPravegaClusterTest {
 
     @Test(timeout = 30000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        EMULATOR.testWriteAndReadAnEventWithValidClientConfig(scope, stream, msg, prepareValidClientConfig());
+        testWriteAndReadAnEvent(scope, stream, msg, prepareValidClientConfig());
     }
 
     private boolean hasTlsException(Throwable e) {

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -33,7 +33,7 @@ import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
 public class TlsEnabledInProcPravegaClusterTest {
 
     @ClassRule
-    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(false, true);
+    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(false, true, false);
     final String scope = "TlsTestScope";
     final String stream = "TlsTestStream";
     final String msg = "Test message on the encrypted channel";

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -21,46 +21,32 @@ import javax.net.ssl.SSLHandshakeException;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 /**
  * Tests for TLS enabled standalone cluster. It inherits the test methods defined in the parent class.
  */
 @Slf4j
-public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest {
+public class TlsEnabledInProcPravegaClusterTest {
 
-    @Before
-    @Override
-    public void setUp() throws Exception {
-        this.authEnabled = false;
-        this.tlsEnabled = true;
-        super.setUp();
-    }
+    @ClassRule
+    public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(false, true);
+    final String scope = "TlsTestScope";
+    final String stream = "TlsTestStream";
+    final String msg = "Test message on the encrypted channel";
 
-    @Override
-    String scopeName() {
-        return "TlsTestScope";
-    }
-
-    @Override
-    String streamName() {
-        return "TlsTestStream";
-    }
-
-    @Override
-    String eventMessage() {
-        return "Test message on the encrypted channel";
-    }
-
-    @Override
     ClientConfig prepareValidClientConfig() {
         return ClientConfig.builder()
-                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
+                .controllerURI(URI.create(EMULATOR.pravega.getInProcPravegaCluster().getControllerURI()))
                 .trustStore(SecurityConfigDefaults.TLS_CA_CERT_PATH)
                 .validateHostName(false)
                 .build();
+    }
+
+    @Test(timeout = 30000)
+    public void testWriteAndReadEventWithValidClientConfig() throws Exception {
+        EMULATOR.testWriteAndReadAnEventWithValidClientConfig(scope, stream, msg, prepareValidClientConfig());
     }
 
     /**
@@ -73,12 +59,12 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
     public void testCreateStreamFailsWithInvalidClientConfig() {
         // Truststore for the TLS connection is missing.
         ClientConfig clientConfig = ClientConfig.builder()
-                .controllerURI(URI.create(localPravega.getInProcPravegaCluster().getControllerURI()))
+                .controllerURI(URI.create(EMULATOR.pravega.getInProcPravegaCluster().getControllerURI()))
                 .build();
 
         ControllerImplConfig controllerImplConfig = ControllerImplConfig.builder()
                 .clientConfig(clientConfig)
-                .retryAttempts(10)
+                .retryAttempts(1)
                 .initialBackoffMillis(1000)
                 .backoffMultiple(1)
                 .maxBackoffMillis(1000)
@@ -88,17 +74,11 @@ public class TlsEnabledInProcPravegaClusterTest extends InProcPravegaClusterTest
         StreamManager streamManager = new StreamManagerImpl(clientConfig, controllerImplConfig);
 
         AssertExtensions.assertThrows("TLS exception did not occur.",
-                () -> streamManager.createScope(scopeName()),
+                () -> streamManager.createScope(scope),
                 e -> hasTlsException(e));
     }
 
     private boolean hasTlsException(Throwable e) {
         return ExceptionUtils.indexOfThrowable(e, SSLHandshakeException.class) != -1;
-    }
-
-    @After
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
     }
 }

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -44,11 +44,6 @@ public class TlsEnabledInProcPravegaClusterTest {
                 .build();
     }
 
-    @Test(timeout = 30000)
-    public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        EMULATOR.testWriteAndReadAnEventWithValidClientConfig(scope, stream, msg, prepareValidClientConfig());
-    }
-
     /**
      * This test verifies that create stream fails when the client config is invalid.
      *
@@ -76,6 +71,11 @@ public class TlsEnabledInProcPravegaClusterTest {
         AssertExtensions.assertThrows("TLS exception did not occur.",
                 () -> streamManager.createScope(scope),
                 e -> hasTlsException(e));
+    }
+
+    @Test(timeout = 30000)
+    public void testWriteAndReadEventWithValidClientConfig() throws Exception {
+        EMULATOR.testWriteAndReadAnEventWithValidClientConfig(scope, stream, msg, prepareValidClientConfig());
     }
 
     private boolean hasTlsException(Throwable e) {


### PR DESCRIPTION
**Change log description**  
- Ensure standalone is not started for every test, this speeds up tests.
- Disable the REST server for the tests.

**Purpose of the change**  
Fixes #5726 

**What the code does**  
- Ensure standalone is not started for every test
  The older tests brought up Pravega standalone for every @Test method. This PR ensures standalone is brought up per test file.
- Disable REST server on the standalone.
- Speeds up the standalone tests due to this logic.

**How to verify it**  
The tests should pass reliably.

