### PR TITLE
Issue 5853: SLTS - BaseMetadataStore.get does not return deep copy when loading from store.

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -663,6 +663,7 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         garbageCollector.report();
         metadataStore.report();
         chunkStorage.report();
+        readIndexCache.report();
     }
 
     @Override

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -663,7 +663,6 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         garbageCollector.report();
         metadataStore.report();
         chunkStorage.report();
-        readIndexCache.report();
     }
 
     @Override

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
@@ -571,16 +571,14 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
     }
 
     private StorageMetadata copyToTransaction(MetadataTransaction txn, String key, TransactionData transactionData) {
-        if (null != transactionData) {
-            val txnLocalCopy = transactionData.toBuilder()
-                    .build();
-            txn.getData().put(key, txnLocalCopy);
-            if (null != transactionData.getValue()) {
-                // Make sure a deep copy is returned.
-                val retValue = transactionData.getValue().deepCopy();
-                txnLocalCopy.setValue(retValue);
-                return retValue;
-            }
+        val txnLocalCopy = transactionData.toBuilder()
+                .build();
+        txn.getData().put(key, txnLocalCopy);
+        if (null != transactionData.getValue()) {
+            // Make sure a deep copy is returned.
+            val retValue = transactionData.getValue().deepCopy();
+            txnLocalCopy.setValue(retValue);
+            return retValue;
         }
         return null;
     }
@@ -672,8 +670,6 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
      * Inserts a copy of metadata into the buffer.
      */
     private TransactionData insertInBuffer(String key, TransactionData copyForBuffer) {
-        Preconditions.checkState(null != copyForBuffer, "Copy for buffer must not be null.");
-        Preconditions.checkState(null != copyForBuffer.getDbObject(), "Missing tracking object");
         // If some other transaction beat us then use that value.
         val oldValue = bufferedTxnData.putIfAbsent(key, copyForBuffer);
         final TransactionData retValue;

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryMetadataStore.java
@@ -45,8 +45,9 @@ public class InMemoryMetadataStore extends BaseMetadataStore {
     private final AtomicBoolean entryTracker = new AtomicBoolean(false);
 
     /**
-     * Write through cache.
+     * Backing in memory data.
      */
+    @Getter
     private final Map<String, TransactionData> backingStore = new ConcurrentHashMap<>();
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/MockStorageMetadata.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/MockStorageMetadata.java
@@ -30,7 +30,7 @@ public class MockStorageMetadata extends StorageMetadata {
 
     final private String key;
 
-    final private String value;
+    private volatile String value;
 
     /**
      * Constructor.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -65,7 +65,7 @@ import org.junit.rules.Timeout;
  */
 @Slf4j
 public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
-    protected static final Duration TIMEOUT = Duration.ofSeconds(3000);
+    protected static final Duration TIMEOUT = Duration.ofSeconds(30);
     private static final int CONTAINER_ID = 42;
     private static final int OWNER_EPOCH = 100;
     protected final Random rnd = new Random(0);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -2707,6 +2707,10 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
 
         SegmentMetadata expectedSegmentMetadata = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
         ChunkMetadata expectedChunkMetadata = TestUtils.getChunkMetadata(testContext.metadataStore, expectedSegmentMetadata.getLastChunk());
+
+        testMetadataStore.evictAllEligibleEntriesFromBuffer();
+        testMetadataStore.evictFromCache();
+
         while (currentOffset < data.length) {
             try {
                 int toWrite = Math.min(length, data.length - currentOffset);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.storage.chunklayer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Longs;
+import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.segmentstore.contracts.BadOffsetException;
 import io.pravega.segmentstore.contracts.SegmentProperties;
@@ -31,6 +32,7 @@ import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
 import io.pravega.segmentstore.storage.noop.NoOpChunkStorage;
 import io.pravega.shared.NameUtils;
 import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
@@ -63,7 +65,7 @@ import org.junit.rules.Timeout;
  */
 @Slf4j
 public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
-    protected static final Duration TIMEOUT = Duration.ofSeconds(30);
+    protected static final Duration TIMEOUT = Duration.ofSeconds(3000);
     private static final int CONTAINER_ID = 42;
     private static final int OWNER_EPOCH = 100;
     protected final Random rnd = new Random(0);
@@ -2668,6 +2670,67 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
                 new long[]{Integer.MAX_VALUE + 1L},
                 new long[]{Integer.MAX_VALUE + 1L, Integer.MAX_VALUE + 1L},
                 new long[]{3L * Integer.MAX_VALUE + 3L});
+    }
+
+    @Test
+    public void testWritesWithFlakyMetadataStore() throws Exception {
+        val primes = new int[] { 2, 3, 5, 7, 11};
+        for (int i = 0; i < primes.length; i++) {
+            for (int j = 0; j < primes.length; j++) {
+                testWritesWithFlakyMetadataStore(primes[i], primes[j]);
+            }
+        }
+    }
+
+    public void testWritesWithFlakyMetadataStore(int failFrequency, int length) throws Exception {
+        String testSegmentName = "foo";
+        @Cleanup
+        TestContext testContext = getTestContext(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .lazyCommitEnabled(false)
+                .build());
+
+        val invocationCount = new AtomicInteger(0);
+        val testMetadataStore = (InMemoryMetadataStore) testContext.metadataStore;
+        testMetadataStore.setMaxEntriesInTxnBuffer(1);
+        testMetadataStore.setWriteCallback(dummy -> {
+            if (invocationCount.incrementAndGet() % failFrequency == 0) {
+                return CompletableFuture.failedFuture(new IntentionalException("Intentional"));
+            }
+            return CompletableFuture.completedFuture(null);
+        });
+
+        val h = testContext.chunkedSegmentStorage.create(testSegmentName, null).get();
+
+        byte[] data = populate(100);
+
+        int currentOffset = 0;
+
+        SegmentMetadata expectedSegmentMetadata = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+        ChunkMetadata expectedChunkMetadata = TestUtils.getChunkMetadata(testContext.metadataStore, expectedSegmentMetadata.getLastChunk());
+        while (currentOffset < data.length) {
+            try {
+                int toWrite = Math.min(length, data.length - currentOffset);
+                expectedSegmentMetadata = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+                expectedChunkMetadata = TestUtils.getChunkMetadata(testContext.metadataStore, expectedSegmentMetadata.getLastChunk());
+                testContext.chunkedSegmentStorage.write(h, currentOffset, new ByteArrayInputStream(data, currentOffset, toWrite), toWrite, null).get();
+                currentOffset += toWrite;
+            } catch (Exception e) {
+                if (!(Exceptions.unwrap(e) instanceof IntentionalException)) {
+                    throw e;
+                }
+                val actual = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
+                val actualChunkMetadata = TestUtils.getChunkMetadata(testContext.metadataStore, expectedSegmentMetadata.getLastChunk());
+                Assert.assertEquals(expectedSegmentMetadata, actual);
+                Assert.assertEquals(expectedChunkMetadata, actualChunkMetadata);
+            } finally {
+                val info = testContext.chunkedSegmentStorage.getStreamSegmentInfo(testSegmentName, null).get();
+                Assert.assertEquals(info.getLength(), currentOffset);
+            }
+        }
+
+        testMetadataStore.setWriteCallback(null);
+
+        checkDataRead(testSegmentName, testContext, 0, data.length, data);
     }
 
     private void checkDataRead(String testSegmentName, TestContext testContext, long offset, long length) throws InterruptedException, java.util.concurrent.ExecutionException {

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
@@ -10,11 +10,13 @@
 package io.pravega.segmentstore.storage.metadata;
 
 import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.Futures;
 import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
 import io.pravega.segmentstore.storage.mocks.MockStorageMetadata;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.ThreadPooledTestSuite;
+import lombok.SneakyThrows;
 import lombok.val;
 import org.junit.After;
 import org.junit.Assert;
@@ -23,6 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
@@ -945,7 +948,286 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
     }
 
     @Test
-    public void testReadWriteFailureAfterEvictionFromBuffer() throws Exception {
+    public void testEvictionFromBufferInParallel() throws Exception {
+        if (metadataStore instanceof InMemoryMetadataStore) {
+            metadataStore.setMaxEntriesInCache(10);
+            metadataStore.setMaxEntriesInTxnBuffer(10);
+            val futures = new ArrayList<CompletableFuture<Void>>();
+            for (int i = 0; i < 10000; i++) {
+                final int k = i;
+                futures.add(CompletableFuture.runAsync(() -> simpleScenarioForKey("Key" + k)));
+            }
+            Futures.allOf(futures);
+        }
+    }
+
+    @SneakyThrows
+    private void simpleScenarioForKey(String key) {
+        // Create key.
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, key)) {
+            txn.create(new MockStorageMetadata(key, VALUE0));
+            assertEquals(txn.get(key), key, VALUE0);
+            txn.commit().get();
+        }
+
+        // Modify
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, key)) {
+            assertEquals(txn.get(key), key, VALUE0);
+            txn.update(new MockStorageMetadata(key, VALUE1));
+            assertEquals(txn.get(key), key, VALUE1);
+            txn.commit().get();
+        }
+
+        // Delete
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, key)) {
+            assertEquals(txn.get(key), key, VALUE1);
+            txn.delete(key);
+            assertNull(txn.get(key));
+            txn.commit().get();
+        }
+
+        try (MetadataTransaction txn = metadataStore.beginTransaction(true, key)) {
+            assertNull(txn.get(key));
+        }
+    }
+
+    @Test
+    public void testEviction() throws Exception {
+        if (!(metadataStore instanceof InMemoryMetadataStore)) {
+            return;
+        }
+
+        val testMetadataStore = (InMemoryMetadataStore) metadataStore;
+
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            txn.create(new MockStorageMetadata(KEY1, VALUE0));
+            txn.commit().get();
+        }
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            // Delete data from backing store , the data should be still in buffer.
+            testMetadataStore.evictFromCache();
+            testMetadataStore.getBackingStore().clear();
+            Assert.assertNull(testMetadataStore.getBackingStore().get(KEY1));
+
+            assertEquals(txn.get(KEY1), KEY1, VALUE0);
+
+            // Invoke eviction, this will move data from buffer to the Guava cache.
+            testMetadataStore.evictAllEligibleEntriesFromBuffer();
+
+            // But data should be still there in Guava cache.
+            // It will be inserted into buffer.
+            assertEquals(txn.get(KEY1), KEY1, VALUE0);
+
+            // Forcibly delete it from cache
+            testMetadataStore.evictFromCache();
+            testMetadataStore.getBackingStore().clear();
+            Assert.assertNull(testMetadataStore.getBackingStore().get(KEY1));
+
+            // But data should be still there in buffer.
+            assertEquals(txn.get(KEY1), KEY1, VALUE0);
+
+        }
+    }
+
+    @Test
+    public void testParallelReadsAfterEviction() throws Exception {
+        if (!(metadataStore instanceof InMemoryMetadataStore)) {
+            return;
+        }
+
+        val testMetadataStore = (InMemoryMetadataStore) metadataStore;
+
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            txn.create(new MockStorageMetadata(KEY1, VALUE1));
+            txn.commit().get();
+        }
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY2)) {
+            val metadata = new MockStorageMetadata(KEY2, VALUE2);
+            txn.create(metadata);
+            txn.markPinned(metadata);
+            txn.commit().get();
+        }
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY4)) {
+            val metadata = new MockStorageMetadata(KEY4, VALUE4);
+            txn.create(metadata);
+            txn.commit(true).get();
+        }
+
+        testMetadataStore.evictFromCache();
+        testMetadataStore.getBackingStore().clear();
+        Assert.assertNull(testMetadataStore.getBackingStore().get(KEY1));
+        // Invoke eviction, this will move data from buffer to the Guava cache.
+        testMetadataStore.evictAllEligibleEntriesFromBuffer();
+
+        val futures = new ArrayList<CompletableFuture<Void>>();
+        for (int i = 0; i < 100; i++) {
+            futures.add(CompletableFuture.runAsync(() -> {
+                readKey(KEY1, VALUE1);
+                readKey(KEY2, VALUE2);
+                readKey(KEY4, VALUE4);
+                evictAll(testMetadataStore);
+            }));
+        }
+        Futures.allOf(futures);
+
+        evictAll(testMetadataStore);
+
+        val futures2 = new ArrayList<CompletableFuture<Void>>();
+        for (int i = 0; i < 100; i++) {
+            futures.add(CompletableFuture.runAsync(() -> {
+                readKey(KEY1, VALUE1);
+                readKey(KEY2, VALUE2);
+                readKey(KEY4, VALUE4);
+                testMetadataStore.evictFromCache();
+                // Invoke eviction, this will move data from buffer to the Guava cache.
+                testMetadataStore.evictAllEligibleEntriesFromBuffer();
+            }));
+        }
+        Futures.allOf(futures2);
+
+        evictAll(testMetadataStore);
+
+        val futures3 = new ArrayList<CompletableFuture<Void>>();
+        for (int i = 0; i < 100; i++) {
+            futures.add(CompletableFuture.runAsync(() -> {
+                readKey(KEY1, VALUE1);
+                readKey(KEY2, VALUE2);
+                readKey(KEY4, VALUE4);
+            }));
+        }
+        Futures.allOf(futures3);
+    }
+
+    private void evictAll(InMemoryMetadataStore testMetadataStore) {
+        testMetadataStore.evictFromCache();
+        testMetadataStore.getBackingStore().clear();
+        testMetadataStore.evictAllEligibleEntriesFromBuffer();
+    }
+
+    @SneakyThrows
+    private void readKey(String key, String value) {
+        try (MetadataTransaction txn = metadataStore.beginTransaction(true, key)) {
+            // But data should be still there in Guava cache.
+            // It will be inserted into buffer.
+            assertEquals(txn.get(key), key, value);
+        }
+    }
+
+    @Test
+    public void testEvictionPinnedKeys() throws Exception {
+        if (!(metadataStore instanceof InMemoryMetadataStore)) {
+            return;
+        }
+
+        val testMetadataStore = (InMemoryMetadataStore) metadataStore;
+
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            val metadata = new MockStorageMetadata(KEY1, VALUE0);
+            txn.create(metadata);
+            txn.markPinned(metadata);
+            txn.commit().get();
+            Assert.assertNull(testMetadataStore.getBackingStore().get(KEY1));
+        }
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            // Delete data from backing store , the data should be still in buffer.
+            testMetadataStore.evictFromCache();
+            testMetadataStore.getBackingStore().clear();
+            Assert.assertNull(testMetadataStore.getBackingStore().get(KEY1));
+
+            assertEquals(txn.get(KEY1), KEY1, VALUE0);
+
+            // Invoke eviction, this will move data from buffer to the Guava cache.
+            testMetadataStore.evictAllEligibleEntriesFromBuffer();
+
+            // Forcibly delete it from cache
+            testMetadataStore.evictFromCache();
+            testMetadataStore.getBackingStore().clear();
+            Assert.assertNull(testMetadataStore.getBackingStore().get(KEY1));
+
+            // But data should be still there in buffer.
+            assertEquals(txn.get(KEY1), KEY1, VALUE0);
+        }
+    }
+
+    @Test
+    public void testEvictionForLazyCommits() throws Exception {
+        if (!(metadataStore instanceof InMemoryMetadataStore)) {
+            return;
+        }
+
+        val testMetadataStore = (InMemoryMetadataStore) metadataStore;
+
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            val metadata = new MockStorageMetadata(KEY1, VALUE0);
+            txn.create(metadata);
+            txn.commit(true).get();
+            Assert.assertNull(testMetadataStore.getBackingStore().get(KEY1));
+        }
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            // Delete data from backing store , the data should be still in buffer.
+            testMetadataStore.evictFromCache();
+            testMetadataStore.getBackingStore().clear();
+            Assert.assertNull(testMetadataStore.getBackingStore().get(KEY1));
+
+            assertEquals(txn.get(KEY1), KEY1, VALUE0);
+
+            // Invoke eviction, this will move data from buffer to the Guava cache.
+            testMetadataStore.evictAllEligibleEntriesFromBuffer();
+
+            // Forcibly delete it from cache
+            testMetadataStore.evictFromCache();
+            testMetadataStore.getBackingStore().clear();
+            Assert.assertNull(testMetadataStore.getBackingStore().get(KEY1));
+
+            // But data should be still there in buffer.
+            assertEquals(txn.get(KEY1), KEY1, VALUE0);
+        }
+    }
+
+    @Test
+    public void testEvictionDuringCommit() throws Exception {
+        if (!(metadataStore instanceof InMemoryMetadataStore)) {
+            return;
+        }
+
+        val testMetadataStore = (InMemoryMetadataStore) metadataStore;
+
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            txn.create(new MockStorageMetadata(KEY1, VALUE0));
+            txn.commit().get();
+        }
+
+        CompletableFuture commitStepFurure = new CompletableFuture();
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            // Block commit
+            txn.setExternalCommitStep(() -> validateInsideCommit(testMetadataStore, txn));
+            txn.commit().join();
+        }
+    }
+
+    @SneakyThrows
+    private Void validateInsideCommit(InMemoryMetadataStore testMetadataStore, MetadataTransaction txn) {
+        // Delete data from backing store , the data should be still in buffer.
+        testMetadataStore.evictFromCache();
+        testMetadataStore.getBackingStore().clear();
+        Assert.assertNull(testMetadataStore.getBackingStore().get(KEY1));
+
+        assertEquals(txn.get(KEY1), KEY1, VALUE0);
+
+        // Invoke eviction, this will move data from buffer to the Guava cache.
+        testMetadataStore.evictAllEligibleEntriesFromBuffer();
+
+        // Forcibly delete data from cache.
+        testMetadataStore.evictFromCache();
+        testMetadataStore.getBackingStore().clear();
+
+        // But data should be still there.
+        assertEquals(txn.get(KEY1), KEY1, VALUE0);
+        return null;
+    }
+
+    @Test
+    public void testCommitFailureAfterEvictionFromBuffer() throws Exception {
         if (metadataStore instanceof InMemoryMetadataStore) {
 
             val testMetadataStore = (InMemoryMetadataStore) metadataStore;
@@ -981,6 +1263,50 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
             try (MetadataTransaction txn = metadataStore.beginTransaction(true, KEY1)) {
                 assertEquals(txn.get(KEY1), KEY1, VALUE0);
             }
+        }
+    }
+
+    @Test
+    public void testCommitFailureWithExternalSteps() throws Exception {
+        // Add some data
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            txn.create(new MockStorageMetadata(KEY1, VALUE0));
+            txn.commit().get();
+        }
+
+        // Now start new transaction. Mutate the local copy.
+        // This txn will fail to commit.
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY1)) {
+            txn.setExternalCommitStep(() -> {
+                throw new IntentionalException("Intentional");
+            });
+            val metadata = (MockStorageMetadata) txn.get(KEY1).get();
+            metadata.setValue(VALUE1);
+            txn.update(metadata);
+            txn.commit().get();
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(Exceptions.unwrap(e).getCause() instanceof IntentionalException);
+        }
+
+        // Validate that object in buffer remains unchanged.
+        try (MetadataTransaction txn = metadataStore.beginTransaction(true, KEY1)) {
+            assertEquals(txn.get(KEY1), KEY1, VALUE0);
+        }
+
+    }
+
+    @Test
+    public void testWithNullExternalStep() throws Exception {
+        try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY0, KEY1)) {
+            assertNull(txn.get(KEY0));
+            txn.setExternalCommitStep(null);
+            txn.create(new MockStorageMetadata(KEY0, VALUE0));
+            Assert.assertNotNull(txn.get(KEY0));
+            txn.commit().get();
+        }
+        try (MetadataTransaction txn = metadataStore.beginTransaction(true, KEY1)) {
+            assertEquals(txn.get(KEY0), KEY0, VALUE0);
         }
     }
 
