### PR TITLE
Issue 5810: (SegmentStore) Fixed a StorageWriter bug that could lead to data loss

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/WriterStateTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/WriterStateTests.java
@@ -11,8 +11,12 @@ package io.pravega.segmentstore.server.writer;
 
 import io.pravega.segmentstore.server.ManualTimer;
 import io.pravega.segmentstore.server.WriterFlushResult;
+import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
+import io.pravega.segmentstore.server.logs.operations.Operation;
+import io.pravega.segmentstore.server.logs.operations.StorageMetadataCheckpointOperation;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestUtils;
+import java.util.LinkedList;
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
@@ -47,6 +51,28 @@ public class WriterStateTests {
 
         s.setLastReadSequenceNumber(123);
         Assert.assertEquals(123, s.getLastReadSequenceNumber());
+    }
+
+    /**
+     * Tests {@link WriterState#getLastRead()} and {@link WriterState#setLastRead}.
+     */
+    @Test
+    public void testLastRead() {
+        val s = new WriterState();
+        Assert.assertNull(s.getLastRead());
+
+        val q = new LinkedList<Operation>();
+        q.add(new MetadataCheckpointOperation());
+        q.add(new StorageMetadataCheckpointOperation());
+
+        s.setLastRead(q);
+        Assert.assertSame(q, s.getLastRead());
+
+        q.removeFirst();
+        Assert.assertEquals(1, s.getLastRead().size());
+
+        q.removeFirst();
+        Assert.assertNull(s.getLastRead());
     }
 
     /**


### PR DESCRIPTION

**Change log description**  
Fixed a bug in StorageWriter where it could lose already read Operations if an operation that had to be processed required the initialization of SegmentAggregator, but that initialization ended up throwing an error (i.e., from getting segment info from Storage).

**Purpose of the change**  
Fixes #5810.

**What the code does**  
See #5810 for context on this.

The fix for this was to store the last read sequence of operations inside the `WriterState` object (as a reference) and clean it up upon a successful completion of `processReadResult`. If any sort of exception occurred during `processReadResult`, the operation on which it failed would still remain the first one in that read queue (we now `peek` it vs `poll`-ing it), and it will be attempted next time. For example, if we read 10 operations, process 5, and the 6th one fails, then the next writer iteration will resume from 6.

To support this, a few more changes have been made:
- the `StorageWriter.readData` will check the `WriterState` for any previously read operations. If any are still outstanding, it will return those vs. attempting to read new ones.
- `processReadResult` peeks the operation, processes it, then removes it from the queue
- Any exception coming from `SegmentAggregator.add` is now interpreted as `DataCorruptionException`. Even if the exception itself does not imply a data corruption, chances are high that it will be thrown again upon a retry, so we might as well stop everything and force a recovery. 
    - Furthermore, the real reason this was changed was because an operation may have to be sent to multiple `WriterProcessor` instances (i.e., `SegmentAggregator`, `AttributeAggregator`, `WriterTableProcessor`). If it has already been sent to one of them but the next one failed (for whatever reason), resending it to the first one will cause another exception (due to the multitude of sanity checks we perform). So, for simplicity, we stop the writer and start fresh.

**How to verify it**  
New unit tests added to verify scenario.
