### PR TITLE
Issue 5823: Cherrypick fix for 5393 to r0.9

### DIFF
--- a/client/src/main/java/io/pravega/client/connection/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/FlowHandler.java
@@ -79,7 +79,7 @@ public class FlowHandler extends FailingReplyProcessor implements AutoCloseable 
         Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkState(!disableFlow.get(), "Ensure flows are enabled.");
         final int flowID = flow.getFlowId();
-        log.info("Creating Flow {} for endpoint {}. ", flow.getFlowId(), location);
+        log.debug("Creating Flow {} for endpoint {}. ", flow.getFlowId(), location);
         if (flowIdReplyProcessorMap.put(flowID, rp) != null) {
             throw new IllegalArgumentException("Multiple flows cannot be created with the same Flow id " + flowID);
         }
@@ -95,7 +95,7 @@ public class FlowHandler extends FailingReplyProcessor implements AutoCloseable 
     public ClientConnection createConnectionWithFlowDisabled(final ReplyProcessor rp) {
         Exceptions.checkNotClosed(closed.get(), this);
         Preconditions.checkState(!disableFlow.getAndSet(true), "Flows are disabled, incorrect usage pattern.");
-        log.info("Creating a new connection with flow disabled for endpoint {}.", location);
+        log.debug("Creating a new connection with flow disabled for endpoint {}.", location);
         flowIdReplyProcessorMap.put(FLOW_DISABLED, rp);
         return new FlowClientConnection(location.toString(), channel, FLOW_DISABLED, this);
     }
