### PR TITLE
Issue 5812: Convenience APIs for working with SegmentRanges and StreamCuts

### DIFF
--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -16,6 +16,7 @@ import io.pravega.client.batch.StreamSegmentsIterator;
 import io.pravega.client.batch.impl.BatchClientFactoryImpl;
 import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
 import io.pravega.client.segment.impl.NoSuchSegmentException;
+import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
@@ -79,6 +80,22 @@ public interface BatchClientFactory extends AutoCloseable {
      * @return A SegmentIterator over the requested segment
      */
     <T> SegmentIterator<T> readSegment(SegmentRange segment, Serializer<T> deserializer);
+
+    /**
+     * Return first offset for a given {@link Segment}
+     *
+     * @param segment The {@link Segment}
+     * @return {@link StreamCut} pointing to the starting offset of the {@link Segment}.
+     */
+    StreamCut firstStreamCut(Segment segment);
+
+    /**
+     * Return last offset for a given {@link Segment}
+     *
+     * @param segment The {@link Segment}
+     * @return {@link StreamCut} pointing to the last offset of the {@link Segment}.
+     */
+    StreamCut lastStreamCut(Segment segment);
 
     /**
      * Closes the client factory. This will close any connections created through it.

--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -82,7 +82,7 @@ public interface BatchClientFactory extends AutoCloseable {
     <T> SegmentIterator<T> readSegment(SegmentRange segment, Serializer<T> deserializer);
 
     /**
-     * Return first offset for a given {@link Segment}
+     * Return first offset for a given {@link Segment}.
      *
      * @param segment The {@link Segment}
      * @return {@link StreamCut} pointing to the starting offset of the {@link Segment}.
@@ -90,7 +90,7 @@ public interface BatchClientFactory extends AutoCloseable {
     StreamCut firstStreamCut(Segment segment);
 
     /**
-     * Return last offset for a given {@link Segment}
+     * Return last offset for a given {@link Segment}.
      *
      * @param segment The {@link Segment}
      * @return {@link StreamCut} pointing to the last offset of the {@link Segment}.

--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -82,20 +82,12 @@ public interface BatchClientFactory extends AutoCloseable {
     <T> SegmentIterator<T> readSegment(SegmentRange segment, Serializer<T> deserializer);
 
     /**
-     * Return first offset for a given {@link Segment}.
+     * Return {@link SegmentRange} with lowest and highest offset for the given {@link Segment}.
      *
      * @param segment The {@link Segment}
-     * @return {@link StreamCut} pointing to the starting offset of the {@link Segment}.
+     * @return {@link SegmentRange} representing the entire {@link Segment}.
      */
-    StreamCut firstStreamCut(Segment segment);
-
-    /**
-     * Return last offset for a given {@link Segment}.
-     *
-     * @param segment The {@link Segment}
-     * @return {@link StreamCut} pointing to the last offset of the {@link Segment}.
-     */
-    StreamCut lastStreamCut(Segment segment);
+    SegmentRange currentSegmentRange(Segment segment);
 
     /**
      * Closes the client factory. This will close any connections created through it.

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamCutHelper.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamCutHelper.java
@@ -72,30 +72,6 @@ public class StreamCutHelper {
                          });
     }
 
-    /**
-     * Obtain the {@link StreamCut} pointing to the starting offset of the Segment.
-     * @param segment The Segment.
-     * @return {@link StreamCut} pointing to the starting offset of the Segment.
-     */
-    public StreamCut fetchFirstStreamCut(final Segment segment) {
-        final Stream stream = segment.getStream();
-        final DelegationTokenProvider tokenProvider = DelegationTokenProviderFactory.create(controller,
-                stream.getScope(), stream.getStreamName(), AccessOperation.READ);
-        return new StreamCutImpl(stream, segment, segmentToInfo(segment, tokenProvider).getStartingOffset());
-    }
-
-    /**
-     * Obtain the {@link StreamCut} pointing to the write offset of the Segment.
-     * @param segment The Segment.
-     * @return {@link StreamCut} pointing to the write offset of the Segment.
-     */
-    public StreamCut fetchLastStreamCut(final Segment segment) {
-        final Stream stream = segment.getStream();
-        final DelegationTokenProvider tokenProvider = DelegationTokenProviderFactory.create(controller,
-                stream.getScope(), stream.getStreamName(), AccessOperation.READ);
-        return new StreamCutImpl(stream, segment, segmentToInfo(segment, tokenProvider).getWriteOffset());
-    }
-
     private SegmentInfo segmentToInfo(Segment s, DelegationTokenProvider tokenProvider) {
         @Cleanup
         SegmentMetadataClient client = segmentMetadataClientFactory.createSegmentMetadataClient(s, tokenProvider);

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
@@ -77,6 +77,16 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
                 segment.asImpl().getStartOffset(), segment.asImpl().getEndOffset());
     }
 
+    @Override
+    public StreamCut firstStreamCut(Segment segment) {
+        return streamCutHelper.fetchFirstStreamCut(segment);
+    }
+
+    @Override
+    public StreamCut lastStreamCut(Segment segment) {
+        return streamCutHelper.fetchLastStreamCut(segment);
+    }
+
     private StreamSegmentsIterator listSegments(final Stream stream, final Optional<StreamCut> startStreamCut,
                                                 final Optional<StreamCut> endStreamCut) {
         val startCut = startStreamCut.filter(sc -> !sc.equals(StreamCut.UNBOUNDED));

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
@@ -78,13 +78,17 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
     }
 
     @Override
