### PR TITLE
Issue 5803: Flakey StreamMetrics test.

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -211,29 +211,35 @@ public class StreamMetricsTest {
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_STREAM).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_SCOPE).count());
 
+        String failedScope = "failedScope";
+        String failedStream = "failedStream";
+        String failedRG = "failedRG";
+        String[] failedScopeTags = streamTags(failedScope, "");
+        String[] failedScopeStreamTags = streamTags(failedScope, failedStream);
+        String[] failedRGTags = streamTags(failedRG, failedRG);
         // Exercise the metrics for failed stream and scope creation/deletion.
-        StreamMetrics.getInstance().createScopeFailed("failedScope");
-        StreamMetrics.getInstance().createStreamFailed("failedScope", "failedStream");
-        StreamMetrics.getInstance().deleteScopeFailed("failedScope");
-        StreamMetrics.getInstance().deleteStreamFailed("failedScope", "failedStream");
-        StreamMetrics.getInstance().updateStreamFailed("failedScope", "failedStream");
-        StreamMetrics.getInstance().truncateStreamFailed("failedScope", "failedStream");
-        StreamMetrics.getInstance().sealStreamFailed("failedScope", "failedStream");
-        StreamMetrics.getInstance().createReaderGroupFailed("failedRG", "failedRG");
-        StreamMetrics.getInstance().deleteReaderGroupFailed("failedRG", "failedRG");
-        StreamMetrics.getInstance().updateReaderGroupFailed("failedRG", "failedRG");
-        StreamMetrics.getInstance().updateTruncationSCFailed("failedRG", "failedRG");
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_SCOPE_FAILED).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_STREAM_FAILED).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_STREAM_FAILED).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_SCOPE_FAILED).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_STREAM_FAILED).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.TRUNCATE_STREAM_FAILED).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.SEAL_STREAM_FAILED).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_READER_GROUP_FAILED).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_READER_GROUP_FAILED).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_READER_GROUP_FAILED).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_SUBSCRIBER_FAILED).count());
+        StreamMetrics.getInstance().createScopeFailed(failedScope);
+        StreamMetrics.getInstance().createStreamFailed(failedScope, failedStream);
+        StreamMetrics.getInstance().deleteScopeFailed(failedScope);
+        StreamMetrics.getInstance().deleteStreamFailed(failedScope, failedStream);
+        StreamMetrics.getInstance().updateStreamFailed(failedScope, failedStream);
+        StreamMetrics.getInstance().truncateStreamFailed(failedScope, failedStream);
+        StreamMetrics.getInstance().sealStreamFailed(failedScope, failedStream);
+        StreamMetrics.getInstance().createReaderGroupFailed(failedRG, failedRG);
+        StreamMetrics.getInstance().deleteReaderGroupFailed(failedRG, failedRG);
+        StreamMetrics.getInstance().updateReaderGroupFailed(failedRG, failedRG);
+        StreamMetrics.getInstance().updateTruncationSCFailed(failedRG, failedRG);
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_SCOPE_FAILED, failedScopeTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_STREAM_FAILED, failedScopeStreamTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_STREAM_FAILED, failedScopeTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_SCOPE_FAILED, failedScopeStreamTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_STREAM_FAILED, failedScopeStreamTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.TRUNCATE_STREAM_FAILED, failedScopeStreamTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.SEAL_STREAM_FAILED, failedScopeStreamTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_READER_GROUP_FAILED, failedRGTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_READER_GROUP_FAILED, failedRGTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_READER_GROUP_FAILED, failedRGTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_SUBSCRIBER_FAILED, failedRGTags).count());
     }
 
     @Test(timeout = 30000)

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamMetricsTest.java
@@ -58,6 +58,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.pravega.shared.MetricsTags.readerGroupTags;
 import static io.pravega.shared.MetricsTags.streamTags;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -216,11 +217,11 @@ public class StreamMetricsTest {
         String failedRG = "failedRG";
         String[] failedScopeTags = streamTags(failedScope, "");
         String[] failedScopeStreamTags = streamTags(failedScope, failedStream);
-        String[] failedRGTags = streamTags(failedRG, failedRG);
+        String[] failedRGTags = readerGroupTags(failedRG, failedRG);
         // Exercise the metrics for failed stream and scope creation/deletion.
         StreamMetrics.getInstance().createScopeFailed(failedScope);
-        StreamMetrics.getInstance().createStreamFailed(failedScope, failedStream);
         StreamMetrics.getInstance().deleteScopeFailed(failedScope);
+        StreamMetrics.getInstance().createStreamFailed(failedScope, failedStream);
         StreamMetrics.getInstance().deleteStreamFailed(failedScope, failedStream);
         StreamMetrics.getInstance().updateStreamFailed(failedScope, failedStream);
         StreamMetrics.getInstance().truncateStreamFailed(failedScope, failedStream);
@@ -230,16 +231,16 @@ public class StreamMetricsTest {
         StreamMetrics.getInstance().updateReaderGroupFailed(failedRG, failedRG);
         StreamMetrics.getInstance().updateTruncationSCFailed(failedRG, failedRG);
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_SCOPE_FAILED, failedScopeTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_SCOPE_FAILED, failedScopeTags).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_STREAM_FAILED, failedScopeStreamTags).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_STREAM_FAILED, failedScopeTags).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_SCOPE_FAILED, failedScopeStreamTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_STREAM_FAILED, failedScopeStreamTags).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_STREAM_FAILED, failedScopeStreamTags).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.TRUNCATE_STREAM_FAILED, failedScopeStreamTags).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.SEAL_STREAM_FAILED, failedScopeStreamTags).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.CREATE_READER_GROUP_FAILED, failedRGTags).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_READER_GROUP_FAILED, failedRGTags).count());
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_READER_GROUP_FAILED, failedRGTags).count());
-        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_SUBSCRIBER_FAILED, failedRGTags).count());
+        assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.UPDATE_SUBSCRIBER_FAILED, streamTags(failedRG, failedRG)).count());
     }
 
     @Test(timeout = 30000)


