### PR TITLE
Issue 5628: Speed up WatermarkingTest

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/PravegaResource.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/PravegaResource.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.test.integration;
+
+import io.pravega.client.control.impl.Controller;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.contracts.tables.TableStore;
+import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.test.common.TestUtils;
+import io.pravega.test.common.TestingServerStarter;
+import io.pravega.test.integration.demo.ControllerWrapper;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.curator.test.TestingServer;
+import org.junit.rules.ExternalResource;
+
+import java.net.URI;
+
+/**
+ * This class contains the rules to start and stop in Pravega for integration tests.
+ * This resource can be configured for a test using @ClassRule and it will ensure standalone is started once
+ * for all the methods in a test and is shutdown once all the tests methods have completed execution.
+ *
+ * - Usage pattern to start it once for all @Test methods in a class
+ *  <pre>
+ *  &#64;ClassRule
+ *  public static final PravegaResource PRAVEGA = new PravegaResource();
+ *  </pre>
+ *  - Usage pattern to start it before every @Test method.
+ *  <pre>
+ *  &#64;Rule
+ *  public final PravegaResource pravega = new PravegaResource();
+ *  </pre>
+ *
+ */
+@Slf4j
+public class PravegaResource extends ExternalResource {
+    private final int controllerPort = TestUtils.getAvailableListenPort();
+    private final int servicePort = TestUtils.getAvailableListenPort();
+    private final String serviceHost = "localhost";
+    private final int containerCount = 4;
+
+    private final TestingServer zkTestServer;
+    private final ControllerWrapper controllerWrapper;
+    private final PravegaConnectionListener server;
+    private final ServiceBuilder serviceBuilder;
+
+    @SneakyThrows
+    public PravegaResource() {
+        // 1. Start ZK
+        zkTestServer = new TestingServerStarter().start();
+
+        serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
+        serviceBuilder.initialize();
+        StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
+        TableStore tableStore = serviceBuilder.createTableStoreService();
+
+        server = new PravegaConnectionListener(false, servicePort, store, tableStore, serviceBuilder.getLowPriorityExecutor());
+        server.startListening();
+
+        // 2. Start controller
+        // the default watermarking frequency on the controller is 10 seconds.
+        System.setProperty("controller.watermarking.frequency.seconds", "5");
+        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), false,
+                controllerPort, serviceHost, servicePort, containerCount);
+    }
+
+    protected void before() throws Exception {
+        controllerWrapper.awaitRunning();
+    }
+
+    @SneakyThrows
+    protected void after() {
+        if (controllerWrapper != null) {
+            controllerWrapper.close();
+        }
+        if (server != null) {
+            server.close();
+        }
+        if (serviceBuilder != null) {
+            serviceBuilder.close();
+        }
+        if (zkTestServer != null) {
+            zkTestServer.close();
+        }
+    }
+
+    public Controller getLocalController() throws InterruptedException {
+        return controllerWrapper.getController();
+    }
+
+    public URI getControllerURI() {
+        return URI.create("tcp://" + serviceHost + ":" + controllerPort);
+    }
+}
+
+

--- a/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
@@ -479,7 +479,6 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
             return writer.writeEvent(count.toString(), currentTime.get())
                     .thenAccept(v -> {
                         if (count.incrementAndGet() % 3 == 0) {
-                            log.info("===> Note time invoked");
                             writer.noteTime(currentTime.get());
                         }
                     });
@@ -512,8 +511,6 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
             Iterator<Map.Entry<Revision, Watermark>> marks = watermarkReader.readFrom(revision.get());
             if (marks.hasNext()) {
                 Map.Entry<Revision, Watermark> next = marks.next();
-                log.info("==> watermark = {}", next.getValue());
-
                 watermarks.add(next.getValue());
                 revision.set(next.getKey());
             }

--- a/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package io.pravega.test.integration;
@@ -43,19 +43,11 @@ import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.StreamCutImpl;
 import io.pravega.client.watermark.WatermarkSerializer;
 import io.pravega.common.concurrent.Futures;
-import io.pravega.segmentstore.contracts.StreamSegmentStore;
-import io.pravega.segmentstore.contracts.tables.TableStore;
-import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
-import io.pravega.segmentstore.server.store.ServiceBuilder;
-import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.shared.NameUtils;
 import io.pravega.shared.watermarks.Watermark;
 import io.pravega.test.common.AssertExtensions;