@@ -106,7 +106,7 @@ public class FlowHandler extends FailingReplyProcessor implements AutoCloseable 
      */
     void closeFlow(FlowClientConnection clientConnection) {
         int flow = clientConnection.getFlowId();
-        log.info("Closing Flow {} for endpoint {}", flow, clientConnection.getConnectionName());
+        log.debug("Closing Flow {} for endpoint {}", flow, clientConnection.getConnectionName());
         flowIdReplyProcessorMap.remove(flow);
         if (flow == FLOW_DISABLED) {
             // close the channel immediately since this connection will not be reused by other flows.
@@ -171,7 +171,7 @@ public class FlowHandler extends FailingReplyProcessor implements AutoCloseable 
 
     @Override
     public void errorMessage(WireCommands.ErrorMessage errorMessage) {
-        log.info("Received an errorMessage containing an unhandled {} on segment {}",
+        log.warn("Received an errorMessage containing an unhandled {} on segment {}",
                 errorMessage.getErrorCode().getExceptionType().getSimpleName(),
                 errorMessage.getSegment());
         processingFailure(errorMessage.getThrowableException());
@@ -205,7 +205,7 @@ public class FlowHandler extends FailingReplyProcessor implements AutoCloseable 
             if (keepAliveFuture != null) {
                 keepAliveFuture.cancel(false);
             }
-            log.info("Connection closed observed with endpoint {}", location);
+            log.debug("Connection closed observed with endpoint {}", location);
             flowIdReplyProcessorMap.forEach((flowId, rp) -> {
                 try {
                     log.debug("Connection dropped for flow id {}", flowId);

--- a/client/src/main/java/io/pravega/client/connection/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/FlowHandler.java
@@ -171,7 +171,7 @@ public class FlowHandler extends FailingReplyProcessor implements AutoCloseable 
 
     @Override
     public void errorMessage(WireCommands.ErrorMessage errorMessage) {
-        log.warn("Received an errorMessage containing an unhandled {} on segment {}",
+        log.info("Received an errorMessage containing an unhandled {} on segment {}",
                 errorMessage.getErrorCode().getExceptionType().getSimpleName(),
                 errorMessage.getSegment());
         processingFailure(errorMessage.getThrowableException());

--- a/controller/src/conf/logback.xml
+++ b/controller/src/conf/logback.xml
@@ -17,19 +17,16 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>controller-server.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <file>logs/controller-server.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- daily rollover. Make sure the path matches the one in the file element or else
              the rollover logs are placed in the working directory. -->
-            <fileNamePattern>controller_server_%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>10MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <!-- keep 30 days' worth of history -->
+            <fileNamePattern>logs/%d{YYYY-MM-dd, aux}/controller_server_%d{yyyy-MM-dd_HH}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 30 files worth of history, but at most 10GB -->
+            <maxFileSize>10MB</maxFileSize>
             <maxHistory>30</maxHistory>
+            <totalSizeCap>10GB</totalSizeCap>
         </rollingPolicy>
-
         <encoder>
             <charset>UTF-8</charset>
             <pattern>%d %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -612,7 +612,7 @@ public class SegmentHelper implements AutoCloseable {
     }
 
     private void closeConnection(Reply reply, RawClient client) {
-        log.info("Closing connection as a result of receiving: {}", reply);
+        log.debug("Closing connection as a result of receiving: {}", reply);
         if (client != null) {
             try {
                 client.close();
@@ -671,10 +671,10 @@ public class SegmentHelper implements AutoCloseable {
         Set<Class<? extends Reply>> expectedReplies = EXPECTED_SUCCESS_REPLIES.get(requestType);
         Set<Class<? extends Reply>> expectedFailingReplies = EXPECTED_FAILING_REPLIES.get(requestType);
         if (expectedReplies != null && expectedReplies.contains(reply.getClass())) {
-            log.info(callerRequestId, "{} {} {} {}.", requestType.getSimpleName(), qualifiedStreamSegmentName,
+            log.debug(callerRequestId, "{} {} {} {}.", requestType.getSimpleName(), qualifiedStreamSegmentName,
                     reply.getClass().getSimpleName(), reply.getRequestId());
         } else if (expectedFailingReplies != null && expectedFailingReplies.contains(reply.getClass())) {
-            log.info(callerRequestId, "{} {} {} {}.", requestType.getSimpleName(), qualifiedStreamSegmentName,
+            log.debug(callerRequestId, "{} {} {} {}.", requestType.getSimpleName(), qualifiedStreamSegmentName,
                     reply.getClass().getSimpleName(), reply.getRequestId());
             if (reply instanceof WireCommands.NoSuchSegment) {
                 throw new WireCommandFailedException(type, WireCommandFailedException.Reason.SegmentDoesNotExist);

--- a/dist/conf/logback.xml
+++ b/dist/conf/logback.xml
@@ -18,16 +18,14 @@ You may obtain a copy of the License at
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${log.dir:-.}/${log.name:-pravega}.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!-- daily rollover. Make sure the path matches the one in the file element or else
              the rollover logs are placed in the working directory. -->
-            <fileNamePattern>${log.dir:-.}/${log.name:-pravega}_%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>10MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <!-- keep 30 days' worth of history -->
+            <fileNamePattern>${log.dir:-.}/%d{YYYY-MM-dd, aux}/${log.name:-pravega}_%d{yyyy-MM-dd_HH}.%i.log.gz</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 30 files worth of history, but at most 10GB -->
+            <maxFileSize>10MB</maxFileSize>
             <maxHistory>30</maxHistory>
+            <totalSizeCap>10GB</totalSizeCap>
         </rollingPolicy>
 
         <encoder>


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
Segment Helper and Flow Handler APIs get invoked multiple times during a single Controller operation, esp. during transaction processing.
Info Logs explaining the details of each operation cause too many logs to be written and sometimes cause Controller to run our of disk space.

**Purpose of the change**  
Fixes #5823

**What the code does**  
Changed the log level, from "INFO" to "DEBUG", for low-level operations in Segment Helper and Flow Handler, since these logs are only needed for debugging.
Changed `logback.xml` to include a new _SizeAndTimeBasedRollingPolicy_ for logs with a cap on the size of Controller logs. That way we can be sure that the disk space occupied by Controller logs never exceeds a certain limit.

**How to verify it**  
All tests should pass.
Size of logs on Controller pod should not exceed the value specified against totalSizeCap in logback.xml
