### PR TITLE
Issue 5850: (SegmentStore) Fixed a bug in WriterTableProcessor where it would attempt to flush to a deleted segment.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterFlushResult.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterFlushResult.java
@@ -17,9 +17,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * Represents the result of a Storage Flush Operation.
  */
 public class WriterFlushResult {
-    private AtomicLong flushedBytes;
-    private AtomicLong mergedBytes;
-    private AtomicInteger flushedAttributes;
+    private final AtomicLong flushedBytes;
+    private final AtomicLong mergedBytes;
+    private final AtomicInteger flushedAttributes;
 
     /**
      * Creates a new instance of the WriterFlushResult class.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
@@ -156,6 +156,10 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
     @Override
     public CompletableFuture<WriterFlushResult> flush(boolean force, Duration timeout) {
         Exceptions.checkNotClosed(this.closed.get(), this);
+        if (!force && !mustFlush()) {
+            return CompletableFuture.completedFuture(new WriterFlushResult());
+        }
+
         TimeoutTimer timer = new TimeoutTimer(timeout);
         return this.connector
                 .getSegment(timer.getRemaining())

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/WriterTableProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/WriterTableProcessorTests.java
@@ -252,14 +252,17 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
 
             // Flush.
             val initialNotifyCount = context.connector.notifyCount.get();
-            context.processor.flush(TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            val f1 = context.processor.flush(TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             AssertExtensions.assertGreaterThan("No calls to notifyIndexOffsetChanged().",
                     initialNotifyCount, context.connector.notifyCount.get());
+            Assert.assertTrue(f1.isAnythingFlushed());
 
             // Post-flush validation.
             Assert.assertFalse("Unexpected value from mustFlush() after call to flush().", context.processor.mustFlush());
+            val f2 = context.processor.flush(false, TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertEquals("Unexpected LUSN after call to flush().",
                     Operation.NO_SEQUENCE_NUMBER, context.processor.getLowestUncommittedSequenceNumber());
+            Assert.assertFalse(f2.isAnythingFlushed());
 
             // Verify correctness.
             batch.expectedEntries.keySet().forEach(k -> allKeys.put(k, context.keyHasher.hash(k)));


### PR DESCRIPTION
**Change log description**  
Fixed a bug in WriterTableProcessor where it would incorrectly try to flush if the flush conditions were not met - including if the segment had already been deleted.

**Purpose of the change**  
Fixes #5850.

**What the code does**  
Fixes the `WriterTableProcessor` to not attempt a flush if the segment has already been deleted. This should prevent repeated attempts to modify a deleted segment - reduces log noise. This could also prevents the writer from making progress in some cases.

**How to verify it**  
Unit test updated to verify the flush is not invoked.