-import io.pravega.test.common.TestUtils;
-import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.common.ThreadPooledTestSuite;
-import io.pravega.test.integration.demo.ControllerWrapper;
-import java.net.URI;
+
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -72,11 +64,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -90,80 +79,30 @@ import static org.junit.Assert.assertTrue;
 @Slf4j
 public class WatermarkingTest extends ThreadPooledTestSuite {
 
-    private static final int controllerPort = TestUtils.getAvailableListenPort();
-    private static final int servicePort = TestUtils.getAvailableListenPort();
-
-    private static TestingServer zkTestServer;
-    private static ControllerWrapper controllerWrapper;
-    private static PravegaConnectionListener server;
-    private static ServiceBuilder serviceBuilder;
-    private static StreamSegmentStore store;
-    private static TableStore tableStore;
-    private static AtomicLong timer = new AtomicLong();
+    @ClassRule
+    public static final PravegaResource PRAVEGA = new PravegaResource();
+    private final AtomicLong timer = new AtomicLong();
 
     protected int getThreadPoolSize() {
         return 5;
     }
 
-    @BeforeClass
-    public static void setup() throws Exception {
-        final String serviceHost = "localhost";
-        final int containerCount = 4;
-
-        // 1. Start ZK
-        zkTestServer = new TestingServerStarter().start();
-
-        serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
-        serviceBuilder.initialize();
-        store = serviceBuilder.createStreamSegmentService();
-        tableStore = serviceBuilder.createTableStoreService();
-
-        server = new PravegaConnectionListener(false, servicePort, store, tableStore, serviceBuilder.getLowPriorityExecutor());
-        server.startListening();
-
-        // 2. Start controller
-        // the default watermarking frequency on the controller is 10 seconds.
-        System.setProperty("controller.watermarking.frequency.seconds", "5");
-        controllerWrapper = new ControllerWrapper(zkTestServer.getConnectString(), false,
-                controllerPort, serviceHost, servicePort, containerCount);
-
-        controllerWrapper.awaitRunning();
-        timer.set(0);
-    }
-
-    @AfterClass
-    public static void cleanup() throws Exception {
-        if (controllerWrapper != null) {
-            controllerWrapper.close();
-        }
-        if (server != null) {
-            server.close();
-        }
-        if (serviceBuilder != null) {
-            serviceBuilder.close();
-        }
-        if (zkTestServer != null) {
-            zkTestServer.close();
-        }
-    }
-
     @Test(timeout = 120000)
     public void watermarkTest() throws Exception {
-        Controller controller = controllerWrapper.getController();
+        Controller controller = PRAVEGA.getLocalController();
         String scope = "scope";
         String stream = "stream";
         StreamConfiguration config = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(5)).build();
-
-        URI controllerUri = URI.create("tcp://localhost:" + controllerPort);
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(PRAVEGA.getControllerURI()).build();
         @Cleanup
-        StreamManager streamManager = StreamManager.create(controllerUri);
+        StreamManager streamManager = StreamManager.create(clientConfig);
         streamManager.createScope(scope);
         streamManager.createStream(scope, stream, config);
 
         Stream streamObj = Stream.of(scope, stream);
 
         // create 2 writers
-        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
         JavaSerializer<Long> javaSerializer = new JavaSerializer<>();
@@ -205,11 +144,11 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
 
         writer1Future.join();
         writer2Future.join();
-        
+
         // read events from the stream
         @Cleanup
         ReaderGroupManager readerGroupManager = new ReaderGroupManagerImpl(scope, controller, syncClientFactory);
-        
+
         Watermark watermark0 = watermarks.take();
         Watermark watermark1 = watermarks.take();
         assertTrue(watermark0.getLowerTimeBound() <= watermark0.getUpperTimeBound());
@@ -225,7 +164,7 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
         StreamCut streamCutSecond = new StreamCutImpl(streamObj, positionMap1);
         Map<Stream, StreamCut> firstMarkStreamCut = Collections.singletonMap(streamObj, streamCutFirst);
         Map<Stream, StreamCut> secondMarkStreamCut = Collections.singletonMap(streamObj, streamCutSecond);
-        
+
         // read from stream cut of first watermark
         String readerGroup = "rg";
         readerGroupManager.createReaderGroup(readerGroup, ReaderGroupConfig.builder().stream(streamObj)
@@ -260,13 +199,13 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
             assertTrue(currentTimeWindow.getLowerTimeBound() == null || nextTimeWindow.getLowerTimeBound() >= currentTimeWindow.getLowerTimeBound());
             assertTrue(currentTimeWindow.getUpperTimeBound() == null || nextTimeWindow.getUpperTimeBound() >= currentTimeWindow.getUpperTimeBound());
             currentTimeWindow = nextTimeWindow;
-            
+
             event = reader.readNextEvent(10000L);
             if (event.isCheckpoint()) {
                 event = reader.readNextEvent(10000L);
             }
         }
-        
+
         assertNotNull(currentTimeWindow.getLowerTimeBound());
     }
 
@@ -274,13 +213,13 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
     @Test(timeout = 120000)
     public void recreateStreamWatermarkTest() throws Exception {
         StreamConfiguration config = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(5)).build();
-        URI controllerUri = URI.create("tcp://localhost:" + controllerPort);
-        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(PRAVEGA.getControllerURI()).build();
+
         @Cleanup
-        StreamManager streamManager = StreamManager.create(controllerUri);
+        StreamManager streamManager = StreamManager.create(clientConfig);
 
         // in each iteration create stream, note times and let watermark be generated.
