### PR TITLE
Issue 5789: (SegmentStore) Improving stability during Segment Container Recoveries

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
@@ -9,13 +9,10 @@
  */
 package io.pravega.segmentstore.server;
 
-import io.pravega.common.Exceptions;
 import io.pravega.segmentstore.storage.ThrottleSourceListener;
-import java.util.ArrayList;
-import java.util.HashSet;
+import io.pravega.segmentstore.storage.ThrottlerSourceListenerCollection;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -30,8 +27,7 @@ public class CacheUtilizationProvider {
 
     private final CachePolicy policy;
     private final Supplier<Long> getCacheStoredBytes;
-    @GuardedBy("cleanupListeners")
-    private final HashSet<ThrottleSourceListener> cleanupListeners;
+    private final ThrottlerSourceListenerCollection cleanupListeners;
     private final AtomicLong pendingBytes;
     private final double utilizationSpread;
     private final double maxInsertCapacityThreshold;
@@ -49,7 +45,7 @@ public class CacheUtilizationProvider {
     CacheUtilizationProvider(@NonNull CachePolicy policy, @NonNull Supplier<Long> getCacheStoredBytes) {
         this.policy = policy;
         this.getCacheStoredBytes = getCacheStoredBytes;
-        this.cleanupListeners = new HashSet<>();
+        this.cleanupListeners = new ThrottlerSourceListenerCollection();
         this.pendingBytes = new AtomicLong();
         this.utilizationSpread = 2 * (policy.getMaxUtilization() - policy.getTargetUtilization());
         this.maxInsertCapacityThreshold = policy.getMaxUtilization() - this.utilizationSpread;
@@ -160,14 +156,7 @@ public class CacheUtilizationProvider {
      *                 run that detects {@link ThrottleSourceListener#isClosed()} to be true.
      */
     public void registerCleanupListener(@NonNull ThrottleSourceListener listener) {
-        if (listener.isClosed()) {
-            log.warn("Attempted to register a closed ThrottleSourceListener ({}).", listener);
-            return;
-        }
-
-        synchronized (this.cleanupListeners) {
-            this.cleanupListeners.add(listener); // This is a Set, so we won't be adding the same listener twice.
-        }
+        this.cleanupListeners.register(listener);
     }
 
     /**
@@ -175,31 +164,7 @@ public class CacheUtilizationProvider {
      * event has just completed.
      */
     void notifyCleanupListeners() {
-        ArrayList<ThrottleSourceListener> toNotify = new ArrayList<>();
-        ArrayList<ThrottleSourceListener> toRemove = new ArrayList<>();
-        synchronized (this.cleanupListeners) {
-            for (ThrottleSourceListener l : this.cleanupListeners) {
-                if (l.isClosed()) {
-                    toRemove.add(l);
-                } else {
-                    toNotify.add(l);
-                }
-            }
-
-            this.cleanupListeners.removeAll(toRemove);
-        }
-
-        for (ThrottleSourceListener l : toNotify) {
-            try {
-                l.notifyThrottleSourceChanged();
-            } catch (Throwable ex) {
-                if (Exceptions.mustRethrow(ex)) {
-                    throw ex;
-                }
-
-                log.error("Error while notifying cleanup listener {}.", l, ex);
-            }
-        }
+        this.cleanupListeners.notifySourceChanged();
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ReadIndex.java
@@ -126,6 +126,12 @@ public interface ReadIndex extends AutoCloseable {
     void cleanup(Collection<Long> segmentIds);
 
     /**
+     * Evicts all cache entries that are eligible for eviction. Only applicable in recovery mode.
+     * @throws IllegalStateException If the ReadIndex is not in recovery mode.
+     */
+    long trimCache();
+
+    /**
      * Puts the ReadIndex in Recovery Mode. Some operations may not be available in Recovery Mode.
      *
      * @param recoveryMetadataSource The Metadata Source to use. This Metadata must be in sync with the ReadIndex base

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -422,7 +422,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                 // and rebuild the metadata from the information we have so far.
                 if (this.processedCheckpoint) {
                     // A MetadataCheckpoint should be processed fully only if is the first checkpoint encountered.
-                    // Any subsequent MetadataCheckpoints should be partially processed and applied
+                    // Any subsequent MetadataCheckpoints should be partially processed and applied.
                     // But we can (should) only process at most one MetadataCheckpoint per recovery. Any additional
                     // ones are redundant (used just for Truncation purposes) and contain the same information as
                     // if we processed every operation in order, up to them.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -399,12 +399,12 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                     // But we can (should) only process at most one MetadataCheckpoint per recovery. Any additional
                     // ones are redundant (used just for Truncation purposes) and contain the same information as
                     // if we processed every operation in order, up to them.
-                    log.debug("MetadataUpdate[{}-{}}]: Skipping MetadataCheckpointOperation with SequenceNumber {} because we already have metadata changes.",
+                    log.debug("MetadataUpdate[{}-{}}]: Skipping MetadataCheckpointOperation({}) because we already have metadata changes.",
                             this.containerId, this.transactionId, operation.getSequenceNumber());
                     return;
                 }
 
-                log.info("MetadataUpdate[{}-{}}]: Recovering MetadataCheckpointOperation with SequenceNumber {}.",
+                log.info("MetadataUpdate[{}-{}}]: Recovering MetadataCheckpointOperation({}).",
                         this.containerId, this.transactionId, operation.getSequenceNumber());
                 clear();
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -18,6 +18,8 @@ import io.pravega.common.io.serialization.VersionedSerializer;
 import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.ContainerException;
+import io.pravega.segmentstore.contracts.SegmentProperties;
+import io.pravega.segmentstore.contracts.SegmentType;
 import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.TooManyActiveSegmentsException;
@@ -41,10 +43,15 @@ import io.pravega.segmentstore.server.logs.operations.UpdateAttributesOperation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
+import lombok.Data;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -59,13 +66,14 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
     // region Members
 
     private static final MetadataCheckpointSerializer METADATA_CHECKPOINT_SERIALIZER = new MetadataCheckpointSerializer();
+    private static final MetadataCheckpointIncrementalDeserializer METADATA_CHECKPOINT_INCREMENTAL_DESERIALIZER = new MetadataCheckpointIncrementalDeserializer();
     private static final StorageCheckpointSerializer STORAGE_CHECKPOINT_SERIALIZER = new StorageCheckpointSerializer();
     /**
      * Pointer to the real (live) ContainerMetadata. Used when needing access to live information (such as Storage Info).
      */
     private final ContainerMetadata realMetadata;
     private final HashMap<Long, SegmentMetadataUpdateTransaction> segmentUpdates;
-    private final HashMap<Long, UpdateableSegmentMetadata> newSegments;
+    private final HashMap<Long, StreamSegmentMetadata> newSegments;
     private final HashMap<String, Long> newSegmentNames;
     private final List<Long> newTruncationPoints;
     @Getter
@@ -267,6 +275,23 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         resetNewSequenceNumber();
     }
 
+    private boolean isNewSegment(long segmentId) {
+        return this.newSegments.containsKey(segmentId);
+    }
+
+    private void removeNewSegment(long segmentId) {
+        assert isRecoveryMode();
+        val sm = this.newSegments.remove(segmentId);
+        if (sm != null) {
+            sm.markInactive();
+            this.newSegmentNames.remove(sm.getName());
+            val ut = this.segmentUpdates.remove(segmentId);
+            if (ut != null) {
+                ut.setActive(false);
+            }
+        }
+    }
+
     private void resetNewSequenceNumber() {
         if (this.baseMetadata.isRecoveryMode()) {
             this.newSequenceNumber = ContainerMetadata.INITIAL_OPERATION_SEQUENCE_NUMBER;
@@ -396,22 +421,25 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                 // metadata is serialized in this operation. We need to discard whatever we have accumulated so far
                 // and rebuild the metadata from the information we have so far.
                 if (this.processedCheckpoint) {
+                    // A MetadataCheckpoint should be processed fully only if is the first checkpoint encountered.
+                    // Any subsequent MetadataCheckpoints should be partially processed and applied
                     // But we can (should) only process at most one MetadataCheckpoint per recovery. Any additional
                     // ones are redundant (used just for Truncation purposes) and contain the same information as
                     // if we processed every operation in order, up to them.
-                    log.debug("MetadataUpdate[{}-{}}]: Skipping MetadataCheckpointOperation({}) because we already have metadata changes.",
-                            this.containerId, this.transactionId, operation.getSequenceNumber());
-                    return;
-                }
+                    log.info("MetadataUpdate[{}]: Recovering MetadataCheckpointOperation({}) and applying incrementally.",
+                            this.containerId, operation.getSequenceNumber());
+                    METADATA_CHECKPOINT_INCREMENTAL_DESERIALIZER.deserialize(operation.getContents(), this);
+                } else {
+                    log.info("MetadataUpdate[{}]: Recovering MetadataCheckpointOperation({}).",
+                            this.containerId, operation.getSequenceNumber());
+                    clear();
 
-                log.info("MetadataUpdate[{}-{}}]: Recovering MetadataCheckpointOperation({}).",
-                        this.containerId, this.transactionId, operation.getSequenceNumber());
-                clear();
+                    METADATA_CHECKPOINT_SERIALIZER.deserialize(operation.getContents(), this);
+                    this.processedCheckpoint = true;
+                }
 
                 // This is not retrieved from serialization, but rather from the operation itself.
                 setOperationSequenceNumber(operation.getSequenceNumber());
-                METADATA_CHECKPOINT_SERIALIZER.deserialize(operation.getContents(), this);
-                this.processedCheckpoint = true;
             } else {
                 // In non-Recovery Mode, a MetadataCheckpointOperation means we need to serialize the current state of
                 // the Metadata, both the base Container Metadata and the current Transaction.
@@ -567,13 +595,13 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
      * Creates a new UpdateableSegmentMetadata for the given Segment and registers it.
      */
     private UpdateableSegmentMetadata createSegmentMetadata(String segmentName, long segmentId) {
-        UpdateableSegmentMetadata metadata = new StreamSegmentMetadata(segmentName, segmentId, this.containerId);
+        StreamSegmentMetadata metadata = new StreamSegmentMetadata(segmentName, segmentId, this.containerId);
         this.newSegments.put(metadata.getId(), metadata);
         this.newSegmentNames.put(metadata.getName(), metadata.getId());
         return metadata;
     }
 
-    private void copySegmentMetadata(Collection<UpdateableSegmentMetadata> newSegments, UpdateableContainerMetadata target) {
+    private void copySegmentMetadata(Collection<StreamSegmentMetadata> newSegments, UpdateableContainerMetadata target) {
         for (SegmentMetadata newMetadata : newSegments) {
             // Update real metadata with all the information from the new metadata.
             UpdateableSegmentMetadata existingMetadata = target.mapStreamSegmentId(newMetadata.getName(), newMetadata.getId());
@@ -647,7 +675,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
             version(0).revision(0, this::write00, this::read00);
         }
 
-        private void write00(ContainerMetadataUpdateTransaction t, RevisionDataOutput output) throws IOException {
+        protected void write00(ContainerMetadataUpdateTransaction t, RevisionDataOutput output) throws IOException {
             // Intentionally skipping over the Sequence Number. There is no need for that here; it will be set on the
             // operation anyway when it gets serialized.
             output.writeCompactInt(t.containerId);
@@ -675,7 +703,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                 throw new SerializationException(String.format("Invalid ContainerId. Expected '%d', actual '%d'.", t.containerId, containerId));
             }
 
-            input.readCollection(s -> readSegmentMetadata00(s, t));
+            Collection<UpdateableSegmentMetadata> checkpointMetadata = input.readCollection(s -> readSegmentMetadata00(s, t));
+            postRead(checkpointMetadata, t);
         }
 
         private void writeSegmentMetadata00(RevisionDataOutput output, SegmentMetadata sm) throws IOException {
@@ -699,7 +728,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
             long segmentId = input.readLong();
             String name = input.readUTF();
 
-            UpdateableSegmentMetadata metadata = t.getOrCreateSegmentUpdateTransaction(name, segmentId);
+            UpdateableSegmentMetadata metadata = getSegmentMetadata(name, segmentId, t);
 
             metadata.setLength(input.readLong());
             metadata.setStorageLength(input.readLong());
@@ -735,6 +764,190 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
             val attributes = input.readMap(RevisionDataInput::readUUID, RevisionDataInput::readLong);
             metadata.updateAttributes(attributes);
             return metadata;
+        }
+
+        protected UpdateableSegmentMetadata getSegmentMetadata(String name, long segmentId, ContainerMetadataUpdateTransaction t) {
+            return t.getOrCreateSegmentUpdateTransaction(name, segmentId);
+        }
+
+        protected void postRead(Collection<UpdateableSegmentMetadata> checkpointMetadata, ContainerMetadataUpdateTransaction t) {
+            // This method intentionally left blank. Will be overridden in derived classes.
+        }
+    }
+
+    //endregion
+
+    //region MetadataCheckpointPartialDeserializer
+
+    private static class MetadataCheckpointIncrementalDeserializer extends MetadataCheckpointSerializer {
+        @Override
+        protected void write00(ContainerMetadataUpdateTransaction t, RevisionDataOutput output) {
+            throw new UnsupportedOperationException("MetadataCheckpointPartialDeserializer may not be used for serialization.");
+        }
+
+        @Override
+        protected UpdateableSegmentMetadata getSegmentMetadata(String name, long segmentId, ContainerMetadataUpdateTransaction t) {
+            return new PartialSegmentMetadata(name, segmentId);
+        }
+
+        @Override
+        protected void postRead(Collection<UpdateableSegmentMetadata> checkpointMetadata, ContainerMetadataUpdateTransaction t) {
+            Preconditions.checkState(t.isRecoveryMode(), "MetadataCheckpointPartialDeserializer can only be used in recovery mode.");
+
+            // Index checkpointed metadata by segment id.
+            val byId = checkpointMetadata.stream().collect(Collectors.toMap(SegmentMetadata::getId, m -> m));
+
+            // Update any segment that we encountered. This includes unregistering a missing segment (eviction) or updating
+            // its storage state as necessary.
+            for (val segmentId : t.getAllStreamSegmentIds()) {
+                val m = byId.getOrDefault(segmentId, null);
+                if (m == null) {
+                    val existingMetadata = t.getStreamSegmentMetadata(segmentId);
+                    if (t.isNewSegment(segmentId) && existingMetadata != null && canUnregister(existingMetadata)) {
+                        // This segment existed in our Update Transaction/Base Metadata, however this checkpoint no longer has it.
+                        // This means that the segment has been evicted at one point between the last checkpoint and this one,
+                        // so it should be safe to remove it from our list (if possible).
+                        log.debug("MetadataUpdate[{}]: Un-mapping Segment Id '%s' because it is no longer present in a MetadataCheckpoint.", t.containerId);
+                        t.removeNewSegment(segmentId);
+                    }
+                } else {
+                    // Update segment's state with latest info.
+                    val segmentUpdate = t.getOrCreateSegmentUpdateTransaction(m.getName(), m.getId());
+                    if (m.isSealedInStorage()) {
+                        segmentUpdate.markSealed();
+                    }
+
+                    if (m.isDeletedInStorage()) {
+                        segmentUpdate.markDeleted();
+                    }
+
+                    segmentUpdate.updateStorageState(m.getStorageLength(), m.isSealedInStorage(), m.isDeleted(), m.isDeletedInStorage());
+                }
+            }
+        }
+
+        private boolean canUnregister(SegmentMetadata existingMetadata) {
+            return existingMetadata.isDeleted()
+                    || existingMetadata.getStorageLength() >= existingMetadata.getLength();
+        }
+
+        @Data
+        private static class PartialSegmentMetadata implements UpdateableSegmentMetadata {
+            private final String name;
+            private final long id;
+            private long storageLength;
+            private long startOffset;
+            private long length;
+            private boolean sealed;
+            private boolean sealedInStorage;
+            private boolean deleted;
+            private boolean deletedInStorage;
+            private boolean merged;
+
+            @Override
+            public void markSealed() {
+                this.sealed = true;
+            }
+
+            @Override
+            public void markSealedInStorage() {
+                this.sealedInStorage = true;
+            }
+
+            @Override
+            public void markDeleted() {
+                this.deleted = true;
+            }
+
+            @Override
+            public void markDeletedInStorage() {
+                this.deletedInStorage = true;
+            }
+
+            @Override
+            public void markMerged() {
+                this.merged = true;
+            }
+
+            // region Unimplemented methods
+
+            @Override
+            public boolean isActive() {
+                return true;
+            }
+
+            @Override
+            public void updateAttributes(Map<UUID, Long> attributeValues) {
+                // Not relevant here.
+            }
+
+            @Override
+            public void setLastModified(ImmutableDate date) {
+                // Not relevant here.
+            }
+
+            @Override
+            public void copyFrom(SegmentMetadata other) {
+                throw new UnsupportedOperationException("copyFrom not supported on " + PartialSegmentMetadata.class.getSimpleName());
+            }
+
+            @Override
+            public void refreshType() {
+                // Not relevant here.
+            }
+
+            @Override
+            public int getContainerId() {
+                return -1;
+            }
+
+
+            @Override
+            public long getLastUsed() {
+                return 0;
+            }
+
+            @Override
+            public void setLastUsed(long value) {
+                // Not relevant here.
+            }
+
+            @Override
+            public SegmentProperties getSnapshot() {
+                return this;
+            }
+
+            @Override
+            public void markPinned() {
+                // Not relevant here.
+            }
+
+            @Override
+            public boolean isPinned() {
+                return false;
+            }
+
+            @Override
+            public ImmutableDate getLastModified() {
+                return null;
+            }
+
+            @Override
+            public Map<UUID, Long> getAttributes() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public Map<UUID, Long> getAttributes(BiPredicate<UUID, Long> filter) {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public SegmentType getType() {
+                return null;
+            }
+
+            //endregion
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -342,9 +342,12 @@ public class DurableLog extends AbstractService implements OperationLog {
         log.debug("{}: Read (MaxCount = {}, Timeout = {}).", this.traceObjectId, maxCount, timeout);
         CompletableFuture<Queue<Operation>> result = this.inMemoryOperationLog.take(maxCount, timeout, this.executor);
         result.thenAccept(r -> {
-            int size = r.size();
+            final int size = r.size();
             this.operationProcessor.getMetrics().operationLogRead(size);
-            log.debug("{}: ReadResult (Count = {}).", this.traceObjectId, size);
+            log.debug("{}: ReadResult (Count = {}, Remaining = {}).", this.traceObjectId, size, this.inMemoryOperationLog.size());
+            if (size > 0) {
+                this.memoryStateUpdater.notifyLogRead();
+            }
         });
         return result;
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -319,7 +319,7 @@ public class DurableLog extends AbstractService implements OperationLog {
         // Before we do any real truncation, we need to mini-snapshot the metadata with only those fields that are updated
         // asynchronously for us (i.e., not via normal Log Operations) such as the Storage State. That ensures that this
         // info will be readily available upon recovery without delay.
-        return add(new StorageMetadataCheckpointOperation(), OperationPriority.High, timer.getRemaining())
+        return add(new StorageMetadataCheckpointOperation(), OperationPriority.SystemCritical, timer.getRemaining())
                 .thenComposeAsync(v -> this.durableDataLog.truncate(truncationFrameAddress, timer.getRemaining()), this.executor)
                 .thenRunAsync(() -> this.metadata.removeTruncationMarkers(actualTruncationSequenceNumber), this.executor);
     }
@@ -329,9 +329,9 @@ public class DurableLog extends AbstractService implements OperationLog {
         log.debug("{}: Queuing MetadataCheckpointOperation.", this.traceObjectId);
         MetadataCheckpointOperation op = new MetadataCheckpointOperation();
         return this.operationProcessor
-                .process(op, OperationPriority.Normal)
+                .process(op, OperationPriority.SystemCritical)
                 .thenApply(v -> {
-                    log.info("{}: MetadataCheckpointOperation durably stored.", this.traceObjectId);
+                    log.info("{}: MetadataCheckpointOperation({}} stored.", this.traceObjectId, op.getSequenceNumber());
                     return op.getSequenceNumber();
                 });
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -331,7 +331,7 @@ public class DurableLog extends AbstractService implements OperationLog {
         return this.operationProcessor
                 .process(op, OperationPriority.SystemCritical)
                 .thenApply(v -> {
-                    log.info("{}: MetadataCheckpointOperation({}} stored.", this.traceObjectId, op.getSequenceNumber());
+                    log.info("{}: MetadataCheckpointOperation({}) stored.", this.traceObjectId, op.getSequenceNumber());
                     return op.getSequenceNumber();
                 });
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
@@ -121,6 +121,16 @@ class MemoryStateUpdater {
     }
 
     /**
+     * Performs a cleanup of the {@link ReadIndex} by releasing resources allocated for segments that are no longer active
+     * and trimming to cache to the minimum essential.
+     */
+    void cleanupReadIndex() {
+        Preconditions.checkState(this.recoveryMode.get(), "cleanupReadIndex can only be performed in recovery mode.");
+        this.readIndex.cleanup(null);
+        this.readIndex.trimCache();
+    }
+
+    /**
      * Processes the given operations and applies them to the ReadIndex and InMemory OperationLog.
      *
      * @param operations An Iterator iterating over the operations to process (in sequence).

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
@@ -24,12 +24,15 @@ import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
+import io.pravega.segmentstore.storage.ThrottlerSourceListenerCollection;
 import io.pravega.segmentstore.storage.cache.CacheFullException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.ThreadSafe;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -43,6 +46,7 @@ class MemoryStateUpdater {
     private final ReadIndex readIndex;
     private final AbstractDrainingQueue<Operation> inMemoryOperationLog;
     private final AtomicBoolean recoveryMode;
+    private final ThrottlerSourceListenerCollection readListeners;
 
     //endregion
 
@@ -58,11 +62,32 @@ class MemoryStateUpdater {
         this.inMemoryOperationLog = Preconditions.checkNotNull(inMemoryOperationLog, "inMemoryOperationLog");
         this.readIndex = Preconditions.checkNotNull(readIndex, "readIndex");
         this.recoveryMode = new AtomicBoolean();
+        this.readListeners = new ThrottlerSourceListenerCollection();
     }
 
     //endregion
 
     //region Operations
+
+    /**
+     * Registers a {@link ThrottleSourceListener} that will be notified on every Operation Log read.
+     *
+     * @param listener The {@link ThrottleSourceListener} to register.
+     */
+    void registerReadListener(@NonNull ThrottleSourceListener listener) {
+        this.readListeners.register(listener);
+    }
+
+    /**
+     * Notifies all registered {@link ThrottleSourceListener} that an Operation Log read has been truncated.
+     */
+    void notifyLogRead() {
+        this.readListeners.notifySourceChanged();
+    }
+
+    public int getInMemoryOperationLogSize() {
+        return this.inMemoryOperationLog.size();
+    }
 
     /**
      * Gets the {@link CacheUtilizationProvider} shared across all Segment Containers hosted in this process that can

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -108,10 +108,12 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
                 .cacheThrottler(this.cacheUtilizationProvider::getCacheUtilization, this.cacheUtilizationProvider.getCacheTargetUtilization(), this.cacheUtilizationProvider.getCacheMaxUtilization())
                 .batchingThrottler(durableDataLog::getQueueStatistics)
                 .durableDataLogThrottler(durableDataLog.getWriteSettings(), durableDataLog::getQueueStatistics)
+                .operationLogThrottler(this.stateUpdater::getInMemoryOperationLogSize)
                 .build();
         this.throttler = new Throttler(this.metadata.getContainerId(), throttlerCalculator, this::hasThrottleExemptOperations, executor, this.metrics);
         this.cacheUtilizationProvider.registerCleanupListener(this.throttler);
         durableDataLog.registerQueueStateChangeListener(this.throttler);
+        this.stateUpdater.registerReadListener(this.throttler);
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/RecoveryProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/RecoveryProcessor.java
@@ -17,6 +17,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.SegmentStoreMetrics;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
+import io.pravega.segmentstore.server.logs.operations.CheckpointOperationBase;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.OperationSerializer;
@@ -187,6 +188,11 @@ class RecoveryProcessor {
 
         // Update in-memory structures.
         this.stateUpdater.process(operation);
+
+        // Perform necessary read index cleanups if possible.
+        if (operation instanceof CheckpointOperationBase) {
+            this.stateUpdater.cleanupReadIndex();
+        }
     }
 
     private void recordTruncationMarker(DataFrameRecord<Operation> dataFrameRecord) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import java.util.function.BiPredicate;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * An update transaction that can apply changes to a SegmentMetadata.
@@ -79,6 +80,9 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
     @Getter
     private long lastUsed;
     private boolean isChanged;
+    @Getter
+    @Setter
+    private boolean active;
 
     //endregion
 
@@ -108,6 +112,7 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
         this.baseAttributeValues = baseMetadata.getAttributes();
         this.attributeUpdates = new HashMap<>();
         this.lastUsed = baseMetadata.getLastUsed();
+        this.active = true;
     }
 
     //endregion
@@ -126,11 +131,6 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
     @Override
     public long getStorageLength() {
         return this.storageLength < 0 ? this.baseStorageLength : this.storageLength;
-    }
-
-    @Override
-    public boolean isActive() {
-        return true;
     }
 
     @Override
@@ -685,6 +685,7 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
                 "Target Segment Id mismatch. Expected %s, given %s.", this.id, target.getId());
         Preconditions.checkArgument(target.getName().equals(this.name),
                 "Target Segment Name mismatch. Expected %s, given %s.", name, target.getName());
+        Preconditions.checkState(isActive(), "Cannot apply changes for an inactive segment. Segment Id = %s, Segment Name = '%s'.", this.id, this.name);
 
         // Apply to base metadata.
         target.setLastUsed(this.lastUsed);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
@@ -186,8 +186,7 @@ class Throttler implements ThrottleSourceListener, AutoCloseable {
     }
 
     private boolean isInterruptible(ThrottlerCalculator.ThrottlerName name) {
-        return name == ThrottlerCalculator.ThrottlerName.Cache
-                || name == ThrottlerCalculator.ThrottlerName.DurableDataLog;
+        return name != null && name.isInterruptible();
     }
 
     @VisibleForTesting

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -65,6 +65,16 @@ class ThrottlerCalculator {
      */
     @VisibleForTesting
     static final double DURABLE_DATALOG_THROTTLE_THRESHOLD_FRACTION = 0.1;
+    /**
+     * Maximum size (in number of operations) of the OperationLog, above which maximum throttling will be applied.
+     */
+    @VisibleForTesting
+    static final int OPERATION_LOG_MAX_SIZE = 1_000_000;
+    /**
+     * Desired size (in number of operations) of the OperationLog, above which a gradual throttling will begin.
+     */
+    @VisibleForTesting
+    static final int OPERATION_LOG_TARGET_SIZE = (int) (OPERATION_LOG_MAX_SIZE * 0.95);
     @Singular
     private final List<Throttler> throttlers;
 
@@ -287,6 +297,40 @@ class ThrottlerCalculator {
         }
     }
 
+    /**
+     * Calculates the amount of time to wait before processing more operations from the queue in order to relieve pressure
+     * from the OperationLog. This is based solely on the number of operations accumulated in the OperationLog.
+     */
+    @RequiredArgsConstructor
+    private static class OperationLogThrottler extends Throttler {
+        private static final double SIZE_SPAN = OPERATION_LOG_MAX_SIZE - OPERATION_LOG_TARGET_SIZE;
+        @NonNull
+        private final Supplier<Integer> getOperationLogSize;
+
+        @Override
+        boolean isThrottlingRequired() {
+            return this.getOperationLogSize.get() > OPERATION_LOG_TARGET_SIZE;
+        }
+
+        @Override
+        int getDelayMillis() {
+            // We only throttle if we exceed the target log size. We increase the throttling amount in a linear fashion.
+            int size = this.getOperationLogSize.get();
+            if (size <= OPERATION_LOG_TARGET_SIZE) {
+                return 0;
+            } else if (size >= OPERATION_LOG_MAX_SIZE) {
+                return MAX_DELAY_MILLIS;
+            } else {
+                return (int) (MAX_DELAY_MILLIS * (this.getOperationLogSize.get() - OPERATION_LOG_TARGET_SIZE) / SIZE_SPAN);
+            }
+        }
+
+        @Override
+        ThrottlerName getName() {
+            return ThrottlerName.OperationLog;
+        }
+    }
+
     //endregion
 
     //region Builder
@@ -321,6 +365,10 @@ class ThrottlerCalculator {
 
         ThrottlerCalculatorBuilder durableDataLogThrottler(WriteSettings writeSettings, Supplier<QueueStats> getQueueStats) {
             return throttler(new DurableDataLogThrottler(writeSettings, getQueueStats));
+        }
+
+        ThrottlerCalculatorBuilder operationLogThrottler(Supplier<Integer> getDurableLogSize) {
+            return throttler(new OperationLogThrottler(getDurableLogSize));
         }
     }
 
@@ -371,19 +419,28 @@ class ThrottlerCalculator {
     /**
      * Defines Throttler Names.
      */
+    @Getter
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     enum ThrottlerName {
         /**
          * Throttling is required in order to aggregate multiple operations together in a single write.
          */
-        Batching,
+        Batching(false),
         /**
          * Throttling is required due to excessive Cache utilization.
          */
-        Cache,
+        Cache(true),
         /**
          * Throttling is required due to excessive size of DurableDataLog's in-flight queue.
          */
-        DurableDataLog,
+        DurableDataLog(true),
+        /**
+         * Throttling is required due to excessive accumulated Operations in OperationLog (not yet truncated).
+         */
+        OperationLog(true);
+
+        @Getter
+        private final boolean interruptible;
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentMetadataComparer.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentMetadataComparer.java
@@ -33,11 +33,13 @@ public final class SegmentMetadataComparer {
         String idPrefix = message + " SegmentId " + expected.getId();
         Assert.assertEquals(idPrefix + " getId() mismatch.", expected.getId(), actual.getId());
         Assert.assertEquals(idPrefix + " isDeleted() mismatch.", expected.isDeleted(), actual.isDeleted());
+        Assert.assertEquals(idPrefix + " isDeletedInStorage() mismatch.", expected.isDeletedInStorage(), actual.isDeletedInStorage());
         Assert.assertEquals(idPrefix + " getStorageLength() mismatch.", expected.getStorageLength(), actual.getStorageLength());
         Assert.assertEquals(idPrefix + " getStartOffset() mismatch.", expected.getStartOffset(), actual.getStartOffset());
         Assert.assertEquals(idPrefix + " getLength() mismatch.", expected.getLength(), actual.getLength());
         Assert.assertEquals(idPrefix + " getName() mismatch.", expected.getName(), actual.getName());
         Assert.assertEquals(idPrefix + " isSealed() mismatch.", expected.isSealed(), actual.isSealed());
+        Assert.assertEquals(idPrefix + " isSealedInStorage() mismatch.", expected.isSealedInStorage(), actual.isSealedInStorage());
         Assert.assertEquals(idPrefix + " isMerged() mismatch.", expected.isMerged(), actual.isMerged());
         assertSameAttributes(idPrefix + " getAttributes() mismatch:", expected.getAttributes(), actual);
         Assert.assertEquals(idPrefix + " isPinned() mismatch.", expected.isPinned(), actual.isPinned());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.logs;
 
+import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.Service;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
@@ -23,9 +24,12 @@ import io.pravega.segmentstore.server.CacheManager;
 import io.pravega.segmentstore.server.CachePolicy;
 import io.pravega.segmentstore.server.ContainerOfflineException;
 import io.pravega.segmentstore.server.DataCorruptionException;
+import io.pravega.segmentstore.server.EvictableMetadata;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.OperationLog;
 import io.pravega.segmentstore.server.ReadIndex;
+import io.pravega.segmentstore.server.SegmentMetadata;
+import io.pravega.segmentstore.server.SegmentMetadataComparer;
 import io.pravega.segmentstore.server.ServiceListeners;
 import io.pravega.segmentstore.server.TestDurableDataLog;
 import io.pravega.segmentstore.server.TestDurableDataLogFactory;
@@ -34,6 +38,8 @@ import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentContainerMetadata;
 import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.CheckpointOperationBase;
+import io.pravega.segmentstore.server.logs.operations.DeleteSegmentOperation;
+import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.OperationComparer;
@@ -1079,6 +1085,139 @@ public class DurableLogTests extends OperationLogTestBase {
         Assert.assertTrue("Not expecting any other operations.", ops3.isEmpty());
         dl2.stopAsync().awaitTerminated();
         dl3.close();
+    }
+
+    /**
+     * Tests the DurableLog recovery process when there are multiple {@link MetadataCheckpointOperation}s added, with each
+     * such checkpoint including information about evicted segments or segments which had their storage state modified.
+     */
+    @Test
+    public void testRecoveryWithIncrementalCheckpoints() throws Exception {
+        final int streamSegmentCount = 50;
+
+        // Setup a DurableLog and start it.
+        @Cleanup
+        TestDurableDataLogFactory dataLogFactory = new TestDurableDataLogFactory(new InMemoryDurableDataLogFactory(MAX_DATA_LOG_APPEND_SIZE, executorService()));
+        @Cleanup
+        Storage storage = InMemoryStorageFactory.newStorage(executorService());
+        storage.initialize(1);
+
+        // First DurableLog. We use this for generating data.
+        val metadata1 = new MetadataBuilder(CONTAINER_ID).build();
+        @Cleanup
+        CacheStorage cacheStorage = new DirectMemoryCache(Integer.MAX_VALUE);
+        @Cleanup
+        CacheManager cacheManager = new CacheManager(CachePolicy.INFINITE, cacheStorage, executorService());
+        List<Long> deletedIds;
+        Set<Long> evictIds;
+        try (
+                ReadIndex readIndex = new ContainerReadIndex(DEFAULT_READ_INDEX_CONFIG, metadata1, storage, cacheManager, executorService());
+                DurableLog durableLog = new DurableLog(ContainerSetup.defaultDurableLogConfig(), metadata1, dataLogFactory, readIndex, executorService())) {
+            durableLog.startAsync().awaitRunning();
+
+            // Create some segments.
+            val segmentIds = new ArrayList<>(createStreamSegmentsWithOperations(streamSegmentCount, durableLog));
+            deletedIds = segmentIds.subList(0, 5);
+            val mergedFromIds = segmentIds.subList(5, 10);
+            val mergedToIds = segmentIds.subList(10, 15); // Must be same length as mergeFrom
+            evictIds = new HashSet<>(segmentIds.subList(15, 20));
+            val changeStorageStateIds = segmentIds.subList(20, segmentIds.size() - 5);
+
+            // Append something to each segment.
+            for (val segmentId : segmentIds) {
+                if (!evictIds.contains(segmentId)) {
+                    durableLog.add(new StreamSegmentAppendOperation(segmentId, generateAppendData((int) (long) segmentId), null), OperationPriority.Normal, TIMEOUT).join();
+                }
+            }
+
+            // Checkpoint 1.
+            durableLog.checkpoint(TIMEOUT).join();
+
+            // Delete some segments.
+            for (val segmentId : deletedIds) {
+                durableLog.add(new DeleteSegmentOperation(segmentId), OperationPriority.Normal, TIMEOUT).join();
+            }
+
+            // Checkpoint 2.
+            durableLog.checkpoint(TIMEOUT).join();
+
+            // Merge some segments.
+            for (int i = 0; i < mergedFromIds.size(); i++) {
+                durableLog.add(new StreamSegmentSealOperation(mergedFromIds.get(i)), OperationPriority.Normal, TIMEOUT).join();
+                durableLog.add(new MergeSegmentOperation(mergedToIds.get(i), mergedFromIds.get(i)), OperationPriority.Normal, TIMEOUT).join();
+            }
+
+            // Checkpoint 3.
+            durableLog.checkpoint(TIMEOUT).join();
+
+            // Evict some segments.
+            val evictableContainerMetadata = (EvictableMetadata) metadata1;
+            metadata1.removeTruncationMarkers(metadata1.getOperationSequenceNumber());
+            val toEvict = evictableContainerMetadata.getEvictionCandidates(Integer.MAX_VALUE, segmentIds.size())
+                    .stream().filter(m -> evictIds.contains(m.getId())).collect(Collectors.toList());
+            val evicted = evictableContainerMetadata.cleanup(toEvict, Integer.MAX_VALUE);
+            AssertExtensions.assertContainsSameElements("", evictIds, evicted.stream().map(SegmentMetadata::getId).collect(Collectors.toList()));
+
+            // Checkpoint 4.
+            durableLog.checkpoint(TIMEOUT).join();
+
+            // Update storage state for some segments.
+            for (val segmentId : changeStorageStateIds) {
+                val sm = metadata1.getStreamSegmentMetadata(segmentId);
+                if (segmentId % 3 == 0) {
+                    sm.setStorageLength(sm.getLength());
+                }
+                if (segmentId % 4 == 0) {
+                    sm.markSealed();
+                    sm.markSealedInStorage();
+                }
+                if (segmentId % 5 == 0) {
+                    sm.markDeleted();
+                    sm.markDeletedInStorage();
+                }
+            }
+
+            // Checkpoint 5.
+            durableLog.checkpoint(TIMEOUT).join();
+
+            // Stop the processor.
+            durableLog.stopAsync().awaitTerminated();
+        }
+
+        // Second DurableLog. We use this for recovery.
+        val metadata2 = new MetadataBuilder(CONTAINER_ID).build();
+        try (
+                ContainerReadIndex readIndex = new ContainerReadIndex(DEFAULT_READ_INDEX_CONFIG, metadata2, storage, cacheManager, executorService());
+                DurableLog durableLog = new DurableLog(ContainerSetup.defaultDurableLogConfig(), metadata2, dataLogFactory, readIndex, executorService())) {
+            durableLog.startAsync().awaitRunning();
+
+            // Validate metadata matches.
+            val expectedSegmentIds = metadata1.getAllStreamSegmentIds();
+            val actualSegmentIds = metadata2.getAllStreamSegmentIds();
+            AssertExtensions.assertContainsSameElements("Unexpected set of recovered segments. Only Active segments expected to have been recovered.",
+                    expectedSegmentIds, actualSegmentIds);
+
+            val expectedSegments = expectedSegmentIds.stream().sorted()
+                    .map(metadata1::getStreamSegmentMetadata)
+                    .collect(Collectors.toList());
+            val actualSegments = actualSegmentIds.stream().sorted()
+                    .map(metadata2::getStreamSegmentMetadata)
+                    .collect(Collectors.toList());
+            for (int i = 0; i < expectedSegments.size(); i++) {
+                val e = expectedSegments.get(i);
+                val a = actualSegments.get(i);
+                SegmentMetadataComparer.assertEquals("Recovered segment metadata mismatch", e, a);
+            }
+
+            // Validate read index is as it should. Here, we can only check if the read indices for evicted segments are
+            // no longer loaded; we do more thorough checks in the ContainerReadIndexTests suite.
+            Streams.concat(evictIds.stream(), deletedIds.stream())
+                    .forEach(segmentId ->
+                            Assert.assertNull("Not expecting a read index for an evicted or deleted segment.", readIndex.getIndex(segmentId)));
+
+            // Stop the processor.
+            durableLog.stopAsync().awaitTerminated();
+        }
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
@@ -9,13 +9,8 @@
  */
 package io.pravega.segmentstore.server.logs;
 
-import io.pravega.common.Exceptions;
-import io.pravega.common.util.BufferView;
 import io.pravega.common.util.ByteArraySegment;
-import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
-import io.pravega.segmentstore.server.CacheUtilizationProvider;
-import io.pravega.segmentstore.server.ContainerMetadata;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.ReadIndex;
@@ -30,22 +25,23 @@ import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
 import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
-import java.time.Duration;
-import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.mockito.invocation.InvocationOnMock;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -66,59 +62,65 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
 
         // Add to MTL + Add to ReadIndex (append; beginMerge).
         InMemoryLog opLog = new InMemoryLog();
-        ArrayList<TestReadIndex.MethodInvocation> methodInvocations = new ArrayList<>();
-        TestReadIndex readIndex = new TestReadIndex(methodInvocations::add);
+        val readIndex = mock(ReadIndex.class);
+
+        val triggerSegmentIds = new ArrayList<Long>();
+        doAnswer(x -> {
+            triggerSegmentIds.clear();
+            triggerSegmentIds.addAll(x.getArgument(0));
+            return null;
+        }).when(readIndex).triggerFutureReads(anyCollection());
+
+        val invocations = new ArrayList<InvocationOnMock>();
+        doAnswer(invocations::add).when(readIndex).append(anyLong(), anyLong(), any());
+        doAnswer(invocations::add).when(readIndex).beginMerge(anyLong(), anyLong(), anyLong());
+
         MemoryStateUpdater updater = new MemoryStateUpdater(opLog, readIndex);
         ArrayList<Operation> operations = populate(updater, segmentCount, operationCountPerType);
 
         // Verify they were properly processed.
-        int triggerFutureCount = (int) methodInvocations.stream().filter(mi -> mi.methodName.equals(TestReadIndex.TRIGGER_FUTURE_READS)).count();
-        int addCount = methodInvocations.size() - triggerFutureCount;
-        Assert.assertEquals("Unexpected number of items added to ReadIndex.",
-                operations.size() - segmentCount * operationCountPerType, addCount);
-        Assert.assertEquals("Unexpected number of calls to the ReadIndex triggerFutureReads method.", 1, triggerFutureCount);
-
-        // Verify add calls.
         Queue<Operation> logIterator = opLog.poll(operations.size());
         int currentIndex = -1;
-        int currentReadIndex = -1;
+        val invocationIterator = invocations.iterator();
         while (!logIterator.isEmpty()) {
             currentIndex++;
             Operation expected = operations.get(currentIndex);
             Operation actual = logIterator.poll();
             if (expected instanceof StorageOperation) {
-                currentReadIndex++;
-                TestReadIndex.MethodInvocation invokedMethod = methodInvocations.get(currentReadIndex);
+                val invokedMethod = invocationIterator.next();
                 if (expected instanceof StreamSegmentAppendOperation) {
                     Assert.assertTrue("StreamSegmentAppendOperation was not added as a CachedStreamSegmentAppendOperation to the Memory Log.", actual instanceof CachedStreamSegmentAppendOperation);
                     StreamSegmentAppendOperation appendOp = (StreamSegmentAppendOperation) expected;
-                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was not added to the ReadIndex.", TestReadIndex.APPEND, invokedMethod.methodName);
-                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", appendOp.getStreamSegmentId(), invokedMethod.args.get("streamSegmentId"));
-                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", appendOp.getStreamSegmentOffset(), invokedMethod.args.get("offset"));
-                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", appendOp.getData(), invokedMethod.args.get("data"));
+                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was not added to the ReadIndex.",
+                            "append", invokedMethod.getMethod().getName());
+                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            appendOp.getStreamSegmentId(), (long) invokedMethod.getArgument(0));
+                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            appendOp.getStreamSegmentOffset(), (long) invokedMethod.getArgument(1));
+                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            appendOp.getData(), invokedMethod.getArgument(2));
                 } else if (expected instanceof MergeSegmentOperation) {
                     MergeSegmentOperation mergeOp = (MergeSegmentOperation) expected;
-                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was not added to the ReadIndex.", TestReadIndex.BEGIN_MERGE, invokedMethod.methodName);
-                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", mergeOp.getStreamSegmentId(), invokedMethod.args.get("targetStreamSegmentId"));
-                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", mergeOp.getStreamSegmentOffset(), invokedMethod.args.get("offset"));
-                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", mergeOp.getSourceSegmentId(), invokedMethod.args.get("sourceStreamSegmentId"));
+                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was not added to the ReadIndex.",
+                            "beginMerge", invokedMethod.getMethod().getName());
+                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            mergeOp.getStreamSegmentId(), (long) invokedMethod.getArgument(0));
+                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            mergeOp.getStreamSegmentOffset(), (long) invokedMethod.getArgument(1));
+                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            mergeOp.getSourceSegmentId(), (long) invokedMethod.getArgument(2));
                 }
             }
         }
 
         // Verify triggerFutureReads args.
-        @SuppressWarnings("unchecked")
-        Collection<Long> triggerSegmentIds = (Collection<Long>) methodInvocations
-                .stream()
-                .filter(mi -> mi.methodName.equals(TestReadIndex.TRIGGER_FUTURE_READS))
-                .findFirst().get()
-                .args.get("streamSegmentIds");
         val expectedSegmentIds = operations.stream()
-                                           .filter(op -> op instanceof SegmentOperation)
-                                           .map(op -> ((SegmentOperation) op).getStreamSegmentId())
-                                           .collect(Collectors.toSet());
+                .filter(op -> op instanceof SegmentOperation)
+                .map(op -> ((SegmentOperation) op).getStreamSegmentId())
+                .collect(Collectors.toSet());
 
-        AssertExtensions.assertContainsSameElements("ReadIndex.triggerFutureReads() was called with the wrong set of StreamSegmentIds.", expectedSegmentIds, triggerSegmentIds);
+        AssertExtensions.assertContainsSameElements("ReadIndex.triggerFutureReads() was called with the wrong set of StreamSegmentIds.",
+                expectedSegmentIds, triggerSegmentIds);
 
         // Test DataCorruptionException.
         AssertExtensions.assertThrows(
@@ -131,15 +133,14 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
      * Tests the functionality of the {@link MemoryStateUpdater#process} method with critical errors.
      */
     @Test
-    public void testProcessWithErrors() throws Exception {
+    public void testProcessWithErrors() {
         final int corruptAtIndex = 10;
         final int segmentCount = 10;
         final int operationCountPerType = 5;
 
         // Add to MTL + Add to ReadIndex (append; beginMerge).
         val opLog = new OperationLogTestBase.CorruptedMemoryOperationLog(corruptAtIndex);
-        ArrayList<TestReadIndex.MethodInvocation> methodInvocations = new ArrayList<>();
-        TestReadIndex readIndex = new TestReadIndex(methodInvocations::add);
+        val readIndex = mock(ReadIndex.class);
         MemoryStateUpdater updater = new MemoryStateUpdater(opLog, readIndex);
 
         AssertExtensions.assertThrows(
@@ -148,8 +149,7 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
                 ex -> ex instanceof DataCorruptionException);
 
         // Verify they were properly processed.
-        int triggerFutureCount = (int) methodInvocations.stream().filter(mi -> mi.methodName.equals(TestReadIndex.TRIGGER_FUTURE_READS)).count();
-        Assert.assertEquals("Not expecting any trigger-future-read invocations.", 0, triggerFutureCount);
+        verify(readIndex, never()).triggerFutureReads(anyCollection());
 
         Queue<Operation> logIterator = opLog.poll(corruptAtIndex * 2);
         int addCount = 0;
@@ -171,22 +171,18 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
     public void testRecoveryMode() throws Exception {
         // Check it's properly delegated to Read index.
         InMemoryLog opLog = new InMemoryLog();
-        ArrayList<TestReadIndex.MethodInvocation> methodInvocations = new ArrayList<>();
-        TestReadIndex readIndex = new TestReadIndex(methodInvocations::add);
+        val readIndex = mock(ReadIndex.class);
         MemoryStateUpdater updater = new MemoryStateUpdater(opLog, readIndex);
 
         UpdateableContainerMetadata metadata1 = new MetadataBuilder(1).build();
         updater.enterRecoveryMode(metadata1);
+        updater.cleanupReadIndex();
         updater.exitRecoveryMode(true);
 
-        Assert.assertEquals("Unexpected number of method invocations.", 2, methodInvocations.size());
-        TestReadIndex.MethodInvocation enterRecovery = methodInvocations.get(0);
-        Assert.assertEquals("ReadIndex.enterRecoveryMode was not called when expected.", TestReadIndex.ENTER_RECOVERY_MODE, enterRecovery.methodName);
-        Assert.assertEquals("ReadIndex.enterRecoveryMode was called with the wrong arguments.", metadata1, enterRecovery.args.get("recoveryMetadataSource"));
-
-        TestReadIndex.MethodInvocation exitRecovery = methodInvocations.get(1);
-        Assert.assertEquals("ReadIndex.exitRecoveryMode was not called when expected.", TestReadIndex.EXIT_RECOVERY_MODE, exitRecovery.methodName);
-        Assert.assertEquals("ReadIndex.exitRecoveryMode was called with the wrong arguments.", true, exitRecovery.args.get("successfulRecovery"));
+        verify(readIndex).enterRecoveryMode(metadata1);
+        verify(readIndex).cleanup(null);
+        verify(readIndex).trimCache();
+        verify(readIndex).exitRecoveryMode(true);
     }
 
     /**
@@ -194,7 +190,7 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testReadListeners() {
-        val updater = new MemoryStateUpdater(new InMemoryLog(), new TestReadIndex(null));
+        val updater = new MemoryStateUpdater(new InMemoryLog(), mock(ReadIndex.class));
         val l1 = mock(ThrottleSourceListener.class);
         when(l1.isClosed()).thenReturn(false);
         updater.registerReadListener(l1);
@@ -235,123 +231,5 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
         }
 
         return operations;
-    }
-
-    private static class TestReadIndex implements ReadIndex {
-        static final String APPEND = "append";
-        static final String BEGIN_MERGE = "beginMerge";
-        static final String COMPLETE_MERGE = "completeMerge";
-        static final String READ = "read";
-        static final String READ_DIRECT = "readDirect";
-        static final String TRIGGER_FUTURE_READS = "triggerFutureReads";
-        static final String CLEANUP = "cleanup";
-        static final String ENTER_RECOVERY_MODE = "enterRecoveryMode";
-        static final String EXIT_RECOVERY_MODE = "exitRecoveryMode";
-
-        private final Consumer<MethodInvocation> methodInvokeCallback;
-        private boolean closed;
-
-        TestReadIndex(Consumer<MethodInvocation> methodInvokeCallback) {
-            this.methodInvokeCallback = methodInvokeCallback;
-        }
-
-        @Override
-        public void append(long segmentId, long offset, BufferView data) {
-            invoke(new MethodInvocation(APPEND)
-                    .withArg("streamSegmentId", segmentId)
-                    .withArg("offset", offset)
-                    .withArg("data", data));
-        }
-
-        @Override
-        public void beginMerge(long targetStreamSegmentId, long offset, long sourceStreamSegmentId) {
-            invoke(new MethodInvocation(BEGIN_MERGE)
-                    .withArg("targetStreamSegmentId", targetStreamSegmentId)
-                    .withArg("offset", offset)
-                    .withArg("sourceStreamSegmentId", sourceStreamSegmentId));
-        }
-
-        @Override
-        public void completeMerge(long targetStreamSegmentId, long sourceStreamSegmentId) {
-            invoke(new MethodInvocation(COMPLETE_MERGE)
-                    .withArg("targetStreamSegmentId", targetStreamSegmentId)
-                    .withArg("sourceStreamSegmentId", sourceStreamSegmentId));
-        }
-
-        @Override
-        public BufferView readDirect(long streamSegmentId, long offset, int length) {
-            invoke(new MethodInvocation(READ_DIRECT)
-                    .withArg("offset", offset)
-                    .withArg("length", length));
-            return null;
-        }
-
-        @Override
-        public ReadResult read(long streamSegmentId, long offset, int maxLength, Duration timeout) {
-            invoke(new MethodInvocation(READ)
-                    .withArg("offset", offset)
-                    .withArg("maxLength", maxLength));
-            return null;
-        }
-
-        @Override
-        public void triggerFutureReads(Collection<Long> streamSegmentIds) {
-            invoke(new MethodInvocation(TRIGGER_FUTURE_READS)
-                    .withArg("streamSegmentIds", streamSegmentIds));
-        }
-
-        @Override
-        public void clear() {
-            throw new IllegalStateException("Not Implemented");
-        }
-
-        @Override
-        public void cleanup(Collection<Long> segmentIds) {
-            invoke(new MethodInvocation(CLEANUP));
-        }
-
-        @Override
-        public void enterRecoveryMode(ContainerMetadata recoveryMetadataSource) {
-            invoke(new MethodInvocation(ENTER_RECOVERY_MODE)
-                    .withArg("recoveryMetadataSource", recoveryMetadataSource));
-        }
-
-        @Override
-        public void exitRecoveryMode(boolean successfulRecovery) {
-            invoke(new MethodInvocation(EXIT_RECOVERY_MODE)
-                    .withArg("successfulRecovery", successfulRecovery));
-        }
-
-        @Override
-        public void close() {
-            this.closed = true;
-        }
-
-        @Override
-        public CacheUtilizationProvider getCacheUtilizationProvider() {
-            throw new UnsupportedOperationException();
-        }
-
-        private void invoke(MethodInvocation methodInvocation) {
-            Exceptions.checkNotClosed(this.closed, this);
-            if (this.methodInvokeCallback != null) {
-                this.methodInvokeCallback.accept(methodInvocation);
-            }
-        }
-
-        static class MethodInvocation {
-            final String methodName;
-            final AbstractMap<String, Object> args;
-
-            MethodInvocation(String name) {
-                this.methodName = name;
-                this.args = new HashMap<>();
-            }
-
-            MethodInvocation withArg(String name, Object value) {
-                this.args.put(name, value);
-                return this;
-            }
-        }
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
@@ -218,7 +218,7 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
         return result;
     }
 
-    private ByteArraySegment generateAppendData(int appendId) {
+    protected ByteArraySegment generateAppendData(int appendId) {
         return new ByteArraySegment(String.format("Append_%d", appendId).getBytes());
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -1472,6 +1472,75 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
     }
 
     /**
+     * Tests the {@link ContainerReadIndex#trimCache()} method.
+     */
+    @Test
+    public void testTrimCache() throws Exception {
+        // Create a CachePolicy with a set number of generations and a known max size.
+        // Each generation contains exactly one entry, so the number of generations is also the number of entries.
+        // We append one byte at each time. This allows us to test edge cases as well by having the finest precision when
+        // it comes to selecting which bytes we want evicted and which kept.
+        final int appendCount = 100;
+        final int segmentId = 123;
+        final byte[] appendData = new byte[2];
+
+        val removedEntryCount = new AtomicInteger();
+        @Cleanup
+        TestContext context = new TestContext();
+        context.metadata.enterRecoveryMode();
+        context.readIndex.enterRecoveryMode(context.metadata);
+
+        // To ease our testing, we disable appends and instruct the TestCache to report the same value for UsedBytes as it
+        // has for StoredBytes. This shields us from having to know internal details about the layout of the cache.
+        context.cacheStorage.usedBytesSameAsStoredBytes = true;
+        context.cacheStorage.disableAppends = true;
+        context.cacheStorage.deleteCallback = e -> removedEntryCount.incrementAndGet();
+
+        createSegment(segmentId, context);
+        val metadata = context.metadata.getStreamSegmentMetadata(segmentId);
+        metadata.setLength(appendCount * appendData.length);
+        for (int i = 0; i < appendCount; i++) {
+            long offset = i * appendData.length;
+            context.readIndex.append(segmentId, offset, new ByteArraySegment(appendData));
+        }
+
+        // Gradually increase the StorageLength of the segment and invoke trimCache twice at every step. We want to verify
+        // that it also does not evict more than it should if it has nothing to do.
+        int deltaIncrease = 0;
+        while (metadata.getStorageLength() < metadata.getLength()) {
+            val trim1 = context.readIndex.trimCache();
+            Assert.assertEquals("Not expecting any bytes trimmed.", 0, trim1);
+
+            // Every time we trim, increase the StorageLength by a bigger amount - but make sure we don't exceed the length of the segment.
+            deltaIncrease = (int) Math.min(metadata.getLength() - metadata.getStorageLength(), deltaIncrease + appendData.length);
+            metadata.setStorageLength(Math.min(metadata.getLength(), metadata.getStorageLength() + deltaIncrease));
+            removedEntryCount.set(0);
+            val trim2 = context.readIndex.trimCache();
+            Assert.assertEquals("Unexpected number of bytes trimmed.", deltaIncrease, trim2);
+            Assert.assertEquals("Unexpected number of cache entries evicted.", deltaIncrease / appendData.length, removedEntryCount.get());
+        }
+
+        // Take the index out of recovery mode.
+        context.metadata.exitRecoveryMode();
+        context.readIndex.exitRecoveryMode(true);
+
+        // Verify that the entries have actually been evicted.
+        for (int i = 0; i < appendCount; i++) {
+            long offset = i * appendData.length;
+            @Cleanup
+            val readResult = context.readIndex.read(segmentId, offset, appendData.length, TIMEOUT);
+            val first = readResult.next();
+            Assert.assertEquals("", ReadResultEntryType.Storage, first.getType());
+        }
+
+        // Verify trimCache() doesn't work when we are not in recovery mode.
+        AssertExtensions.assertThrows(
+                "trimCache worked in non-recovery mode.",
+                context.readIndex::trimCache,
+                ex -> ex instanceof IllegalStateException);
+    }
+
+    /**
      * Tests the {@link ContainerReadIndex#cleanup} method as well as its handling of inactive segments.
      */
     @Test

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
@@ -29,14 +29,13 @@ import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
 import io.pravega.segmentstore.storage.ThrottleSourceListener;
+import io.pravega.segmentstore.storage.ThrottlerSourceListenerCollection;
 import io.pravega.segmentstore.storage.WriteFailureException;
 import io.pravega.segmentstore.storage.WriteSettings;
 import io.pravega.segmentstore.storage.WriteTooLongException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
@@ -106,8 +105,7 @@ class BookKeeperLog implements DurableDataLog {
     private final SequentialAsyncProcessor rolloverProcessor;
     private final BookKeeperMetrics.BookKeeperLog metrics;
     private final ScheduledFuture<?> metricReporter;
-    @GuardedBy("queueStateChangeListeners")
-    private final HashSet<ThrottleSourceListener> queueStateChangeListeners;
+    private final ThrottlerSourceListenerCollection queueStateChangeListeners;
     //endregion
 
     //region Constructor
@@ -137,7 +135,7 @@ class BookKeeperLog implements DurableDataLog {
         this.rolloverProcessor = new SequentialAsyncProcessor(this::rollover, retry, this::handleRolloverFailure, this.executorService);
         this.metrics = new BookKeeperMetrics.BookKeeperLog(containerId);
         this.metricReporter = this.executorService.scheduleWithFixedDelay(this::reportMetrics, REPORT_INTERVAL, REPORT_INTERVAL, TimeUnit.MILLISECONDS);
-        this.queueStateChangeListeners = new HashSet<>();
+        this.queueStateChangeListeners = new ThrottlerSourceListenerCollection();
     }
 
     private Retry.RetryAndThrowBase<? extends Exception> createRetryPolicy(int maxWriteAttempts, int writeTimeout) {
@@ -360,14 +358,7 @@ class BookKeeperLog implements DurableDataLog {
 
     @Override
     public void registerQueueStateChangeListener(ThrottleSourceListener listener) {
-        if (listener.isClosed()) {
-            log.warn("{} Attempted to register a closed ThrottleSourceListener ({}).", this.traceObjectId, listener);
-            return;
-        }
-
-        synchronized (this.queueStateChangeListeners) {
-            this.queueStateChangeListeners.add(listener); // This is a Set, so we won't be adding the same listener twice.
-        }
+        this.queueStateChangeListeners.register(listener);
     }
 
     //endregion
@@ -411,7 +402,7 @@ class BookKeeperLog implements DurableDataLog {
             return false;
         } else {
             if (cleanupResult.getRemovedCount() > 0) {
-                notifyQueueChangeListeners();
+                this.queueStateChangeListeners.notifySourceChanged();
             }
 
             if (cleanupResult.getStatus() == WriteQueue.CleanupStatus.QueueEmpty) {
@@ -737,34 +728,6 @@ class BookKeeperLog implements DurableDataLog {
 
         log.info("{}: Truncated up to {}.", this.traceObjectId, upToAddress);
         LoggerHelpers.traceLeave(log, this.traceObjectId, "tryTruncate", traceId, upToAddress);
-    }
-
-    private void notifyQueueChangeListeners() {
-        ArrayList<ThrottleSourceListener> toNotify = new ArrayList<>();
-        ArrayList<ThrottleSourceListener> toRemove = new ArrayList<>();
-        synchronized (this.queueStateChangeListeners) {
-            for (ThrottleSourceListener l : this.queueStateChangeListeners) {
-                if (l.isClosed()) {
-                    toRemove.add(l);
-                } else {
-                    toNotify.add(l);
-                }
-            }
-
-            this.queueStateChangeListeners.removeAll(toRemove);
-        }
-
-        for (ThrottleSourceListener l : toNotify) {
-            try {
-                l.notifyThrottleSourceChanged();
-            } catch (Throwable ex) {
-                if (Exceptions.mustRethrow(ex)) {
-                    throw ex;
-                }
-
-                log.error("{}: Error while notifying queue listener {}.", this.traceObjectId, l, ex);
-            }
-        }
     }
 
     //endregion

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/ThrottlerSourceListenerCollection.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/ThrottlerSourceListenerCollection.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.pravega.common.Exceptions;
+import java.util.ArrayList;
+import java.util.HashSet;
+import javax.annotation.concurrent.GuardedBy;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A collection of {@link ThrottleSourceListener} objects.
+ */
+@Slf4j
+public class ThrottlerSourceListenerCollection {
+    @GuardedBy("listeners")
+    private final HashSet<ThrottleSourceListener> listeners = new HashSet<>();
+
+    @VisibleForTesting
+    int getListenerCount() {
+        synchronized (this.listeners) {
+            return this.listeners.size();
+        }
+    }
+
+    /**
+     * Registers a new {@link ThrottleSourceListener}.
+     *
+     * @param listener The listener to register. This listener will be automatically unregistered when {@link #notifySourceChanged()}
+     *                 is invoked and {@link ThrottleSourceListener#isClosed()} is true for it.
+     */
+    public void register(@NonNull ThrottleSourceListener listener) {
+        if (listener.isClosed()) {
+            log.warn("Attempted to register a closed ThrottleSourceListener ({}).", listener);
+            return;
+        }
+
+        synchronized (this.listeners) {
+            this.listeners.add(listener); // This is a Set, so we won't be adding the same listener twice.
+        }
+    }
+
+    /**
+     * Notifies all registered {@link ThrottleSourceListener} instances that something has changed.
+     */
+    public void notifySourceChanged() {
+        ArrayList<ThrottleSourceListener> toNotify = new ArrayList<>();
+        ArrayList<ThrottleSourceListener> toRemove = new ArrayList<>();
+        synchronized (this.listeners) {
+            for (ThrottleSourceListener l : this.listeners) {
+                if (l.isClosed()) {
+                    toRemove.add(l);
+                } else {
+                    toNotify.add(l);
+                }
+            }
+
+            this.listeners.removeAll(toRemove);
+        }
+
+        for (ThrottleSourceListener l : toNotify) {
+            try {
+                l.notifyThrottleSourceChanged();
+            } catch (Throwable ex) {
+                if (Exceptions.mustRethrow(ex)) {
+                    throw ex;
+                }
+
+                log.error("Error while notifying listener {}.", l, ex);
+            }
+        }
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/ThrottlerSourceListenerCollectionTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/ThrottlerSourceListenerCollectionTests.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage;
+
+import io.pravega.test.common.IntentionalException;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link ThrottlerSourceListenerCollection} class.
+ */
+public class ThrottlerSourceListenerCollectionTests {
+    /**
+     * Tests {@link ThrottlerSourceListenerCollection#register} and {@link ThrottlerSourceListenerCollection#notifySourceChanged()}.
+     */
+    @Test
+    public void testRegisterNotify() {
+        val c = new ThrottlerSourceListenerCollection();
+        val l1 = new TestListener();
+        val l2 = new TestListener();
+        val l3 = new TestListener();
+        l3.closed = true;
+        c.register(l1);
+        c.register(l2);
+        c.register(l3);
+        Assert.assertEquals("Not expecting closed listener to be added.", 2, c.getListenerCount());
+
+        l2.setClosed(true);
+        c.notifySourceChanged();
+        Assert.assertEquals("Expected listener to be invoked.", 1, l1.getCallCount());
+        Assert.assertEquals("Not expected closed listener to be invoked.", 0, l2.getCallCount());
+        c.register(l2); // This should have no effect.
+        Assert.assertEquals("Expected closed listener to be removed.", 1, c.getListenerCount());
+
+        // Now verify with errors.
+        c.register(new ThrottleSourceListener() {
+            @Override
+            public void notifyThrottleSourceChanged() {
+                throw new IntentionalException();
+            }
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+        });
+
+        c.notifySourceChanged(); // This should not throw.
+        Assert.assertEquals("Expected cleanup listener to be invoked the second time.", 2, l1.getCallCount());
+        Assert.assertEquals("Not expected removed listeners to be invoked.", 0, l2.getCallCount() + l3.getCallCount());
+    }
+
+    private static class TestListener implements ThrottleSourceListener {
+        @Getter
+        private int callCount = 0;
+        @Setter
+        @Getter
+        private boolean closed;
+
+        @Override
+        public void notifyThrottleSourceChanged() {
+            this.callCount++;
+        }
+    }
+}


### PR DESCRIPTION
**Change log description**  
- Added a new throttler (`OperationLog`) that limits the maximum number of outstanding operations in the Tier 1 Operation Log to 1 million. The throttler will kick in gradually at 95% of that value and apply full backpressure when it hits 1 million. This is to prevent lengthy recoveries.
- Cleaning up inactive or deleted Segments during recovery - we may end up accumulating much more than we need since we may be loading up multiple checkpoints. This helps situations when we could exceed the max allowed segment count even though a previous instance of that container was never close to that limit.
- Cleaning up the Read Index cache during recovery after processing `MetadataCheckpointOperations` or `StorageCheckpointOperations`. Only essential data is preserved in the cache. This helps situations we could exceed the cache limit for a container/process even though a previous instance of that container was never close to that limit.

**Purpose of the change**  
Fixes #5789.

**What the code does**  
- Operation Log Size Throttler
    - Using existing throttler mechanism to define a new throttler type which feeds in from the `OperationLog::size` when it needs to run. 
 - Cleanup during recovery
     - Previously a `MetadataCheckpointOperation` would only be processed (deserialized) when it was the first operation in the log during recovery. All subsequent ones would be ignored since they were redundant.
     - However these checkpoints are not totally redundant. They provide information about which segments had been evicted since the last checkpoint and also snapshot the Storage (LTS) state of each segment at the time of the checkpoint.
     - Subsequent checkpoints are now incrementally applied. 
         - If an existing segment is no longer present in this checkpoint, then it is unregistered (disconsidered) from the recovery. That means it had previously been evicted and is thus of no further interest to us.
         - A segment's Storage state (length, sealed, deletion status) is now applied from the checkpoint.
         - No other information is applied.
     -  The `RecoveryProcessor` will trigger a `ReadIndex` cleanup after it processes any kind of checkpoint operation (Metadata or Storage). This cleanup involves completely unregistering indices that are pointing to inactive segments (previously evicted) and trimming the cache to only keep those entries that had not previously been fully flushed to Storage.

**How to verify it**  
All tests (old and new) must pass.