### PR DESCRIPTION
**Change log description**  
* Use the proper tag set when reading various meters.

**Purpose of the change**  
Fixes #5803.

**What the code does**  
* Minor clean-ups.
* Instead of relying on chance that we will return the expected metric, supply the *exact* tag set required to ensure the proper meter is returned.

Because we do not supply any tags, during this call `return Metrics.globalRegistry.find(metricsName).tags(tags).counter();` micrometer will fetch *all* meters (belonging to the appropriate type) with id `metricsName`. It has to make a choice which to return if there are several, so it simply chooses one at random:

```
    public Counter counter() {
        return findOne(Counter.class);
    }
   ...
    private <M extends Meter> M findOne(Class<M> clazz) {
        return meterStream()
                .filter(clazz::isInstance)
                .findAny()
                .map(clazz::cast)
                .orElse(null);
    }
```

The test failures of `StreamMetricsTest.testStreamsAndScopesBasicMetricsTests` were not because the value what not propagated to micrometer but because we were doing an assert on the wrong counter.

I observed this by adding some log statements before the failing assert:

```
 > 2021-03-11 20:27:21,836 780931 [Time-limited test] INFO  i.p.t.integration.StreamMetricsTest - Counters@@@: 2
 > 2021-03-11 20:27:21,847 780942 [Time-limited test] INFO  i.p.t.integration.StreamMetricsTest - counter: MeterId{name='pravega.controller.scope.create_failed', tags=[tag(host=fv-az182-967),tag(scope=_system),tag(stream=)]} 0.0
 > 2021-03-11 20:27:21,848 780943 [Time-limited test] INFO  i.p.t.integration.StreamMetricsTest - counter: MeterId{name='pravega.controller.scope.create_failed', tags=[tag(host=fv-az182-967),tag(scope=failedScope),tag(stream=)]} 1.0
 > 2021-03-11 20:27:21,849 780944 [Time-limited test] INFO  i.p.t.integration.StreamMetricsTest - actual counter: MeterId{name='pravega.controller.scope.create_failed', tags=[ta182-967),tag(scope=_system),tag(stream=)]} 0.0
```
**How to verify it**  

* Run the integration tests.