### PR TITLE
Issue 5840: (SegmentStore) Fixed a deadlock in SegmentKeyCache.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
@@ -208,14 +208,19 @@ class SegmentKeyCache {
         }
 
         // Update the cache entry directly.
-        entry.update(keyHash, segmentOffset, generation);
+        if (!entry.update(keyHash, segmentOffset, generation)) {
+            evictEntry(entry);
+
+        }
         return segmentOffset;
     }
 
-    private synchronized void entryUpdateFailed(CacheEntry entry, Throwable ex) {
-        log.warn("{}: Cache Entry update failed for {}. Unregistering.", this.segmentId, entry, ex);
-        this.cacheEntries.remove(entry.hashGroup);
-        entry.evict();
+    private void evictEntry(CacheEntry entry) {
+        synchronized (this) {
+            this.cacheEntries.remove(entry.hashGroup);
+        }
+
+        entry.evict(); // This need not be invoked while holding the lock (it has its own synchronization).
     }
 
     /**
@@ -273,11 +278,19 @@ class SegmentKeyCache {
             }
         }
 
-        candidates.forEach(mc -> mc.commit(cacheGeneration));
+        candidates.forEach(mc -> commitMigrationCandidate(mc, cacheGeneration));
         synchronized (this) {
             // Finally, remove tail hashes, but ONLY if they haven't changed - it's possible that since we released the lock
             // above a newer value was recorded; we shouldn't be removing it then. We use Map.remove(Key, Value) for this.
             candidates.forEach(c -> this.tailOffsets.remove(c.keyHash, c.offset));
+        }
+    }
+
+    private void commitMigrationCandidate(MigrationCandidate mc, int cacheGeneration) {
+        if (!mc.commit(cacheGeneration)) {
+            // If we were unable to commit a migration candidate, we should evict it. It likely is in an inconsistent state.
+            // This is safe to do since any data in this entry can be reloaded from the index.
+            evictEntry(mc.cacheEntry);
         }
     }
 
@@ -343,8 +356,7 @@ class SegmentKeyCache {
          */
         boolean commit(int cacheGeneration) {
             try {
-                this.cacheEntry.update(this.keyHash, this.offset.encode(), cacheGeneration);
-                return true;
+                return this.cacheEntry.update(this.keyHash, this.offset.encode(), cacheGeneration);
             } catch (CacheEntryEvictedException ex) {
                 // Nothing to do here. A concurrent eviction has removed this entry so there isn't much more we can do.
                 return false;
@@ -369,10 +381,8 @@ class SegmentKeyCache {
         private static final int INITIAL_ADDRESS = -1;
         private static final int EVICTED_ADDRESS = -2;
         private final short hashGroup;
-        @GuardedBy("this")
-        private int generation;
-        @GuardedBy("this")
-        private long highestOffset;
+        private volatile int generation;
+        private volatile long highestOffset;
         @GuardedBy("this")
         private int cacheAddress;
 
@@ -387,14 +397,14 @@ class SegmentKeyCache {
          * Gets a value representing the current Generation of this Cache Entry. This value is updated every time the
          * data behind this entry is modified or accessed.
          */
-        synchronized int getGeneration() {
+        int getGeneration() {
             return this.generation;
         }
 
         /**
          * Gets a value representing the Highest offset that is stored in any CacheValues in this CacheEntry.
          */
-        synchronized long getHighestOffset() {
+        long getHighestOffset() {
             return this.highestOffset;
         }
 
@@ -411,11 +421,8 @@ class SegmentKeyCache {
             int offset = locate(keyHash, data);
             if (offset >= 0) {
                 // Found it.
-                synchronized (this) {
-                    // Update Entry's generation.
-                    this.generation = currentGeneration;
-                }
-
+                // Update Entry's generation.
+                this.generation = currentGeneration;
                 return data.getLong(offset);
             }
 
@@ -431,7 +438,7 @@ class SegmentKeyCache {
          * @param segmentOffset     See {@link ContainerKeyCache#includeExistingKey} segmentOffset.
          * @param currentGeneration The current Cache Generation (from the Cache Manager).
          */
-        synchronized void update(UUID keyHash, long segmentOffset, int currentGeneration) {
+        synchronized boolean update(UUID keyHash, long segmentOffset, int currentGeneration) {
             ArrayView entryData = getFromCache();
             int entryOffset = locate(keyHash, entryData);
             if (entryOffset < 0) {
@@ -467,8 +474,11 @@ class SegmentKeyCache {
                 throw cex;
             } catch (Throwable ex) {
                 // There is nothing we can do here. Invoke the general handler to remove this from the cache.
-                entryUpdateFailed(this, ex);
+                log.warn("SegmentKeyCache[{}]: Cache Entry update failed for {}.", segmentId, this, ex);
+                return false;
             }
+
+            return true;
         }
 
         /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
@@ -475,6 +475,9 @@ class SegmentKeyCache {
             } catch (CacheEntryEvictedException cex) {
                 // Pass-through exception. If this is the case, the entry has already been evicted so not more we can do.
                 throw cex;
+            } catch (CacheDisabledException cex) {
+                log.debug("SegmentKeyCache[{}]: Not updating cache for {} due to non-essential cache entries disabled.", segmentId, this);
+                return false;
             } catch (Throwable ex) {
                 // There is nothing we can do here. Invoke the general handler to remove this from the cache.
                 log.warn("SegmentKeyCache[{}]: Cache Entry update failed for {}.", segmentId, this, ex);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReaderTests.java
@@ -303,7 +303,6 @@ public class AsyncTableEntryReaderTests extends ThreadPooledTestSuite {
 
         // Verify that we are not holding on to more buffer than we need.
         val allocatedKeySize = soughtKey.getKey().getAllocatedLength();
-        System.out.println(allocatedKeySize);
         if (expectCompaction) {
             Assert.assertEquals("", soughtKey.getKey().getLength(), soughtKey.getKey().getAllocatedLength());
         } else {
@@ -312,7 +311,6 @@ public class AsyncTableEntryReaderTests extends ThreadPooledTestSuite {
 
         if (soughtValue != null) {
             val allocatedValueSize = soughtValue.getAllocatedLength();
-            System.out.println(allocatedValueSize);
             if (expectCompaction) {
                 Assert.assertEquals("", soughtValue.getLength(), soughtValue.getAllocatedLength());
             } else {


### PR DESCRIPTION

**Change log description**  
Fixed a thread deadlock in SegmentKeyCache that could be triggered by a callback from a `CacheFullException`.

**Purpose of the change**  
Fixes #5840.

**What the code does**  
See #5840 for deadlock stack traces.
The situation that lead to this was:
1. Thread A: attempt to insert/update an entry in the cache (acquire Entry lock E1)
2. Thread B: CacheManager requests Cache Status From SegmentKeyCache. SegmentKeyCache acquires its own lock (S1).
3. Thread A: cache insert failed. Invoke failure callback (attempt to acquire acquire parent SegmentKeyCache lock S1)
4. Thread B: SegmentKeyCache queries Entry for status (attempts to acquire Entry lock E1)

This is a typical deadlock scenario. 

This has been fixed as follows:
- `CacheEntry.generation` and `CacheEntry.lastOffset` have been changed to `volatile` and as such a lock acquisition is no longer required when reading them (they need not be updated synchronized as they serve different purposes). 
- Updated `CacheEntry.update` to not auto-invoke the failure handler while holding its lock; it now returns a boolean and the upstream caller will invoke that callback. This ensures that the Entry lock is no longer acquired while invoking the failure handler.

**How to verify it**  
Code review. All existing tests must pass. There is no feasible way to reilably simulate this situation due to JVM thread scheduling, etc.