-    public StreamCut firstStreamCut(Segment segment) {
-        return streamCutHelper.fetchFirstStreamCut(segment);
-    }
+    public SegmentRange currentSegmentRange(final Segment segment) {
+        final DelegationTokenProvider tokenProvider = DelegationTokenProviderFactory
+                .create(controller, segment.getStream().getScope(), segment.getStream().getStreamName(), AccessOperation.READ);
 
-    @Override
-    public StreamCut lastStreamCut(Segment segment) {
-        return streamCutHelper.fetchLastStreamCut(segment);
+        SegmentInfo segmentInfo = segmentToInfo(segment, tokenProvider);
+
+        return SegmentRangeImpl.builder()
+                .segment(segment)
+                .startOffset(segmentInfo.getStartingOffset())
+                .endOffset(segmentInfo.getWriteOffset())
+                .build();
     }
 
     private StreamSegmentsIterator listSegments(final Stream stream, final Optional<StreamCut> startStreamCut,

--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
@@ -79,7 +79,7 @@ public class SegmentRangeImpl implements SegmentRange {
     }
 
     /**
-     * Obtain {@link SegmentRange} from start and end {@link StreamCut} for a given {@link Segment}
+     * Obtain {@link SegmentRange} from start and end {@link StreamCut} for a given {@link Segment}.
      * @param segment The {@link Segment}
      * @param start Beginning of the {@link SegmentRange}
      * @param end End of the {@link SegmentRange}

--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentRangeImpl.java
@@ -13,6 +13,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import io.pravega.client.batch.SegmentRange;
 import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.stream.StreamCut;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -23,6 +24,7 @@ import lombok.ToString;
 /**
  * Implementation of {@link SegmentRange}.
  */
+
 @Beta
 @Builder
 @ToString
@@ -74,5 +76,21 @@ public class SegmentRangeImpl implements SegmentRange {
             Preconditions.checkState(startOffset <= endOffset, "Start offset should be less than end offset.");
             return new SegmentRangeImpl(segment, startOffset, endOffset);
         }
+    }
+
+    /**
+     * Obtain {@link SegmentRange} from start and end {@link StreamCut} for a given {@link Segment}
+     * @param segment The {@link Segment}
+     * @param start Beginning of the {@link SegmentRange}
+     * @param end End of the {@link SegmentRange}
+     * @return {@link SegmentRange} covering start-end
+     */
+    public static SegmentRange fromStreamCuts(final Segment segment, final StreamCut start, final StreamCut end) {
+        Preconditions.checkState(!start.equals(StreamCut.UNBOUNDED), "Start StreamCut may not be UNBOUNDED");
+        Preconditions.checkState(!end.equals(StreamCut.UNBOUNDED), "End StreamCut may not be UNBOUNDED");
+        long startOffset = start.asImpl().getPositions().getOrDefault(segment, -1L);
+        long endOffset = end.asImpl().getPositions().getOrDefault(segment, -1L);
+        Preconditions.checkState(startOffset >= 0 && endOffset > startOffset, "Start offset should be less than end offset.");
+        return new SegmentRangeImpl(segment, startOffset, endOffset);
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/StreamCutImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/StreamCutImpl.java
@@ -63,9 +63,13 @@ public class StreamCutImpl extends StreamCutInternal {
         this.positions = ImmutableMap.copyOf(positions);
     }
 
+    public StreamCutImpl(Stream stream, Segment segment, long position) {
+        this(stream, Collections.singletonMap(segment, position));
+    }
+
     @Override
     public Map<Segment, Long> getPositions() {
-        return Collections.unmodifiableMap(positions);
+        return positions;
     }
 
     @Override

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -141,6 +141,27 @@ public class BatchClientImplTest {
         assertFalse(segmentIterator.hasNext());
     }
 
+    @Test(timeout = 5000)
+    public void testGetCurrentSegment() throws Exception {
+
+        PravegaNodeUri location = new PravegaNodeUri("localhost", 0);
+        @Cleanup
+        MockConnectionFactoryImpl connectionFactory = getMockConnectionFactory(location);
+        MockController mockController = new MockController(location.getEndpoint(), location.getPort(), connectionFactory, false);
+        Stream stream = createStream(SCOPE, STREAM, 1, mockController);
+        @Cleanup
+        BatchClientFactoryImpl client = new BatchClientFactoryImpl(mockController, ClientConfig.builder().build(), connectionFactory);
+
+        Iterator<SegmentRange> segmentIterator = client.getSegments(stream, null, null).getIterator();
+        assertTrue(segmentIterator.hasNext());
+
+        SegmentRange expectedSegmentRange = segmentIterator.next();
+        assertFalse(segmentIterator.hasNext());
+
+        SegmentRange currentSegmentRange = client.currentSegmentRange(expectedSegmentRange.asImpl().getSegment());
+        assertEquals(expectedSegmentRange, currentSegmentRange);
+    }
+
     private Stream createStream(String scope, String streamName, int numSegments, MockController mockController) {
         Stream stream = new StreamImpl(scope, streamName);
         mockController.createScope(scope);


### PR DESCRIPTION
Convenience APIs for working with SegmentRanges and StreamCuts

Signed-off-by: Andrew Robertson <andrew.robertson@dell.com>

**Change log description**  
Introduces following APIs:
- given Segment, start + end StreamCuts, return SegmentRange for the segment start->end offset
- fetch first stream cut for a given segment
- fetch last stream cut for a given segment

**Purpose of the change**  
Fixes #5812 

**What the code does**  
Implements said APIs

**How to verify it**  
(Optional: steps to verify that the changes are effective)