-        // then delete stream and move to next iteration and verify that watermarks are generated. 
+        // then delete stream and move to next iteration and verify that watermarks are generated.
         for (int i = 0; i < 2; i++) {
             String scope = "scope";
             String stream = "recreate";
@@ -322,21 +261,21 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
 
     @Test(timeout = 120000)
     public void watermarkTxnTest() throws Exception {
-        Controller controller = controllerWrapper.getController();
+        Controller controller = PRAVEGA.getLocalController();
         String scope = "scopeTx";
         String stream = "streamTx";
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(PRAVEGA.getControllerURI()).build();
         StreamConfiguration config = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(5)).build();
 
-        URI controllerUri = URI.create("tcp://localhost:" + controllerPort);
         @Cleanup
-        StreamManager streamManager = StreamManager.create(controllerUri);
+        StreamManager streamManager = StreamManager.create(clientConfig);
         streamManager.createScope(scope);
         streamManager.createStream(scope, stream, config);
 
         Stream streamObj = Stream.of(scope, stream);
 
         // create 2 writers
-        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);
         JavaSerializer<Long> javaSerializer = new JavaSerializer<>();
@@ -450,12 +389,10 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
         String streamName = "Timeout";
         int numSegments = 1;
 
-        URI controllerUri = URI.create("tcp://localhost:" + controllerPort);
-
-        ClientConfig clientConfig = ClientConfig.builder().controllerURI(controllerUri).build();
+        ClientConfig clientConfig = ClientConfig.builder().controllerURI(PRAVEGA.getControllerURI()).build();
 
         @Cleanup
-        StreamManager streamManager = StreamManager.create(controllerUri);
+        StreamManager streamManager = StreamManager.create(clientConfig);
         assertNotNull(streamManager);
 
         streamManager.createScope(scope);
@@ -478,7 +415,7 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
         AtomicBoolean stopFlag = new AtomicBoolean(false);
         fetchWatermarks(watermarkReader, watermarks, stopFlag);
 
-        // create two writers and write two sevent and call note time for each writer. 
+        // create two writers and write two sevent and call note time for each writer.
         @Cleanup
         EventStreamWriter<String> writer1 = clientFactory.createEventWriter(streamName,
                 new JavaSerializer<>(),
@@ -495,8 +432,8 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
 
         // writer0 should timeout. writer1 and writer2 should result in two more watermarks with following times:
         // 1: 100L-101L 2: 101-101
-        // then first writer should timeout and be discarded. But second writer should continue to be active as its time 
-        // is higher than first watermark. This should result in a second watermark to be emitted.  
+        // then first writer should timeout and be discarded. But second writer should continue to be active as its time
+        // is higher than first watermark. This should result in a second watermark to be emitted.
         AssertExtensions.assertEventuallyEquals(true, () -> watermarks.size() == 2, 100000);
         Watermark watermark1 = watermarks.poll();
         Watermark watermark2 = watermarks.poll();
@@ -513,7 +450,7 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
         writer1.writeEvent("3").get();
         writer1.noteTime(101L);
 
-        // no watermark should be emitted. 
+        // no watermark should be emitted.
         Watermark nullMark = watermarks.poll(10, TimeUnit.SECONDS);
         assertNull(nullMark);
     }

--- a/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
@@ -74,7 +74,9 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -88,23 +90,23 @@ import static org.junit.Assert.assertTrue;
 @Slf4j
 public class WatermarkingTest extends ThreadPooledTestSuite {
 
-    private final int controllerPort = TestUtils.getAvailableListenPort();
-    private final int servicePort = TestUtils.getAvailableListenPort();
+    private static final int controllerPort = TestUtils.getAvailableListenPort();
+    private static final int servicePort = TestUtils.getAvailableListenPort();
 
-    private TestingServer zkTestServer;
-    private ControllerWrapper controllerWrapper;
-    private PravegaConnectionListener server;
-    private ServiceBuilder serviceBuilder;
-    private StreamSegmentStore store;
-    private TableStore tableStore;
-    private AtomicLong timer = new AtomicLong();
+    private static TestingServer zkTestServer;
+    private static ControllerWrapper controllerWrapper;
+    private static PravegaConnectionListener server;
+    private static ServiceBuilder serviceBuilder;
+    private static StreamSegmentStore store;
+    private static TableStore tableStore;
+    private static AtomicLong timer = new AtomicLong();
 
     protected int getThreadPoolSize() {
         return 5;
     }
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeClass
+    public static void setup() throws Exception {
         final String serviceHost = "localhost";
         final int containerCount = 4;
 
@@ -127,8 +129,8 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
         timer.set(0);
     }
 
-    @After
-    public void cleanup() throws Exception {
+    @AfterClass
+    public static void cleanup() throws Exception {
         if (controllerWrapper != null) {
             controllerWrapper.close();
         }


### PR DESCRIPTION
**Change log description**  
Speed up WatermarkingTest

**Purpose of the change**  
Fixes #5628 

**What the code does**  
Speed up WatermarkingTest. With these changes the test executes
```
WatermarkingTest » recreateStreamWatermarkTest | 37.475s |  
WatermarkingTest » watermarkTest | 26.793s |  
WatermarkingTest » progressingWatermarkWithWriterTimeouts | 25.281s |  
WatermarkingTest » watermarkTxnTest | 25.069s |  
```

**How to verify it**  
All the existing test should continue to pass.
