### PR TITLE
Issue 5820: Missing line to wait for Future tasks to be completed

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -483,6 +483,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
                 opFutures.add(Futures.toVoid(tableStore.put(segmentName, Collections.singletonList(createTableEntry.apply(segmentName, i)), TIMEOUT)));
             }
         }
+        Futures.allOf(opFutures).join();
 
         // 3. Instead of waiting for the Writer to move data to Storage, we invoke the flushToStorage to verify that all
         // operations have been applied to Storage.


### PR DESCRIPTION
**Change log description**  
Single line fix to call join on the list of future tasks which was missing.

**Purpose of the change**  
Fixes #5820 

**What the code does**  
Waits for the future tasks to be completed before forcing flush and closing the container.

**How to verify it**  
Build shall pass.