### PR TITLE
Issue 5726: Ensure the Pravega standalone is up and running before attempting to run tests.

### DIFF
--- a/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
@@ -20,7 +20,6 @@ import io.pravega.client.admin.StreamManager;
 import io.pravega.shared.security.auth.DefaultCredentials;
 import io.pravega.common.Exceptions;
 import io.pravega.test.common.AssertExtensions;
-import io.pravega.test.common.SecurityConfigDefaults;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,15 +37,6 @@ public class AuthEnabledInProcPravegaClusterTest {
     final String scope = "AuthTestScope";
     final String stream = "AuthTestStream";
     final String msg = "Test message on the plaintext channel with auth credentials";
-
-    ClientConfig prepareValidClientConfig() {
-        return ClientConfig.builder()
-                .controllerURI(URI.create(EMULATOR.pravega.getInProcPravegaCluster().getControllerURI()))
-                .credentials(new DefaultCredentials(
-                        SecurityConfigDefaults.AUTH_ADMIN_PASSWORD,
-                        SecurityConfigDefaults.AUTH_ADMIN_USERNAME))
-                .build();
-    }
 
     /**
      * This test verifies that create stream fails when the client config is invalid.
@@ -71,7 +61,7 @@ public class AuthEnabledInProcPravegaClusterTest {
 
     @Test(timeout = 30000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        testWriteAndReadAnEvent(scope, stream, msg, prepareValidClientConfig());
+        testWriteAndReadAnEvent(scope, stream, msg, EMULATOR.getClientConfig());
     }
 
     private boolean hasAuthExceptionAsRootCause(Throwable e) {

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -9,10 +9,6 @@
  */
 package io.pravega.local;
 
-import io.pravega.client.ClientConfig;
-
-import java.net.URI;
-
 import lombok.extern.slf4j.Slf4j;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -30,12 +26,6 @@ public class InProcPravegaClusterTest {
     public static final PravegaEmulatorResource EMULATOR = new PravegaEmulatorResource(false, false, false);
     final String msg = "Test message on the plaintext channel";
 
-    ClientConfig prepareValidClientConfig() {
-        return ClientConfig.builder()
-                .controllerURI(URI.create(EMULATOR.pravega.getInProcPravegaCluster().getControllerURI()))
-                .build();
-    }
-
     /**
      * Compares reads and writes to verify that an in-process Pravega cluster responds properly with
      * with valid client configuration.
@@ -47,6 +37,6 @@ public class InProcPravegaClusterTest {
      */
     @Test(timeout = 30000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        testWriteAndReadAnEvent("TestScope", "TestStream", msg, prepareValidClientConfig());
+        testWriteAndReadAnEvent("TestScope", "TestStream", msg, EMULATOR.getClientConfig());
     }
 }

--- a/standalone/src/test/java/io/pravega/local/PravegaEmulatorResource.java
+++ b/standalone/src/test/java/io/pravega/local/PravegaEmulatorResource.java
@@ -134,8 +134,8 @@ public class PravegaEmulatorResource extends ExternalResource {
         @Cleanup
         StreamManager streamManager = new StreamManagerImpl(clientConfig, controllerConfig);
         assertNotNull(streamManager);
-        // try creating a scope. This will retry based on the provided retry configuration.
-        // if all the retries fail a RetriesExhaustedException will be thrown failing the tests.
+        // Try creating a scope. This will retry based on the provided retry configuration.
+        // If all the retries fail a RetriesExhaustedException will be thrown failing the tests.
         boolean isScopeCreated = streamManager.createScope("healthCheck-scope");
         log.debug("Health check scope creation is successful {}", isScopeCreated);
     }

--- a/standalone/src/test/java/io/pravega/local/PravegaEmulatorResource.java
+++ b/standalone/src/test/java/io/pravega/local/PravegaEmulatorResource.java
@@ -126,7 +126,7 @@ public class PravegaEmulatorResource extends ExternalResource {
         ClientConfig clientConfig = getClientConfig();
         ControllerImplConfig controllerConfig = ControllerImplConfig.builder()
                 .clientConfig(clientConfig)
-                .retryAttempts(10)
+                .retryAttempts(20)
                 .initialBackoffMillis(1000)
                 .backoffMultiple(2)
                 .maxBackoffMillis(10000)

--- a/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
@@ -9,11 +9,6 @@
  */
 package io.pravega.local;
 
-import io.pravega.client.ClientConfig;
-import io.pravega.shared.security.auth.DefaultCredentials;
-import java.net.URI;
-
-import io.pravega.test.common.SecurityConfigDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -32,22 +27,8 @@ public class SecurePravegaClusterTest {
     final String stream = "TlsAndAuthTestStream";
     final String msg = "Test message on the encrypted channel with auth credentials";
 
-    ClientConfig prepareValidClientConfig() {
-        return ClientConfig.builder()
-                .controllerURI(URI.create(EMULATOR.pravega.getInProcPravegaCluster().getControllerURI()))
-
-                // TLS-related
-                .trustStore(SecurityConfigDefaults.TLS_CA_CERT_PATH)
-                .validateHostName(false)
-
-                // Auth-related
-                .credentials(new DefaultCredentials(SecurityConfigDefaults.AUTH_ADMIN_PASSWORD,
-                        SecurityConfigDefaults.AUTH_ADMIN_USERNAME))
-                .build();
-    }
-
     @Test(timeout = 30000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        testWriteAndReadAnEvent(scope, stream, msg, prepareValidClientConfig());
+        testWriteAndReadAnEvent(scope, stream, msg, EMULATOR.getClientConfig());
     }
 }

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -14,7 +14,6 @@ import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
 import io.pravega.client.control.impl.ControllerImplConfig;
-import io.pravega.test.common.SecurityConfigDefaults;
 import io.pravega.test.common.AssertExtensions;
 import java.net.URI;
 import javax.net.ssl.SSLHandshakeException;
@@ -37,14 +36,6 @@ public class TlsEnabledInProcPravegaClusterTest {
     final String scope = "TlsTestScope";
     final String stream = "TlsTestStream";
     final String msg = "Test message on the encrypted channel";
-
-    ClientConfig prepareValidClientConfig() {
-        return ClientConfig.builder()
-                .controllerURI(URI.create(EMULATOR.pravega.getInProcPravegaCluster().getControllerURI()))
-                .trustStore(SecurityConfigDefaults.TLS_CA_CERT_PATH)
-                .validateHostName(false)
-                .build();
-    }
 
     /**
      * This test verifies that create stream fails when the client config is invalid.
@@ -77,7 +68,7 @@ public class TlsEnabledInProcPravegaClusterTest {
 
     @Test(timeout = 30000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        testWriteAndReadAnEvent(scope, stream, msg, prepareValidClientConfig());
+        testWriteAndReadAnEvent(scope, stream, msg, EMULATOR.getClientConfig());
     }
 
     private boolean hasTlsException(Throwable e) {

--- a/standalone/src/test/resources/logback-test.xml
+++ b/standalone/src/test/resources/logback-test.xml
@@ -9,12 +9,14 @@
 -->
 <configuration>
     <!-- This config is valid for all unit tests in this module. We are turning off all logging for unit tests -->
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%msg%n</pattern>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <Pattern>%d %-4relative [%thread] %-5level %logger{35} - %msg%n</Pattern>
         </encoder>
     </appender>
-    <root level="OFF">
-        <appender-ref ref="CONSOLE"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
**Change log description**  
Ensure the Pravega standalone is up and running before attempting to run tests.

**Purpose of the change**  
Fixes #5726 

**What the code does**  
- Ensure the Pravega standalone is up and running before attempting to run tests.
- Enable test logs 

**How to verify it**  
The test should consistently pass. 
Verified this by running standalone tests in a docker container with limited resources.