@@ -1053,6 +1379,22 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
             AssertExtensions.assertThrows("abort should throw an exception",
                     () -> txn.abort(),
                     ex -> ex instanceof IllegalStateException);
+        }
+    }
+
+    @Test
+    public void testTransactionDataIllegalStateException() throws Exception {
+        BaseMetadataStore.TransactionData[] badData = new BaseMetadataStore.TransactionData[] {
+                BaseMetadataStore.TransactionData.builder().build(),
+        };
+        for (val txnData : badData) {
+            try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY0, KEY1)) {
+                assertNull(txn.get(KEY0));
+                txn.getData().put(KEY0, txnData);
+                AssertExtensions.assertFutureThrows("commit should throw an exception",
+                        txn.commit(),
+                        ex -> ex instanceof IllegalStateException);
+            }
         }
     }
 

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
@@ -956,13 +956,9 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
                 txn.commit().get();
             }
 
-            // Force eviction of all cache by inserting lots of junk data.
-            for (int i = 0; i < 10000; i++) {
-                try (MetadataTransaction txn = metadataStore.beginTransaction(false, "Txn" + i)) {
-                    txn.create(new MockStorageMetadata("Txn" + i, "Value" + i));
-                    txn.commit().get();
-                }
-            }
+            // Force eviction of all cache
+            testMetadataStore.evictAllEligibleEntriesFromBuffer();
+            testMetadataStore.evictFromCache();
 
             // Set hook to cause failure on next commit.
             testMetadataStore.setWriteCallback(dummy -> CompletableFuture.failedFuture(new IntentionalException("Intentional")));


### PR DESCRIPTION
**Change log description**  
- Fix bug where during reloading key after previous eviction, mistakenly a deep copy of wrong object was returned.
- Additional tests to repro problem.

**Purpose of the change**  
Fixes #5853

**What the code does**  
- Fix bug where during reloading key after previous eviction, mistakenly a deep copy of wrong object was returned.
- Additional tests

**How to verify it**  

- [x] Build should pass
- [x] System tests should pass
- [x] Longevity should pass
