### PR TITLE
Issue 5859: (v0.9.1) Cherry-pick various SegmentStore bug fixes

### DIFF
--- a/common/src/main/java/io/pravega/common/util/AbstractBufferView.java
+++ b/common/src/main/java/io/pravega/common/util/AbstractBufferView.java
@@ -167,6 +167,11 @@ public abstract class AbstractBufferView implements BufferView {
         }
 
         @Override
+        public int getAllocatedLength() {
+            return 0;
+        }
+
+        @Override
         public InputStream getReader(int offset, int length) {
             return slice(offset, length).getReader();
         }

--- a/common/src/main/java/io/pravega/common/util/BufferView.java
+++ b/common/src/main/java/io/pravega/common/util/BufferView.java
@@ -38,6 +38,13 @@ public interface BufferView {
     int getLength();
 
     /**
+     * Gets a value indicating the amount of memory (in bytes) allocated for this {@link BufferView}.
+     *
+     * @return The allocated memory size.
+     */
+    int getAllocatedLength();
+
+    /**
      * Creates a new {@link BufferView.Reader} that can be used to read this {@link BufferView}. This reader is
      * preferable to {@link #getReader()} that returns an {@link InputStream} as it contains optimized methods for copying
      * directly into other {@link BufferView} instances, such as {@link ByteArraySegment}s.
@@ -87,7 +94,7 @@ public interface BufferView {
     /**
      * Returns a copy of the contents of this {@link BufferView}.
      *
-     * @return A byte array with the same length as this ArrayView, containing a copy of the data within it.
+     * @return A byte array with the same length as this {@link BufferView}, containing a copy of the data within it.
      */
     byte[] getCopy();
 

--- a/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
+++ b/common/src/main/java/io/pravega/common/util/ByteArraySegment.java
@@ -77,6 +77,11 @@ public class ByteArraySegment extends AbstractBufferView implements ArrayView {
     //region ArrayView Implementation
 
     @Override
+    public int getAllocatedLength() {
+        return this.array().length;
+    }
+
+    @Override
     public byte get(int index) {
         return this.buffer.get(this.buffer.position() + index);
     }

--- a/common/src/main/java/io/pravega/common/util/CompositeBufferView.java
+++ b/common/src/main/java/io/pravega/common/util/CompositeBufferView.java
@@ -35,6 +35,7 @@ class CompositeBufferView extends AbstractBufferView implements BufferView {
     private final List<BufferView> components;
     @Getter
     private final int length;
+    private volatile int allocatedLength = -1;
 
     //endregion
 
@@ -65,6 +66,15 @@ class CompositeBufferView extends AbstractBufferView implements BufferView {
     //endregion
 
     //region BufferView implementation
+
+    @Override
+    public int getAllocatedLength() {
+        if (this.allocatedLength < 0) {
+            this.allocatedLength = this.components.stream().mapToInt(BufferView::getAllocatedLength).sum();
+        }
+
+        return this.allocatedLength;
+    }
 
     @Override
     public Reader getBufferViewReader() {

--- a/common/src/main/java/io/pravega/common/util/CompositeByteArraySegment.java
+++ b/common/src/main/java/io/pravega/common/util/CompositeByteArraySegment.java
@@ -183,6 +183,11 @@ public class CompositeByteArraySegment extends AbstractBufferView implements Com
     }
 
     @Override
+    public int getAllocatedLength() {
+        return getAllocatedArrayCount() * this.bufferLayout.bufferSize;
+    }
+
+    @Override
     public CompositeReader getBufferViewReader() {
         return new CompositeReader();
     }

--- a/common/src/test/java/io/pravega/common/util/AbstractBufferViewTests.java
+++ b/common/src/test/java/io/pravega/common/util/AbstractBufferViewTests.java
@@ -81,6 +81,7 @@ public class AbstractBufferViewTests {
         val e = BufferView.empty();
         Assert.assertSame("Expecting same instance.", e, BufferView.empty());
         Assert.assertEquals(0, e.getLength());
+        Assert.assertEquals(0, e.getAllocatedLength());
         Assert.assertEquals(0, e.getCopy().length);
         Assert.assertSame(e, e.slice(0, 0));
         AssertExtensions.assertThrows("", () -> e.slice(0, 1), ex -> ex instanceof IndexOutOfBoundsException);

--- a/common/src/test/java/io/pravega/common/util/BufferViewTestBase.java
+++ b/common/src/test/java/io/pravega/common/util/BufferViewTestBase.java
@@ -304,7 +304,10 @@ public abstract class BufferViewTestBase {
             for (int length = 0; length < data.getLength() - offset; length += 11) {
                 val expected = new byte[length];
                 System.arraycopy(data.array(), data.arrayOffset() + offset, expected, 0, length);
-                val slice = bufferView.slice(offset, length).getCopy();
+                val sliceBuffer = bufferView.slice(offset, length);
+                checkAllocatedSize(sliceBuffer, bufferView);
+
+                val slice = sliceBuffer.getCopy();
                 Assert.assertArrayEquals("Unexpected slice() result for offset " + offset + ", length " + length, expected, slice);
                 if (length == 0) {
                     Assert.assertEquals("Unexpected getReader() result for offset " + offset + ", length " + length,
@@ -338,6 +341,12 @@ public abstract class BufferViewTestBase {
 
     protected List<ByteBuffer> getContents(BufferView bufferView) {
         return Lists.newArrayList(bufferView.iterateBuffers());
+    }
+
+    protected void checkAllocatedSize(BufferView slice, BufferView base) {
+        Assert.assertEquals("Unexpected allocated length for slice.", slice.getAllocatedLength(), base.getLength());
+        AssertExtensions.assertGreaterThanOrEqual("Expected slice length to be at most the allocated length.",
+                slice.getLength(), slice.getAllocatedLength());
     }
 
     protected abstract BufferView toBufferView(ArrayView data);

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResult.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ReadResult.java
@@ -86,10 +86,25 @@ public interface ReadResult extends Iterator<ReadResultEntry>, AutoCloseable {
     void setCopyOnRead(boolean value);
 
     /**
+     * Gets a value indicating the maximum number of bytes to read at once with every invocation of {@link #next()}.
+     *
+     * @return The maximum number of bytes to read at once.
+     */
+    int getMaxReadAtOnce();
+
+    /**
+     * Sets the maximum number of bytes to read at once with every invocation of {@link #next()}.
+     *
+     * @param value The value to set. If not positive or exceeds {@link #getMaxResultLength()}, this will be set to
+     *              {@link #getMaxResultLength()}.
+     */
+    void setMaxReadAtOnce(int value);
+
+    /**
      * Gets a value indicating whether this ReadResult is fully consumed (either because it was read in its entirety
      * or because it was closed externally).
      *
-     * @return true if ReadResult is fully consumed or closed externally, otherwise false
+     * @return true if ReadResult is fully consumed or closed externally, otherwise false.
      */
     boolean isClosed();
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheManager.java
@@ -57,6 +57,7 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
     private final ScheduledExecutorService executorService;
     private final AtomicInteger currentGeneration;
     private final AtomicInteger oldestGeneration;
+    private final AtomicBoolean essentialEntriesOnly;
     private final AtomicReference<CacheState> lastCacheState;
     private final AtomicBoolean running;
     private final CachePolicy policy;
@@ -98,6 +99,7 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
         this.clients = new HashSet<>();
         this.oldestGeneration = new AtomicInteger(0);
         this.currentGeneration = new AtomicInteger(0);
+        this.essentialEntriesOnly = new AtomicBoolean(false);
         this.running = new AtomicBoolean();
         this.closed = new AtomicBoolean();
         this.lastCacheState = new AtomicReference<>();
@@ -176,7 +178,7 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
             }
         }
 
-        client.updateGenerations(this.currentGeneration.get(), this.oldestGeneration.get());
+        client.updateGenerations(this.currentGeneration.get(), this.oldestGeneration.get(), this.essentialEntriesOnly.get());
         log.info("{} Registered {}.", TRACE_OBJECT_ID, client);
     }
 
@@ -202,6 +204,21 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
     //endregion
 
     //region Helpers
+
+    /**
+     * Gets a value indicating whether the CacheManager has entered "Essential-only" mode.
+     *
+     * @return True if essential-only, false otherwise.
+     */
+    @VisibleForTesting
+    public boolean isEssentialEntriesOnly() {
+        return this.essentialEntriesOnly.get();
+    }
+
+    @VisibleForTesting
+    public int getCurrentGeneration() {
+        return this.currentGeneration.get();
+    }
 
     private boolean cacheFullCallback() {
         log.info("{}: Cache full. Forcing cache policy.", TRACE_OBJECT_ID);
@@ -352,16 +369,19 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
 
     private void fetchCacheState() {
         this.lastCacheState.set(this.cacheStorage.getState());
+        adjustNonEssentialEnabled();
     }
 
     private boolean updateClients() {
         final int cg = this.currentGeneration.get();
         final int og = this.oldestGeneration.get();
+        final boolean essentialEntriesOnly = this.essentialEntriesOnly.get();
         ArrayList<Client> toUnregister = new ArrayList<>();
         boolean reduced = false;
+        log.debug("{}: UpdateClients. Gen={}-{}, EssentialOnly={}.", TRACE_OBJECT_ID, cg, og, essentialEntriesOnly);
         for (Client c : getClients()) {
             try {
-                reduced = c.updateGenerations(cg, og) | reduced;
+                reduced = c.updateGenerations(cg, og, essentialEntriesOnly) | reduced;
             } catch (ObjectClosedException ex) {
                 // This object was closed but it was not unregistered. Do it now.
                 log.warn("{} Detected closed client {}.", TRACE_OBJECT_ID, c);
@@ -415,6 +435,10 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
         return isAdjusted;
     }
 
+    private void adjustNonEssentialEnabled() {
+        this.essentialEntriesOnly.set(this.lastCacheState.get().getUsedBytes() >= this.policy.getCriticalThreshold());
+    }
+
     private boolean exceedsPolicy(CacheStatus currentStatus) {
         // We need to increment the OldestGeneration only if any of the following conditions occurred:
         // 1. We currently exceed the maximum usable size as defined by the cache policy.
@@ -432,8 +456,9 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
     }
 
     private void logCurrentStatus(CacheStatus status) {
-        log.info("{}: Gen: {}-{}; Clients: {} ({}-{}); Cache: {}.", TRACE_OBJECT_ID, this.currentGeneration, this.oldestGeneration,
-                this.clients.size(), status.getNewestGeneration(), status.getOldestGeneration(), this.lastCacheState);
+        log.info("{}: Gen: {}-{}; EssentialOnly: {}; Clients: {} ({}-{}); Cache: {}.", TRACE_OBJECT_ID, this.currentGeneration,
+                this.oldestGeneration, this.essentialEntriesOnly, this.clients.size(), status.getNewestGeneration(),
+                status.getOldestGeneration(), this.lastCacheState);
     }
 
     private long getStoredBytes() {
@@ -462,9 +487,15 @@ public class CacheManager extends AbstractScheduledService implements AutoClosea
          * @param currentGeneration The value of the current generation.
          * @param oldestGeneration  The value of the oldest generation. This is the cutoff for which entries can still
          *                          exist in the cache.
+         * @param essentialOnly     If true, essential-only indicates that only cache entries that must be added to the
+         *                          cache should be inserted (i.e., those that cannot yet be recovered from persistent storage).
+         *                          This usually indicates an extremely high cache utilization level so non-essential cache
+         *                          entries should not be inserted in order to improve system stability (such as avoiding
+         *                          {@link io.pravega.segmentstore.storage.cache.CacheFullException}).
+         *                          If false, any cache entries may be inserted.
          * @return If any cache data was trimmed with this update.
          */
-        boolean updateGenerations(int currentGeneration, int oldestGeneration);
+        boolean updateGenerations(int currentGeneration, int oldestGeneration, boolean essentialOnly);
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CachePolicy.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CachePolicy.java
@@ -46,11 +46,19 @@ public class CachePolicy {
     @Getter
     private final double maxUtilization;
     /**
-     * The maximum usable size of the cache. When the cache reaches or exceeds this threshold, cache eviction will kick in.
-     * This is a pre-calculated value of {@link #getMaxSize()} * {@link #getTargetUtilization()} ()}.
+     * The target size of the cache (ideally, the cache would contain at most this amount of data). When the cache reaches
+     * or exceeds this threshold, cache eviction will kick in.
+     * This is a pre-calculated value of {@link #getMaxSize()} * {@link #getTargetUtilization()}.
      */
     @Getter
     private final long evictionThreshold;
+    /**
+     * The maximum usable size of the cache. If the cache reaches or exceeds this threshold, the cache is considered to
+     * be under critical stress, and there is no guarantee that a subsequent cache insertion would succeed.
+     * This is a pre-calculated value of {@link  #getMaxSize()} * {@link #getMaxUtilization()}.
+     */
+    @Getter
+    private final long criticalThreshold;
     /**
      * The maximum number of generations a cache entry can be inactive in the cache for, before being eligible for eviction.
      */
@@ -97,6 +105,7 @@ public class CachePolicy {
         this.targetUtilization = targetUtilization;
         this.maxUtilization = maxUtilization;
         this.evictionThreshold = (long) Math.floor(this.maxSize * this.targetUtilization);
+        this.criticalThreshold = (long) Math.floor(this.maxSize * this.maxUtilization);
         this.generationDuration = generationDuration;
         this.maxGenerations = Math.max(1, (int) ((double) maxTime.toMillis() / generationDuration.toMillis()));
     }
@@ -105,7 +114,7 @@ public class CachePolicy {
 
     @Override
     public String toString() {
-        return String.format("MaxSize = %d, UsableSize = %d, MaxGen = %d, Generation = %s",
-                this.maxSize, this.evictionThreshold, this.maxGenerations, this.generationDuration);
+        return String.format("MaxSize = %d, UsableSize = %d, CriticalSize = %d, MaxGen = %d, Generation = %s",
+                this.maxSize, this.evictionThreshold, this.criticalThreshold, this.maxGenerations, this.generationDuration);
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/CacheUtilizationProvider.java
@@ -9,13 +9,10 @@
  */
 package io.pravega.segmentstore.server;
 
-import io.pravega.common.Exceptions;
 import io.pravega.segmentstore.storage.ThrottleSourceListener;
-import java.util.ArrayList;
-import java.util.HashSet;
+import io.pravega.segmentstore.storage.ThrottlerSourceListenerCollection;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
-import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -30,8 +27,7 @@ public class CacheUtilizationProvider {
 
     private final CachePolicy policy;
     private final Supplier<Long> getCacheStoredBytes;
-    @GuardedBy("cleanupListeners")
-    private final HashSet<ThrottleSourceListener> cleanupListeners;
+    private final ThrottlerSourceListenerCollection cleanupListeners;
     private final AtomicLong pendingBytes;
     private final double utilizationSpread;
     private final double maxInsertCapacityThreshold;
@@ -49,7 +45,7 @@ public class CacheUtilizationProvider {
     CacheUtilizationProvider(@NonNull CachePolicy policy, @NonNull Supplier<Long> getCacheStoredBytes) {
         this.policy = policy;
         this.getCacheStoredBytes = getCacheStoredBytes;
-        this.cleanupListeners = new HashSet<>();
+        this.cleanupListeners = new ThrottlerSourceListenerCollection();
         this.pendingBytes = new AtomicLong();
         this.utilizationSpread = 2 * (policy.getMaxUtilization() - policy.getTargetUtilization());
         this.maxInsertCapacityThreshold = policy.getMaxUtilization() - this.utilizationSpread;
@@ -160,14 +156,7 @@ public class CacheUtilizationProvider {
      *                 run that detects {@link ThrottleSourceListener#isClosed()} to be true.
      */
     public void registerCleanupListener(@NonNull ThrottleSourceListener listener) {
-        if (listener.isClosed()) {
-            log.warn("Attempted to register a closed ThrottleSourceListener ({}).", listener);
-            return;
-        }
-
-        synchronized (this.cleanupListeners) {
-            this.cleanupListeners.add(listener); // This is a Set, so we won't be adding the same listener twice.
-        }
+        this.cleanupListeners.register(listener);
     }
 
     /**
@@ -175,31 +164,7 @@ public class CacheUtilizationProvider {
      * event has just completed.
      */
     void notifyCleanupListeners() {
-        ArrayList<ThrottleSourceListener> toNotify = new ArrayList<>();
-        ArrayList<ThrottleSourceListener> toRemove = new ArrayList<>();
-        synchronized (this.cleanupListeners) {
-            for (ThrottleSourceListener l : this.cleanupListeners) {
-                if (l.isClosed()) {
-                    toRemove.add(l);
-                } else {
-                    toNotify.add(l);
-                }
-            }
-
-            this.cleanupListeners.removeAll(toRemove);
-        }
-
-        for (ThrottleSourceListener l : toNotify) {
-            try {
-                l.notifyThrottleSourceChanged();
-            } catch (Throwable ex) {
-                if (Exceptions.mustRethrow(ex)) {
-                    throw ex;
-                }
-
-                log.error("Error while notifying cleanup listener {}.", l, ex);
-            }
-        }
+        this.cleanupListeners.notifySourceChanged();
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ReadIndex.java
@@ -126,6 +126,12 @@ public interface ReadIndex extends AutoCloseable {
     void cleanup(Collection<Long> segmentIds);
 
     /**
+     * Evicts all cache entries that are eligible for eviction. Only applicable in recovery mode.
+     * @throws IllegalStateException If the ReadIndex is not in recovery mode.
+     */
+    long trimCache();
+
+    /**
      * Puts the ReadIndex in Recovery Mode. Some operations may not be available in Recovery Mode.
      *
      * @param recoveryMetadataSource The Metadata Source to use. This Metadata must be in sync with the ReadIndex base

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterFlushResult.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterFlushResult.java
@@ -17,9 +17,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * Represents the result of a Storage Flush Operation.
  */
 public class WriterFlushResult {
-    private AtomicLong flushedBytes;
-    private AtomicLong mergedBytes;
-    private AtomicInteger flushedAttributes;
+    private final AtomicLong flushedBytes;
+    private final AtomicLong mergedBytes;
+    private final AtomicInteger flushedAttributes;
 
     /**
      * Creates a new instance of the WriterFlushResult class.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/attributes/SegmentAttributeBTreeIndex.java
@@ -105,6 +105,8 @@ class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.Client,
     private int currentCacheGeneration;
     @GuardedBy("cacheEntries")
     private final Map<Long, CacheEntry> cacheEntries;
+    @GuardedBy("cacheEntries")
+    private boolean cacheDisabled;
     @GuardedBy("pendingReads")
     private final Map<Long, PendingRead> pendingReads;
     private final BTreeIndex index;
@@ -148,6 +150,7 @@ class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.Client,
         this.cacheEntries = new HashMap<>();
         this.pendingReads = new HashMap<>();
         this.closed = new AtomicBoolean();
+        this.cacheDisabled = false;
     }
 
     /**
@@ -247,12 +250,14 @@ class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.Client,
     }
 
     @Override
-    public boolean updateGenerations(int currentGeneration, int oldestGeneration) {
+    public boolean updateGenerations(int currentGeneration, int oldestGeneration, boolean essentialOnly) {
         Exceptions.checkNotClosed(this.closed.get(), this);
 
         // Remove those entries that have a generation below the oldest permissible one.
         boolean anyRemoved;
         synchronized (this.cacheEntries) {
+            // All of our data are non-essential as we only cache BTreeIndex pages that are already durable persisted.
+            this.cacheDisabled = essentialOnly;
             this.currentCacheGeneration = currentGeneration;
             ArrayList<CacheEntry> toRemove = new ArrayList<>();
             for (val entry : this.cacheEntries.values()) {
@@ -356,6 +361,13 @@ class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.Client,
     @VisibleForTesting
     SegmentHandle getAttributeSegmentHandle() {
         return this.handle.get();
+    }
+
+    @VisibleForTesting
+    int getPendingReadCount() {
+        synchronized (this.pendingReads) {
+            return this.pendingReads.size();
+        }
     }
 
     @Override
@@ -714,6 +726,14 @@ class SegmentAttributeBTreeIndex implements AttributeIndex, CacheManager.Client,
         CacheEntry entry = this.cacheEntries.getOrDefault(entryOffset, null);
         if (entry != null && entry.getSize() == data.getLength()) {
             // Already cached.
+            return;
+        }
+
+        // All our cache entries are considered "non-essential" since they can always be reloaded from Storage. Do not
+        // try to insert/update them into the cache if such traffic is discouraged.
+        if (this.cacheDisabled) {
+            log.debug("{}: Cache update skipped for offset {}, length {}. Non-essential cache disabled.",
+                    this.traceObjectId, entryOffset, data.getLength());
             return;
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -18,6 +18,8 @@ import io.pravega.common.io.serialization.VersionedSerializer;
 import io.pravega.common.util.ImmutableDate;
 import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.ContainerException;
+import io.pravega.segmentstore.contracts.SegmentProperties;
+import io.pravega.segmentstore.contracts.SegmentType;
 import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.TooManyActiveSegmentsException;
@@ -41,10 +43,15 @@ import io.pravega.segmentstore.server.logs.operations.UpdateAttributesOperation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.NotThreadSafe;
+import lombok.Data;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -59,13 +66,14 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
     // region Members
 
     private static final MetadataCheckpointSerializer METADATA_CHECKPOINT_SERIALIZER = new MetadataCheckpointSerializer();
+    private static final MetadataCheckpointIncrementalDeserializer METADATA_CHECKPOINT_INCREMENTAL_DESERIALIZER = new MetadataCheckpointIncrementalDeserializer();
     private static final StorageCheckpointSerializer STORAGE_CHECKPOINT_SERIALIZER = new StorageCheckpointSerializer();
     /**
      * Pointer to the real (live) ContainerMetadata. Used when needing access to live information (such as Storage Info).
      */
     private final ContainerMetadata realMetadata;
     private final HashMap<Long, SegmentMetadataUpdateTransaction> segmentUpdates;
-    private final HashMap<Long, UpdateableSegmentMetadata> newSegments;
+    private final HashMap<Long, StreamSegmentMetadata> newSegments;
     private final HashMap<String, Long> newSegmentNames;
     private final List<Long> newTruncationPoints;
     @Getter
@@ -267,6 +275,23 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         resetNewSequenceNumber();
     }
 
+    private boolean isNewSegment(long segmentId) {
+        return this.newSegments.containsKey(segmentId);
+    }
+
+    private void removeNewSegment(long segmentId) {
+        assert isRecoveryMode();
+        val sm = this.newSegments.remove(segmentId);
+        if (sm != null) {
+            sm.markInactive();
+            this.newSegmentNames.remove(sm.getName());
+            val ut = this.segmentUpdates.remove(segmentId);
+            if (ut != null) {
+                ut.setActive(false);
+            }
+        }
+    }
+
     private void resetNewSequenceNumber() {
         if (this.baseMetadata.isRecoveryMode()) {
             this.newSequenceNumber = ContainerMetadata.INITIAL_OPERATION_SEQUENCE_NUMBER;
@@ -396,22 +421,25 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                 // metadata is serialized in this operation. We need to discard whatever we have accumulated so far
                 // and rebuild the metadata from the information we have so far.
                 if (this.processedCheckpoint) {
+                    // A MetadataCheckpoint should be processed fully only if is the first checkpoint encountered.
+                    // Any subsequent MetadataCheckpoints should be partially processed and applied.
                     // But we can (should) only process at most one MetadataCheckpoint per recovery. Any additional
                     // ones are redundant (used just for Truncation purposes) and contain the same information as
                     // if we processed every operation in order, up to them.
-                    log.debug("MetadataUpdate[{}-{}}]: Skipping MetadataCheckpointOperation with SequenceNumber {} because we already have metadata changes.",
-                            this.containerId, this.transactionId, operation.getSequenceNumber());
-                    return;
-                }
+                    log.info("MetadataUpdate[{}]: Recovering MetadataCheckpointOperation({}) and applying incrementally.",
+                            this.containerId, operation.getSequenceNumber());
+                    METADATA_CHECKPOINT_INCREMENTAL_DESERIALIZER.deserialize(operation.getContents(), this);
+                } else {
+                    log.info("MetadataUpdate[{}]: Recovering MetadataCheckpointOperation({}).",
+                            this.containerId, operation.getSequenceNumber());
+                    clear();
 
-                log.info("MetadataUpdate[{}-{}}]: Recovering MetadataCheckpointOperation with SequenceNumber {}.",
-                        this.containerId, this.transactionId, operation.getSequenceNumber());
-                clear();
+                    METADATA_CHECKPOINT_SERIALIZER.deserialize(operation.getContents(), this);
+                    this.processedCheckpoint = true;
+                }
 
                 // This is not retrieved from serialization, but rather from the operation itself.
                 setOperationSequenceNumber(operation.getSequenceNumber());
-                METADATA_CHECKPOINT_SERIALIZER.deserialize(operation.getContents(), this);
-                this.processedCheckpoint = true;
             } else {
                 // In non-Recovery Mode, a MetadataCheckpointOperation means we need to serialize the current state of
                 // the Metadata, both the base Container Metadata and the current Transaction.
@@ -567,13 +595,13 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
      * Creates a new UpdateableSegmentMetadata for the given Segment and registers it.
      */
     private UpdateableSegmentMetadata createSegmentMetadata(String segmentName, long segmentId) {
-        UpdateableSegmentMetadata metadata = new StreamSegmentMetadata(segmentName, segmentId, this.containerId);
+        StreamSegmentMetadata metadata = new StreamSegmentMetadata(segmentName, segmentId, this.containerId);
         this.newSegments.put(metadata.getId(), metadata);
         this.newSegmentNames.put(metadata.getName(), metadata.getId());
         return metadata;
     }
 
-    private void copySegmentMetadata(Collection<UpdateableSegmentMetadata> newSegments, UpdateableContainerMetadata target) {
+    private void copySegmentMetadata(Collection<StreamSegmentMetadata> newSegments, UpdateableContainerMetadata target) {
         for (SegmentMetadata newMetadata : newSegments) {
             // Update real metadata with all the information from the new metadata.
             UpdateableSegmentMetadata existingMetadata = target.mapStreamSegmentId(newMetadata.getName(), newMetadata.getId());
@@ -647,7 +675,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
             version(0).revision(0, this::write00, this::read00);
         }
 
-        private void write00(ContainerMetadataUpdateTransaction t, RevisionDataOutput output) throws IOException {
+        protected void write00(ContainerMetadataUpdateTransaction t, RevisionDataOutput output) throws IOException {
             // Intentionally skipping over the Sequence Number. There is no need for that here; it will be set on the
             // operation anyway when it gets serialized.
             output.writeCompactInt(t.containerId);
@@ -675,7 +703,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                 throw new SerializationException(String.format("Invalid ContainerId. Expected '%d', actual '%d'.", t.containerId, containerId));
             }
 
-            input.readCollection(s -> readSegmentMetadata00(s, t));
+            Collection<UpdateableSegmentMetadata> checkpointMetadata = input.readCollection(s -> readSegmentMetadata00(s, t));
+            postRead(checkpointMetadata, t);
         }
 
         private void writeSegmentMetadata00(RevisionDataOutput output, SegmentMetadata sm) throws IOException {
@@ -699,7 +728,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
             long segmentId = input.readLong();
             String name = input.readUTF();
 
-            UpdateableSegmentMetadata metadata = t.getOrCreateSegmentUpdateTransaction(name, segmentId);
+            UpdateableSegmentMetadata metadata = getSegmentMetadata(name, segmentId, t);
 
             metadata.setLength(input.readLong());
             metadata.setStorageLength(input.readLong());
@@ -735,6 +764,190 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
             val attributes = input.readMap(RevisionDataInput::readUUID, RevisionDataInput::readLong);
             metadata.updateAttributes(attributes);
             return metadata;
+        }
+
+        protected UpdateableSegmentMetadata getSegmentMetadata(String name, long segmentId, ContainerMetadataUpdateTransaction t) {
+            return t.getOrCreateSegmentUpdateTransaction(name, segmentId);
+        }
+
+        protected void postRead(Collection<UpdateableSegmentMetadata> checkpointMetadata, ContainerMetadataUpdateTransaction t) {
+            // This method intentionally left blank. Will be overridden in derived classes.
+        }
+    }
+
+    //endregion
+
+    //region MetadataCheckpointPartialDeserializer
+
+    private static class MetadataCheckpointIncrementalDeserializer extends MetadataCheckpointSerializer {
+        @Override
+        protected void write00(ContainerMetadataUpdateTransaction t, RevisionDataOutput output) {
+            throw new UnsupportedOperationException("MetadataCheckpointPartialDeserializer may not be used for serialization.");
+        }
+
+        @Override
+        protected UpdateableSegmentMetadata getSegmentMetadata(String name, long segmentId, ContainerMetadataUpdateTransaction t) {
+            return new PartialSegmentMetadata(name, segmentId);
+        }
+
+        @Override
+        protected void postRead(Collection<UpdateableSegmentMetadata> checkpointMetadata, ContainerMetadataUpdateTransaction t) {
+            Preconditions.checkState(t.isRecoveryMode(), "MetadataCheckpointPartialDeserializer can only be used in recovery mode.");
+
+            // Index checkpointed metadata by segment id.
+            val byId = checkpointMetadata.stream().collect(Collectors.toMap(SegmentMetadata::getId, m -> m));
+
+            // Update any segment that we encountered. This includes unregistering a missing segment (eviction) or updating
+            // its storage state as necessary.
+            for (val segmentId : t.getAllStreamSegmentIds()) {
+                val m = byId.getOrDefault(segmentId, null);
+                if (m == null) {
+                    val existingMetadata = t.getStreamSegmentMetadata(segmentId);
+                    if (t.isNewSegment(segmentId) && existingMetadata != null && canUnregister(existingMetadata)) {
+                        // This segment existed in our Update Transaction/Base Metadata, however this checkpoint no longer has it.
+                        // This means that the segment has been evicted at one point between the last checkpoint and this one,
+                        // so it should be safe to remove it from our list (if possible).
+                        log.debug("MetadataUpdate[{}]: Un-mapping Segment Id '%s' because it is no longer present in a MetadataCheckpoint.", t.containerId);
+                        t.removeNewSegment(segmentId);
+                    }
+                } else {
+                    // Update segment's state with latest info.
+                    val segmentUpdate = t.getOrCreateSegmentUpdateTransaction(m.getName(), m.getId());
+                    if (m.isSealedInStorage()) {
+                        segmentUpdate.markSealed();
+                    }
+
+                    if (m.isDeletedInStorage()) {
+                        segmentUpdate.markDeleted();
+                    }
+
+                    segmentUpdate.updateStorageState(m.getStorageLength(), m.isSealedInStorage(), m.isDeleted(), m.isDeletedInStorage());
+                }
+            }
+        }
+
+        private boolean canUnregister(SegmentMetadata existingMetadata) {
+            return existingMetadata.isDeleted()
+                    || existingMetadata.getStorageLength() >= existingMetadata.getLength();
+        }
+
+        @Data
+        private static class PartialSegmentMetadata implements UpdateableSegmentMetadata {
+            private final String name;
+            private final long id;
+            private long storageLength;
+            private long startOffset;
+            private long length;
+            private boolean sealed;
+            private boolean sealedInStorage;
+            private boolean deleted;
+            private boolean deletedInStorage;
+            private boolean merged;
+
+            @Override
+            public void markSealed() {
+                this.sealed = true;
+            }
+
+            @Override
+            public void markSealedInStorage() {
+                this.sealedInStorage = true;
+            }
+
+            @Override
+            public void markDeleted() {
+                this.deleted = true;
+            }
+
+            @Override
+            public void markDeletedInStorage() {
+                this.deletedInStorage = true;
+            }
+
+            @Override
+            public void markMerged() {
+                this.merged = true;
+            }
+
+            // region Unimplemented methods
+
+            @Override
+            public boolean isActive() {
+                return true;
+            }
+
+            @Override
+            public void updateAttributes(Map<UUID, Long> attributeValues) {
+                // Not relevant here.
+            }
+
+            @Override
+            public void setLastModified(ImmutableDate date) {
+                // Not relevant here.
+            }
+
+            @Override
+            public void copyFrom(SegmentMetadata other) {
+                throw new UnsupportedOperationException("copyFrom not supported on " + PartialSegmentMetadata.class.getSimpleName());
+            }
+
+            @Override
+            public void refreshType() {
+                // Not relevant here.
+            }
+
+            @Override
+            public int getContainerId() {
+                return -1;
+            }
+
+
+            @Override
+            public long getLastUsed() {
+                return 0;
+            }
+
+            @Override
+            public void setLastUsed(long value) {
+                // Not relevant here.
+            }
+
+            @Override
+            public SegmentProperties getSnapshot() {
+                return this;
+            }
+
+            @Override
+            public void markPinned() {
+                // Not relevant here.
+            }
+
+            @Override
+            public boolean isPinned() {
+                return false;
+            }
+
+            @Override
+            public ImmutableDate getLastModified() {
+                return null;
+            }
+
+            @Override
+            public Map<UUID, Long> getAttributes() {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public Map<UUID, Long> getAttributes(BiPredicate<UUID, Long> filter) {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public SegmentType getType() {
+                return null;
+            }
+
+            //endregion
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -319,7 +319,7 @@ public class DurableLog extends AbstractService implements OperationLog {
         // Before we do any real truncation, we need to mini-snapshot the metadata with only those fields that are updated
         // asynchronously for us (i.e., not via normal Log Operations) such as the Storage State. That ensures that this
         // info will be readily available upon recovery without delay.
-        return add(new StorageMetadataCheckpointOperation(), OperationPriority.High, timer.getRemaining())
+        return add(new StorageMetadataCheckpointOperation(), OperationPriority.SystemCritical, timer.getRemaining())
                 .thenComposeAsync(v -> this.durableDataLog.truncate(truncationFrameAddress, timer.getRemaining()), this.executor)
                 .thenRunAsync(() -> this.metadata.removeTruncationMarkers(actualTruncationSequenceNumber), this.executor);
     }
@@ -329,9 +329,9 @@ public class DurableLog extends AbstractService implements OperationLog {
         log.debug("{}: Queuing MetadataCheckpointOperation.", this.traceObjectId);
         MetadataCheckpointOperation op = new MetadataCheckpointOperation();
         return this.operationProcessor
-                .process(op, OperationPriority.Normal)
+                .process(op, OperationPriority.SystemCritical)
                 .thenApply(v -> {
-                    log.info("{}: MetadataCheckpointOperation durably stored.", this.traceObjectId);
+                    log.info("{}: MetadataCheckpointOperation({}) stored.", this.traceObjectId, op.getSequenceNumber());
                     return op.getSequenceNumber();
                 });
     }
@@ -342,9 +342,12 @@ public class DurableLog extends AbstractService implements OperationLog {
         log.debug("{}: Read (MaxCount = {}, Timeout = {}).", this.traceObjectId, maxCount, timeout);
         CompletableFuture<Queue<Operation>> result = this.inMemoryOperationLog.take(maxCount, timeout, this.executor);
         result.thenAccept(r -> {
-            int size = r.size();
+            final int size = r.size();
             this.operationProcessor.getMetrics().operationLogRead(size);
-            log.debug("{}: ReadResult (Count = {}).", this.traceObjectId, size);
+            log.debug("{}: ReadResult (Count = {}, Remaining = {}).", this.traceObjectId, size, this.inMemoryOperationLog.size());
+            if (size > 0) {
+                this.memoryStateUpdater.notifyLogRead();
+            }
         });
         return result;
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
@@ -24,12 +24,15 @@ import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
+import io.pravega.segmentstore.storage.ThrottlerSourceListenerCollection;
 import io.pravega.segmentstore.storage.cache.CacheFullException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.ThreadSafe;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -43,6 +46,7 @@ class MemoryStateUpdater {
     private final ReadIndex readIndex;
     private final AbstractDrainingQueue<Operation> inMemoryOperationLog;
     private final AtomicBoolean recoveryMode;
+    private final ThrottlerSourceListenerCollection readListeners;
 
     //endregion
 
@@ -58,11 +62,32 @@ class MemoryStateUpdater {
         this.inMemoryOperationLog = Preconditions.checkNotNull(inMemoryOperationLog, "inMemoryOperationLog");
         this.readIndex = Preconditions.checkNotNull(readIndex, "readIndex");
         this.recoveryMode = new AtomicBoolean();
+        this.readListeners = new ThrottlerSourceListenerCollection();
     }
 
     //endregion
 
     //region Operations
+
+    /**
+     * Registers a {@link ThrottleSourceListener} that will be notified on every Operation Log read.
+     *
+     * @param listener The {@link ThrottleSourceListener} to register.
+     */
+    void registerReadListener(@NonNull ThrottleSourceListener listener) {
+        this.readListeners.register(listener);
+    }
+
+    /**
+     * Notifies all registered {@link ThrottleSourceListener} that an Operation Log read has been truncated.
+     */
+    void notifyLogRead() {
+        this.readListeners.notifySourceChanged();
+    }
+
+    public int getInMemoryOperationLogSize() {
+        return this.inMemoryOperationLog.size();
+    }
 
     /**
      * Gets the {@link CacheUtilizationProvider} shared across all Segment Containers hosted in this process that can
@@ -93,6 +118,16 @@ class MemoryStateUpdater {
     void exitRecoveryMode(boolean successfulRecovery) throws DataCorruptionException {
         this.readIndex.exitRecoveryMode(successfulRecovery);
         this.recoveryMode.set(false);
+    }
+
+    /**
+     * Performs a cleanup of the {@link ReadIndex} by releasing resources allocated for segments that are no longer active
+     * and trimming to cache to the minimum essential.
+     */
+    void cleanupReadIndex() {
+        Preconditions.checkState(this.recoveryMode.get(), "cleanupReadIndex can only be performed in recovery mode.");
+        this.readIndex.cleanup(null);
+        this.readIndex.trimCache();
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -108,10 +108,12 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
                 .cacheThrottler(this.cacheUtilizationProvider::getCacheUtilization, this.cacheUtilizationProvider.getCacheTargetUtilization(), this.cacheUtilizationProvider.getCacheMaxUtilization())
                 .batchingThrottler(durableDataLog::getQueueStatistics)
                 .durableDataLogThrottler(durableDataLog.getWriteSettings(), durableDataLog::getQueueStatistics)
+                .operationLogThrottler(this.stateUpdater::getInMemoryOperationLogSize)
                 .build();
         this.throttler = new Throttler(this.metadata.getContainerId(), throttlerCalculator, this::hasThrottleExemptOperations, executor, this.metrics);
         this.cacheUtilizationProvider.registerCleanupListener(this.throttler);
         durableDataLog.registerQueueStateChangeListener(this.throttler);
+        this.stateUpdater.registerReadListener(this.throttler);
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/RecoveryProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/RecoveryProcessor.java
@@ -17,6 +17,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.SegmentStoreMetrics;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
+import io.pravega.segmentstore.server.logs.operations.CheckpointOperationBase;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.OperationSerializer;
@@ -187,6 +188,11 @@ class RecoveryProcessor {
 
         // Update in-memory structures.
         this.stateUpdater.process(operation);
+
+        // Perform necessary read index cleanups if possible.
+        if (operation instanceof CheckpointOperationBase) {
+            this.stateUpdater.cleanupReadIndex();
+        }
     }
 
     private void recordTruncationMarker(DataFrameRecord<Operation> dataFrameRecord) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import java.util.function.BiPredicate;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * An update transaction that can apply changes to a SegmentMetadata.
@@ -79,6 +80,9 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
     @Getter
     private long lastUsed;
     private boolean isChanged;
+    @Getter
+    @Setter
+    private boolean active;
 
     //endregion
 
@@ -108,6 +112,7 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
         this.baseAttributeValues = baseMetadata.getAttributes();
         this.attributeUpdates = new HashMap<>();
         this.lastUsed = baseMetadata.getLastUsed();
+        this.active = true;
     }
 
     //endregion
@@ -126,11 +131,6 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
     @Override
     public long getStorageLength() {
         return this.storageLength < 0 ? this.baseStorageLength : this.storageLength;
-    }
-
-    @Override
-    public boolean isActive() {
-        return true;
     }
 
     @Override
@@ -685,6 +685,7 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
                 "Target Segment Id mismatch. Expected %s, given %s.", this.id, target.getId());
         Preconditions.checkArgument(target.getName().equals(this.name),
                 "Target Segment Name mismatch. Expected %s, given %s.", name, target.getName());
+        Preconditions.checkState(isActive(), "Cannot apply changes for an inactive segment. Segment Id = %s, Segment Name = '%s'.", this.id, this.name);
 
         // Apply to base metadata.
         target.setLastUsed(this.lastUsed);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
@@ -186,8 +186,7 @@ class Throttler implements ThrottleSourceListener, AutoCloseable {
     }
 
     private boolean isInterruptible(ThrottlerCalculator.ThrottlerName name) {
-        return name == ThrottlerCalculator.ThrottlerName.Cache
-                || name == ThrottlerCalculator.ThrottlerName.DurableDataLog;
+        return name != null && name.isInterruptible();
     }
 
     @VisibleForTesting

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ThrottlerCalculator.java
@@ -65,6 +65,16 @@ class ThrottlerCalculator {
      */
     @VisibleForTesting
     static final double DURABLE_DATALOG_THROTTLE_THRESHOLD_FRACTION = 0.1;
+    /**
+     * Maximum size (in number of operations) of the OperationLog, above which maximum throttling will be applied.
+     */
+    @VisibleForTesting
+    static final int OPERATION_LOG_MAX_SIZE = 1_000_000;
+    /**
+     * Desired size (in number of operations) of the OperationLog, above which a gradual throttling will begin.
+     */
+    @VisibleForTesting
+    static final int OPERATION_LOG_TARGET_SIZE = (int) (OPERATION_LOG_MAX_SIZE * 0.95);
     @Singular
     private final List<Throttler> throttlers;
 
@@ -287,6 +297,40 @@ class ThrottlerCalculator {
         }
     }
 
+    /**
+     * Calculates the amount of time to wait before processing more operations from the queue in order to relieve pressure
+     * from the OperationLog. This is based solely on the number of operations accumulated in the OperationLog.
+     */
+    @RequiredArgsConstructor
+    private static class OperationLogThrottler extends Throttler {
+        private static final double SIZE_SPAN = OPERATION_LOG_MAX_SIZE - OPERATION_LOG_TARGET_SIZE;
+        @NonNull
+        private final Supplier<Integer> getOperationLogSize;
+
+        @Override
+        boolean isThrottlingRequired() {
+            return this.getOperationLogSize.get() > OPERATION_LOG_TARGET_SIZE;
+        }
+
+        @Override
+        int getDelayMillis() {
+            // We only throttle if we exceed the target log size. We increase the throttling amount in a linear fashion.
+            int size = this.getOperationLogSize.get();
+            if (size <= OPERATION_LOG_TARGET_SIZE) {
+                return 0;
+            } else if (size >= OPERATION_LOG_MAX_SIZE) {
+                return MAX_DELAY_MILLIS;
+            } else {
+                return (int) (MAX_DELAY_MILLIS * (this.getOperationLogSize.get() - OPERATION_LOG_TARGET_SIZE) / SIZE_SPAN);
+            }
+        }
+
+        @Override
+        ThrottlerName getName() {
+            return ThrottlerName.OperationLog;
+        }
+    }
+
     //endregion
 
     //region Builder
@@ -321,6 +365,10 @@ class ThrottlerCalculator {
 
         ThrottlerCalculatorBuilder durableDataLogThrottler(WriteSettings writeSettings, Supplier<QueueStats> getQueueStats) {
             return throttler(new DurableDataLogThrottler(writeSettings, getQueueStats));
+        }
+
+        ThrottlerCalculatorBuilder operationLogThrottler(Supplier<Integer> getDurableLogSize) {
+            return throttler(new OperationLogThrottler(getDurableLogSize));
         }
     }
 
@@ -371,19 +419,28 @@ class ThrottlerCalculator {
     /**
      * Defines Throttler Names.
      */
+    @Getter
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     enum ThrottlerName {
         /**
          * Throttling is required in order to aggregate multiple operations together in a single write.
          */
-        Batching,
+        Batching(false),
         /**
          * Throttling is required due to excessive Cache utilization.
          */
-        Cache,
+        Cache(true),
         /**
          * Throttling is required due to excessive size of DurableDataLog's in-flight queue.
          */
-        DurableDataLog,
+        DurableDataLog(true),
+        /**
+         * Throttling is required due to excessive accumulated Operations in OperationLog (not yet truncated).
+         */
+        OperationLog(true);
+
+        @Getter
+        private final boolean interruptible;
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultHandler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultHandler.java
@@ -9,9 +9,9 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.ReadResultEntry;
 import io.pravega.segmentstore.contracts.ReadResultEntryType;
-
 import java.time.Duration;
 
 /**
@@ -61,4 +61,14 @@ public interface AsyncReadResultHandler {
      * @return The timeout.
      */
     Duration getRequestContentTimeout();
+
+    /**
+     * Gets a value indicating the maximum number of bytes to process at any time. See {@link ReadResult#getMaxReadAtOnce()}.
+     *
+     * @return The maximum number of bytes to process at any time. Default value is {@link Integer#MAX_VALUE}, which
+     * means the underlying read result has absolute freedom in choosing the read size.
+     */
+    default int getMaxReadAtOnce() {
+        return Integer.MAX_VALUE;
+    }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/AsyncReadResultProcessor.java
@@ -66,6 +66,7 @@ public class AsyncReadResultProcessor implements AutoCloseable {
         this.readResult = readResult;
         this.entryHandler = entryHandler;
         this.closed = new AtomicBoolean();
+        this.readResult.setMaxReadAtOnce(this.entryHandler.getMaxReadAtOnce());
     }
 
     /**
@@ -141,6 +142,7 @@ public class AsyncReadResultProcessor implements AutoCloseable {
                         resultEntry -> {
                             if (resultEntry != null) {
                                 shouldContinue.set(this.entryHandler.processEntry(resultEntry));
+                                this.readResult.setMaxReadAtOnce(this.entryHandler.getMaxReadAtOnce());
                             }
                         },
                         executor)

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexSummary.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/ReadIndexSummary.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.reading;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.pravega.segmentstore.server.CacheManager;
 import java.util.HashMap;
@@ -105,5 +106,10 @@ class ReadIndexSummary {
      */
     synchronized CacheManager.CacheStatus toCacheStatus() {
         return CacheManager.CacheStatus.fromGenerations(this.generations.keySet().iterator());
+    }
+
+    @VisibleForTesting
+    synchronized int size() {
+        return this.generations.values().stream().mapToInt(i -> i).sum();
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -44,6 +44,8 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
@@ -71,10 +73,13 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     @GuardedBy("lock")
     private final HashMap<Long, PendingMerge> pendingMergers; //Key = Source Segment Id, Value = Pending Merge Info.
     private final StorageReadManager storageReadManager;
+    @VisibleForTesting
+    @Getter(AccessLevel.PACKAGE)
     private final ReadIndexSummary summary;
     private final ScheduledExecutorService executor;
     private SegmentMetadata metadata;
     private final AtomicLong lastAppendedOffset;
+    private volatile boolean storageCacheDisabled; // True (Disabled): No Storage inserts; False (Enabled): all cache inserts.
     private boolean recoveryMode;
     private boolean closed;
     private boolean merged;
@@ -117,6 +122,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         this.executor = executor;
         this.summary = new ReadIndexSummary();
         this.storageReadAlignment = alignToCacheBlockSize(this.config.getStorageReadAlignment());
+        this.storageCacheDisabled = false;
     }
 
     private int alignToCacheBlockSize(int value) {
@@ -211,8 +217,12 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     }
 
     @Override
-    public boolean updateGenerations(int currentGeneration, int oldestGeneration) {
+    public boolean updateGenerations(int currentGeneration, int oldestGeneration, boolean essentialOnly) {
         Exceptions.checkNotClosed(this.closed, this);
+
+        // If we are told that only essential cache entries must be inserted, then we need to disable Storage read
+        // cache inserts (as we can always re-read that data from Storage).
+        this.storageCacheDisabled = essentialOnly;
 
         // Update the current generation with the provided info.
         this.summary.setCurrentGeneration(currentGeneration);
@@ -523,6 +533,11 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     }
 
     private void insert(long offset, ByteArraySegment data) {
+        if (this.storageCacheDisabled) {
+            log.debug("{}: Not inserting (Offset = {}, Length = {}) due to Storage Cache disabled.", this.traceObjectId, offset, data.getLength());
+            return;
+        }
+
         log.debug("{}: Insert (Offset = {}, Length = {}).", this.traceObjectId, offset, data.getLength());
 
         // There is a very small chance we might be adding data twice, if we get two concurrent requests that slipped past

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyCache.java
@@ -87,7 +87,7 @@ class ContainerKeyCache implements CacheManager.Client, AutoCloseable {
     }
 
     @Override
-    public boolean updateGenerations(int currentGeneration, int oldestGeneration) {
+    public boolean updateGenerations(int currentGeneration, int oldestGeneration, boolean essentialOnly) {
         Exceptions.checkNotClosed(this.closed.get(), this);
 
         // Instruct each Segment Cache to perform its own cache management, collect eviction candidates, and remove them
@@ -96,6 +96,7 @@ class ContainerKeyCache implements CacheManager.Client, AutoCloseable {
         synchronized (this.segmentCaches) {
             this.currentCacheGeneration = currentGeneration;
             for (SegmentKeyCache segmentCache : this.segmentCaches.values()) {
+                segmentCache.setEssentialCacheOnly(essentialOnly);
                 evictions.addAll(segmentCache.evictBefore(oldestGeneration));
             }
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/SegmentKeyCache.java
@@ -211,18 +211,19 @@ class SegmentKeyCache {
         }
 
         // Update the cache entry directly.
-        entry.update(keyHash, segmentOffset, generation);
+        if (!entry.update(keyHash, segmentOffset, generation)) {
+            evictEntry(entry);
+
+        }
         return segmentOffset;
     }
 
-    private synchronized void entryUpdateFailed(CacheEntry entry, Throwable ex) {
-        if (ex instanceof CacheDisabledException) {
-            log.debug("{}: Not updating cache for {} due to non-essential cache entries disabled.", this.segmentId, entry);
-        } else {
-            log.warn("{}: Cache Entry update failed for {}. Unregistering.", this.segmentId, entry, ex);
+    private void evictEntry(CacheEntry entry) {
+        synchronized (this) {
+            this.cacheEntries.remove(entry.hashGroup);
         }
-        this.cacheEntries.remove(entry.hashGroup);
-        entry.evict();
+
+        entry.evict(); // This need not be invoked while holding the lock (it has its own synchronization).
     }
 
     /**
@@ -280,11 +281,19 @@ class SegmentKeyCache {
             }
         }
 
-        candidates.forEach(mc -> mc.commit(cacheGeneration));
+        candidates.forEach(mc -> commitMigrationCandidate(mc, cacheGeneration));
         synchronized (this) {
             // Finally, remove tail hashes, but ONLY if they haven't changed - it's possible that since we released the lock
             // above a newer value was recorded; we shouldn't be removing it then. We use Map.remove(Key, Value) for this.
             candidates.forEach(c -> this.tailOffsets.remove(c.keyHash, c.offset));
+        }
+    }
+
+    private void commitMigrationCandidate(MigrationCandidate mc, int cacheGeneration) {
+        if (!mc.commit(cacheGeneration)) {
+            // If we were unable to commit a migration candidate, we should evict it. It likely is in an inconsistent state.
+            // This is safe to do since any data in this entry can be reloaded from the index.
+            evictEntry(mc.cacheEntry);
         }
     }
 
@@ -350,8 +359,7 @@ class SegmentKeyCache {
          */
         boolean commit(int cacheGeneration) {
             try {
-                this.cacheEntry.update(this.keyHash, this.offset.encode(), cacheGeneration);
-                return true;
+                return this.cacheEntry.update(this.keyHash, this.offset.encode(), cacheGeneration);
             } catch (CacheEntryEvictedException ex) {
                 // Nothing to do here. A concurrent eviction has removed this entry so there isn't much more we can do.
                 return false;
@@ -376,10 +384,8 @@ class SegmentKeyCache {
         private static final int INITIAL_ADDRESS = -1;
         private static final int EVICTED_ADDRESS = -2;
         private final short hashGroup;
-        @GuardedBy("this")
-        private int generation;
-        @GuardedBy("this")
-        private long highestOffset;
+        private volatile int generation;
+        private volatile long highestOffset;
         @GuardedBy("this")
         private int cacheAddress;
 
@@ -394,14 +400,14 @@ class SegmentKeyCache {
          * Gets a value representing the current Generation of this Cache Entry. This value is updated every time the
          * data behind this entry is modified or accessed.
          */
-        synchronized int getGeneration() {
+        int getGeneration() {
             return this.generation;
         }
 
         /**
          * Gets a value representing the Highest offset that is stored in any CacheValues in this CacheEntry.
          */
-        synchronized long getHighestOffset() {
+        long getHighestOffset() {
             return this.highestOffset;
         }
 
@@ -418,11 +424,8 @@ class SegmentKeyCache {
             int offset = locate(keyHash, data);
             if (offset >= 0) {
                 // Found it.
-                synchronized (this) {
-                    // Update Entry's generation.
-                    this.generation = currentGeneration;
-                }
-
+                // Update Entry's generation.
+                this.generation = currentGeneration;
                 return data.getLong(offset);
             }
 
@@ -438,7 +441,7 @@ class SegmentKeyCache {
          * @param segmentOffset     See {@link ContainerKeyCache#includeExistingKey} segmentOffset.
          * @param currentGeneration The current Cache Generation (from the Cache Manager).
          */
-        synchronized void update(UUID keyHash, long segmentOffset, int currentGeneration) {
+        synchronized boolean update(UUID keyHash, long segmentOffset, int currentGeneration) {
             ArrayView entryData = getFromCache();
             int entryOffset = locate(keyHash, entryData);
             if (entryOffset < 0) {
@@ -472,10 +475,16 @@ class SegmentKeyCache {
             } catch (CacheEntryEvictedException cex) {
                 // Pass-through exception. If this is the case, the entry has already been evicted so not more we can do.
                 throw cex;
+            } catch (CacheDisabledException cex) {
+                log.debug("SegmentKeyCache[{}]: Not updating cache for {} due to non-essential cache entries disabled.", segmentId, this);
+                return false;
             } catch (Throwable ex) {
                 // There is nothing we can do here. Invoke the general handler to remove this from the cache.
-                entryUpdateFailed(this, ex);
+                log.warn("SegmentKeyCache[{}]: Cache Entry update failed for {}.", segmentId, this, ex);
+                return false;
             }
+
+            return true;
         }
 
         /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
@@ -156,6 +156,10 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
     @Override
     public CompletableFuture<WriterFlushResult> flush(boolean force, Duration timeout) {
         Exceptions.checkNotClosed(this.closed.get(), this);
+        if (!force && !mustFlush()) {
+            return CompletableFuture.completedFuture(new WriterFlushResult());
+        }
+
         TimeoutTimer timer = new TimeoutTimer(timeout);
         return this.connector
                 .getSegment(timer.getRemaining())

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/CacheManagerTests.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import lombok.Cleanup;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -138,7 +138,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
 
                 // Fail the test if we get an unexpected value for currentGeneration.
                 clients.forEach(c ->
-                        c.setUpdateGenerationsImpl((current, oldest) -> {
+                        c.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> {
                             Assert.assertEquals("Unexpected value for current generation.", currentGeneration.get(), (int) current);
                             updatedClients.add(c);
                             return false;
@@ -149,7 +149,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
             } else {
                 // Non-active cycle: each client will declare that they had no activity in the last generation.
                 clients.forEach(c ->
-                        c.setUpdateGenerationsImpl((current, oldest) -> {
+                        c.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> {
                             updatedClients.add(c);
                             return false;
                         }));
@@ -171,7 +171,6 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
      * Tests the ability to increment the oldest generation (or not) based on the activity of the clients.
      */
     @Test
-    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     public void testIncrementOldestGeneration() {
         final int cycleCount = 12345;
         final int defaultOldestGeneration = 0;
@@ -197,7 +196,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         AtomicInteger currentGeneration = new AtomicInteger();
         for (int cycleId = 0; cycleId < cycleCount * 3; cycleId++) {
             client.setCacheStatus(0, currentGeneration.get());
-            client.setUpdateGenerationsImpl((current, oldest) -> false);
+            client.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> false);
             cm.applyCachePolicy();
             currentGeneration.incrementAndGet();
         }
@@ -214,7 +213,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
                 // the cache is within limits or no change can be made.
                 cache.setUsedBytes(policy.getEvictionThreshold() + excess);
                 client.setCacheStatus(currentOldestGeneration.get(), currentGeneration.get());
-                client.setUpdateGenerationsImpl((current, oldest) -> {
+                client.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> {
                     AssertExtensions.assertGreaterThan("Expected an increase in oldestGeneration.", currentOldestGeneration.get(), oldest);
                     currentOldestGeneration.set(oldest);
                     callCount.incrementAndGet();
@@ -231,7 +230,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
                 cache.setStoredBytes(policy.getEvictionThreshold() - 1);
                 cache.setUsedBytes(policy.getEvictionThreshold() - 1);
                 client.setCacheStatus(defaultOldestGeneration, currentGeneration.get());
-                client.setUpdateGenerationsImpl((current, oldest) -> {
+                client.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> {
                     Assert.assertEquals("Not expecting a change for oldestGeneration", currentOldestGeneration.get(), (int) oldest);
                     return false;
                 });
@@ -255,6 +254,81 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
                     expectedCallCount,
                     callCount.get());
         }
+    }
+
+    /**
+     * Tests the ability to adjust the "Non-Essential Only" flags based on cache utilization.
+     */
+    @Test
+    public void testNonEssentialOnly() {
+        final int maxSize = 100;
+        final double targetUtilization = 0.5;
+        final double maxUtilization = 0.9;
+        final CachePolicy policy = new CachePolicy(maxSize, targetUtilization, maxUtilization, Duration.ofHours(10000), Duration.ofHours(1));
+        @Cleanup
+        val cache = new TestCache(policy.getMaxSize());
+        cache.setStoredBytes(1); // The Cache Manager won't do anything if there's no stored data.
+        @Cleanup
+        TestCacheManager cm = new TestCacheManager(policy, cache, executorService());
+
+        TestClient client = new TestClient();
+        cm.register(client);
+        client.setCacheStatus(0, 0);
+        val essentialOnly = new AtomicBoolean(false);
+        val essentialCount = new AtomicInteger(0);
+        val nonEssentialCount = new AtomicInteger(0);
+        val changeNewGen = new AtomicBoolean();
+        val changeOldGen = new AtomicBoolean();
+        client.setUpdateGenerationsImpl((current, oldest, essential) -> {
+            essentialOnly.set(essential);
+            Assert.assertEquals("Essential flag passed to client is different from actual state.", essential, cm.isEssentialEntriesOnly());
+            if (essential) {
+                essentialCount.incrementAndGet();
+            } else {
+                nonEssentialCount.incrementAndGet();
+            }
+
+            // Change the client's old gen and new gen alternatively.
+            if (changeNewGen.get()) {
+                int og = client.getCacheStatus().getOldestGeneration();
+                if (changeOldGen.get()) {
+                    og++;
+                }
+                changeOldGen.set(!changeOldGen.get());
+                client.setCacheStatus(og, current);
+            }
+            changeNewGen.set(!changeNewGen.get());
+            return !changeNewGen.get();
+        });
+
+        val isExpected = new Supplier<Boolean>() {
+            @Override
+            public Boolean get() {
+                return cache.getUsedBytes() >= policy.getCriticalThreshold();
+            }
+        };
+
+        // First increase size.
+        AtomicInteger currentGeneration = new AtomicInteger();
+        for (long size = cache.getStoredBytes(); size < maxSize; size++) {
+            cache.setUsedBytes(size);
+            cm.applyCachePolicy();
+            currentGeneration.incrementAndGet();
+            Assert.assertEquals("Unexpected value for essentialOnly for StoredBytes = " + size, isExpected.get(), essentialOnly.get());
+            Assert.assertEquals("Unexpected value for isEssentialEntriesOnly for StoredBytes = " + size, isExpected.get(), cm.isEssentialEntriesOnly());
+        }
+
+        // Then decrease size.
+        for (long size = cache.getUsedBytes(); size >= 0; size--) {
+            cache.setUsedBytes(size);
+            cm.applyCachePolicy();
+            currentGeneration.incrementAndGet();
+            Assert.assertEquals("Unexpected value for essentialOnly for StoredBytes = " + size, isExpected.get(), essentialOnly.get());
+            Assert.assertEquals("Unexpected value for isEssentialEntriesOnly for StoredBytes = " + size, isExpected.get(), cm.isEssentialEntriesOnly());
+        }
+
+        AssertExtensions.assertGreaterThan("", 0, essentialCount.get());
+        AssertExtensions.assertGreaterThan("", 0, nonEssentialCount.get());
     }
 
     /**
@@ -284,14 +358,14 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         // First do a dry-run - we need this to make sure the current generation advances enough.
         for (int cycleId = 0; cycleId < maxGenerationCount; cycleId++) {
             client.setCacheStatus(0, cycleId);
-            client.setUpdateGenerationsImpl((current, oldest) -> false);
+            client.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> false);
             cm.applyCachePolicy();
         }
 
         cache.setUsedBytes(policy.getEvictionThreshold() + 1);
         client.setCacheStatus(0, maxGenerationCount);
         AtomicInteger callCount = new AtomicInteger();
-        client.setUpdateGenerationsImpl((current, oldest) -> {
+        client.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> {
             client.setCacheStatus(oldest, current); // Update the client's cache status to reflect a full eviction.
             cache.setUsedBytes(policy.getEvictionThreshold() - 1); // Reduce the cache size to something below the threshold.
             callCount.incrementAndGet();
@@ -317,14 +391,14 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
 
         // Setup the client so that it throws ObjectClosedException when updateGenerations is called.
         client.setCacheStatus(0, 0);
-        client.setUpdateGenerationsImpl((current, oldest) -> {
+        client.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> {
             throw new ObjectClosedException(this);
         });
         cm.applyCachePolicy();
 
         // Now do the actual verification.
         client.setCacheStatus(0, 1);
-        client.setUpdateGenerationsImpl((current, oldest) -> {
+        client.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> {
             Assert.fail("Client was not unregistered after throwing ObjectClosedException.");
             return false;
         });
@@ -350,7 +424,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         cache.setUsedBytes(policy.getMaxSize() + 1);
         AtomicInteger updatedOldest = new AtomicInteger(-1);
         AtomicInteger updatedCurrent = new AtomicInteger(-1);
-        client.setUpdateGenerationsImpl((current, oldest) -> {
+        client.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> {
             updatedOldest.set(oldest);
             updatedCurrent.set(current);
             return true;
@@ -366,7 +440,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         cache.setUsedBytes(10);
         updatedCurrent.set(-1);
         updatedOldest.set(-1);
-        client.setUpdateGenerationsImpl((current, oldest) -> {
+        client.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> {
             updatedOldest.set(oldest);
             updatedCurrent.set(current);
             return false;
@@ -399,7 +473,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         // Setup the TestClient to evict write1 when requested.
         val cleanupRequestCount = new AtomicInteger(0);
         client.setCacheStatus(0, 1);
-        client.setUpdateGenerationsImpl((ng, og) -> {
+        client.setUpdateGenerationsImpl((ng, og, essentialOnly) -> {
             cleanupRequestCount.incrementAndGet();
             cache.delete(write1);
             return true;
@@ -441,7 +515,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         val cleanupRequestCount = new AtomicInteger(0);
         val concurrentRequest = new AtomicBoolean(false);
         client.setCacheStatus(0, 1);
-        client.setUpdateGenerationsImpl((ng, og) -> {
+        client.setUpdateGenerationsImpl((ng, og, essentialOnly) -> {
             int rc = cleanupRequestCount.incrementAndGet();
             if (rc == 1) {
                 // This is the first concurrent request requesting a cleanup.
@@ -505,7 +579,7 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         TestCleanupListener l2 = new TestCleanupListener();
         cm.getUtilizationProvider().registerCleanupListener(l1);
         cm.getUtilizationProvider().registerCleanupListener(l2);
-        client.setUpdateGenerationsImpl((current, oldest) -> true); // We always remove something.
+        client.setUpdateGenerationsImpl((current, oldest, essentialOnly) -> true); // We always remove something.
 
         // In the first iteration, we should invoke both listeners.
         client.setCacheStatus(0, 0);
@@ -538,13 +612,13 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
 
     private static class TestClient implements CacheManager.Client {
         private CacheManager.CacheStatus currentStatus;
-        private BiFunction<Integer, Integer, Boolean> updateGenerationsImpl = (current, oldest) -> false;
+        private UpdateGenerations updateGenerationsImpl = (current, oldest, essentialOnly) -> false;
 
         void setCacheStatus(int oldestGeneration, int newestGeneration) {
             this.currentStatus = new CacheManager.CacheStatus(oldestGeneration, newestGeneration);
         }
 
-        void setUpdateGenerationsImpl(BiFunction<Integer, Integer, Boolean> function) {
+        void setUpdateGenerationsImpl(UpdateGenerations function) {
             this.updateGenerationsImpl = function;
         }
 
@@ -554,8 +628,8 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
         }
 
         @Override
-        public boolean updateGenerations(int currentGeneration, int oldestGeneration) {
-            return this.updateGenerationsImpl.apply(currentGeneration, oldestGeneration);
+        public boolean updateGenerations(int currentGeneration, int oldestGeneration, boolean essentialOnly) {
+            return this.updateGenerationsImpl.apply(currentGeneration, oldestGeneration, essentialOnly);
         }
     }
 
@@ -564,7 +638,6 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
             setCacheStatus(CacheManager.CacheStatus.EMPTY_VALUE, CacheManager.CacheStatus.EMPTY_VALUE);
         }
     }
-
 
     @RequiredArgsConstructor
     @Getter
@@ -579,5 +652,10 @@ public class CacheManagerTests extends ThreadPooledTestSuite {
             val s = super.getState();
             return new CacheState(this.storedBytes, this.usedBytes, 0, 0, this.maxBytes);
         }
+    }
+
+    @FunctionalInterface
+    interface UpdateGenerations {
+        boolean apply(int currentGeneration, int oldestGeneration, boolean essentialOnly);
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentMetadataComparer.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentMetadataComparer.java
@@ -33,11 +33,13 @@ public final class SegmentMetadataComparer {
         String idPrefix = message + " SegmentId " + expected.getId();
         Assert.assertEquals(idPrefix + " getId() mismatch.", expected.getId(), actual.getId());
         Assert.assertEquals(idPrefix + " isDeleted() mismatch.", expected.isDeleted(), actual.isDeleted());
+        Assert.assertEquals(idPrefix + " isDeletedInStorage() mismatch.", expected.isDeletedInStorage(), actual.isDeletedInStorage());
         Assert.assertEquals(idPrefix + " getStorageLength() mismatch.", expected.getStorageLength(), actual.getStorageLength());
         Assert.assertEquals(idPrefix + " getStartOffset() mismatch.", expected.getStartOffset(), actual.getStartOffset());
         Assert.assertEquals(idPrefix + " getLength() mismatch.", expected.getLength(), actual.getLength());
         Assert.assertEquals(idPrefix + " getName() mismatch.", expected.getName(), actual.getName());
         Assert.assertEquals(idPrefix + " isSealed() mismatch.", expected.isSealed(), actual.isSealed());
+        Assert.assertEquals(idPrefix + " isSealedInStorage() mismatch.", expected.isSealedInStorage(), actual.isSealedInStorage());
         Assert.assertEquals(idPrefix + " isMerged() mismatch.", expected.isMerged(), actual.isMerged());
         assertSameAttributes(idPrefix + " getAttributes() mismatch:", expected.getAttributes(), actual);
         Assert.assertEquals(idPrefix + " isPinned() mismatch.", expected.isPinned(), actual.isPinned());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/AttributeIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/AttributeIndexTests.java
@@ -658,7 +658,7 @@ public class AttributeIndexTests extends ThreadPooledTestSuite {
         val cacheStatus = idx.getCacheStatus();
         Assert.assertEquals("Not expecting different generations yet.", cacheStatus.getOldestGeneration(), cacheStatus.getNewestGeneration());
         val newGen = cacheStatus.getNewestGeneration() + 1;
-        boolean anythingRemoved = idx.updateGenerations(newGen, newGen);
+        boolean anythingRemoved = idx.updateGenerations(newGen, newGen, false);
         Assert.assertTrue("Expecting something to be evicted.", anythingRemoved);
 
         // Re-check the index and verify at least one Storage Read happened.
@@ -675,6 +675,70 @@ public class AttributeIndexTests extends ThreadPooledTestSuite {
         intercepted.set(false);
         checkIndex(idx, expectedValues);
         Assert.assertFalse("Not expecting any Storage read.", intercepted.get());
+    }
+
+    /**
+     * Tests the ability to enable or disable the cache based on {@link SegmentAttributeBTreeIndex#updateGenerations}
+     * when it receives different values for the "essentialOnly" arg.
+     */
+    @Test
+    public void testNonEssentialCache() throws Exception {
+        val attributeId = UUID.randomUUID();
+        val config = AttributeIndexConfig
+                .builder()
+                .with(AttributeIndexConfig.MAX_INDEX_PAGE_SIZE, 1024)
+                .build();
+
+        @Cleanup
+        val context = new TestContext(config);
+        populateSegments(context);
+
+        // 1. Populate and verify first index.
+        @Cleanup
+        val idx = (SegmentAttributeBTreeIndex) context.index.forSegment(SEGMENT_ID, TIMEOUT).join();
+        val expectedValues = new HashMap<UUID, Long>();
+        expectedValues.put(attributeId, 1L);
+
+        // Populate data.
+        idx.update(expectedValues, TIMEOUT).join();
+        checkIndex(idx, expectedValues);
+
+        val cacheStatus = idx.getCacheStatus();
+        val newGen = cacheStatus.getNewestGeneration() + 1;
+        boolean anythingRemoved = idx.updateGenerations(newGen, newGen, false);
+        Assert.assertTrue("Expecting something to be evicted (essential=false).", anythingRemoved);
+
+        val readCount = new AtomicInteger(0);
+        context.storage.readInterceptor = (String streamSegmentName, long offset, int length, SyncStorage wrappedStorage) -> {
+            readCount.incrementAndGet();
+            return CompletableFuture.completedFuture(null);
+        };
+
+        // Re-insert that page into the cache and verify it's being loaded and cached (by reading it twice).
+        checkIndex(idx, expectedValues);
+        checkIndex(idx, expectedValues);
+        Assert.assertEquals("Not expecting caching to be disabled yet.", 1, readCount.get());
+        TestUtils.await(() -> idx.getPendingReadCount() == 0, 5, TIMEOUT.toMillis()); // Let the pending read index clear before proceeding.
+
+        // Set the non-essential-only flag.
+        anythingRemoved = idx.updateGenerations(newGen, newGen, true);
+        Assert.assertFalse("Not expecting anything to be evicted (essential=true).", anythingRemoved);
+        checkIndex(idx, expectedValues);
+        Assert.assertEquals("Not expecting anything to be evicted yet (essential=true).", 1, readCount.get());
+
+        expectedValues.put(attributeId, 2L);
+        idx.update(expectedValues, TIMEOUT).join();
+        Assert.assertEquals("Not expecting any storage reads yet (essential=true).", 1, readCount.get());
+        checkIndex(idx, expectedValues);
+        Assert.assertEquals("Expected a storage read (essential=true).", 2, readCount.get());
+
+        // Disable the non-essential-only flag.
+        anythingRemoved = idx.updateGenerations(newGen, newGen, false);
+        TestUtils.await(() -> idx.getPendingReadCount() == 0, 5, TIMEOUT.toMillis()); // Let the pending read index clear before proceeding.
+        Assert.assertFalse("Not expecting anything to be evicted (essential=false).", anythingRemoved);
+        checkIndex(idx, expectedValues);
+        checkIndex(idx, expectedValues); // Do it twice to check that the cache has been properly re-enabled.
+        Assert.assertEquals("Expected a single storage read (essential=false).", 3, readCount.get());
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/DurableLogTests.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.logs;
 
+import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.Service;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
@@ -23,9 +24,12 @@ import io.pravega.segmentstore.server.CacheManager;
 import io.pravega.segmentstore.server.CachePolicy;
 import io.pravega.segmentstore.server.ContainerOfflineException;
 import io.pravega.segmentstore.server.DataCorruptionException;
+import io.pravega.segmentstore.server.EvictableMetadata;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.OperationLog;
 import io.pravega.segmentstore.server.ReadIndex;
+import io.pravega.segmentstore.server.SegmentMetadata;
+import io.pravega.segmentstore.server.SegmentMetadataComparer;
 import io.pravega.segmentstore.server.ServiceListeners;
 import io.pravega.segmentstore.server.TestDurableDataLog;
 import io.pravega.segmentstore.server.TestDurableDataLogFactory;
@@ -34,6 +38,8 @@ import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentContainerMetadata;
 import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.CheckpointOperationBase;
+import io.pravega.segmentstore.server.logs.operations.DeleteSegmentOperation;
+import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.OperationComparer;
@@ -1079,6 +1085,139 @@ public class DurableLogTests extends OperationLogTestBase {
         Assert.assertTrue("Not expecting any other operations.", ops3.isEmpty());
         dl2.stopAsync().awaitTerminated();
         dl3.close();
+    }
+
+    /**
+     * Tests the DurableLog recovery process when there are multiple {@link MetadataCheckpointOperation}s added, with each
+     * such checkpoint including information about evicted segments or segments which had their storage state modified.
+     */
+    @Test
+    public void testRecoveryWithIncrementalCheckpoints() throws Exception {
+        final int streamSegmentCount = 50;
+
+        // Setup a DurableLog and start it.
+        @Cleanup
+        TestDurableDataLogFactory dataLogFactory = new TestDurableDataLogFactory(new InMemoryDurableDataLogFactory(MAX_DATA_LOG_APPEND_SIZE, executorService()));
+        @Cleanup
+        Storage storage = InMemoryStorageFactory.newStorage(executorService());
+        storage.initialize(1);
+
+        // First DurableLog. We use this for generating data.
+        val metadata1 = new MetadataBuilder(CONTAINER_ID).build();
+        @Cleanup
+        CacheStorage cacheStorage = new DirectMemoryCache(Integer.MAX_VALUE);
+        @Cleanup
+        CacheManager cacheManager = new CacheManager(CachePolicy.INFINITE, cacheStorage, executorService());
+        List<Long> deletedIds;
+        Set<Long> evictIds;
+        try (
+                ReadIndex readIndex = new ContainerReadIndex(DEFAULT_READ_INDEX_CONFIG, metadata1, storage, cacheManager, executorService());
+                DurableLog durableLog = new DurableLog(ContainerSetup.defaultDurableLogConfig(), metadata1, dataLogFactory, readIndex, executorService())) {
+            durableLog.startAsync().awaitRunning();
+
+            // Create some segments.
+            val segmentIds = new ArrayList<>(createStreamSegmentsWithOperations(streamSegmentCount, durableLog));
+            deletedIds = segmentIds.subList(0, 5);
+            val mergedFromIds = segmentIds.subList(5, 10);
+            val mergedToIds = segmentIds.subList(10, 15); // Must be same length as mergeFrom
+            evictIds = new HashSet<>(segmentIds.subList(15, 20));
+            val changeStorageStateIds = segmentIds.subList(20, segmentIds.size() - 5);
+
+            // Append something to each segment.
+            for (val segmentId : segmentIds) {
+                if (!evictIds.contains(segmentId)) {
+                    durableLog.add(new StreamSegmentAppendOperation(segmentId, generateAppendData((int) (long) segmentId), null), OperationPriority.Normal, TIMEOUT).join();
+                }
+            }
+
+            // Checkpoint 1.
+            durableLog.checkpoint(TIMEOUT).join();
+
+            // Delete some segments.
+            for (val segmentId : deletedIds) {
+                durableLog.add(new DeleteSegmentOperation(segmentId), OperationPriority.Normal, TIMEOUT).join();
+            }
+
+            // Checkpoint 2.
+            durableLog.checkpoint(TIMEOUT).join();
+
+            // Merge some segments.
+            for (int i = 0; i < mergedFromIds.size(); i++) {
+                durableLog.add(new StreamSegmentSealOperation(mergedFromIds.get(i)), OperationPriority.Normal, TIMEOUT).join();
+                durableLog.add(new MergeSegmentOperation(mergedToIds.get(i), mergedFromIds.get(i)), OperationPriority.Normal, TIMEOUT).join();
+            }
+
+            // Checkpoint 3.
+            durableLog.checkpoint(TIMEOUT).join();
+
+            // Evict some segments.
+            val evictableContainerMetadata = (EvictableMetadata) metadata1;
+            metadata1.removeTruncationMarkers(metadata1.getOperationSequenceNumber());
+            val toEvict = evictableContainerMetadata.getEvictionCandidates(Integer.MAX_VALUE, segmentIds.size())
+                    .stream().filter(m -> evictIds.contains(m.getId())).collect(Collectors.toList());
+            val evicted = evictableContainerMetadata.cleanup(toEvict, Integer.MAX_VALUE);
+            AssertExtensions.assertContainsSameElements("", evictIds, evicted.stream().map(SegmentMetadata::getId).collect(Collectors.toList()));
+
+            // Checkpoint 4.
+            durableLog.checkpoint(TIMEOUT).join();
+
+            // Update storage state for some segments.
+            for (val segmentId : changeStorageStateIds) {
+                val sm = metadata1.getStreamSegmentMetadata(segmentId);
+                if (segmentId % 3 == 0) {
+                    sm.setStorageLength(sm.getLength());
+                }
+                if (segmentId % 4 == 0) {
+                    sm.markSealed();
+                    sm.markSealedInStorage();
+                }
+                if (segmentId % 5 == 0) {
+                    sm.markDeleted();
+                    sm.markDeletedInStorage();
+                }
+            }
+
+            // Checkpoint 5.
+            durableLog.checkpoint(TIMEOUT).join();
+
+            // Stop the processor.
+            durableLog.stopAsync().awaitTerminated();
+        }
+
+        // Second DurableLog. We use this for recovery.
+        val metadata2 = new MetadataBuilder(CONTAINER_ID).build();
+        try (
+                ContainerReadIndex readIndex = new ContainerReadIndex(DEFAULT_READ_INDEX_CONFIG, metadata2, storage, cacheManager, executorService());
+                DurableLog durableLog = new DurableLog(ContainerSetup.defaultDurableLogConfig(), metadata2, dataLogFactory, readIndex, executorService())) {
+            durableLog.startAsync().awaitRunning();
+
+            // Validate metadata matches.
+            val expectedSegmentIds = metadata1.getAllStreamSegmentIds();
+            val actualSegmentIds = metadata2.getAllStreamSegmentIds();
+            AssertExtensions.assertContainsSameElements("Unexpected set of recovered segments. Only Active segments expected to have been recovered.",
+                    expectedSegmentIds, actualSegmentIds);
+
+            val expectedSegments = expectedSegmentIds.stream().sorted()
+                    .map(metadata1::getStreamSegmentMetadata)
+                    .collect(Collectors.toList());
+            val actualSegments = actualSegmentIds.stream().sorted()
+                    .map(metadata2::getStreamSegmentMetadata)
+                    .collect(Collectors.toList());
+            for (int i = 0; i < expectedSegments.size(); i++) {
+                val e = expectedSegments.get(i);
+                val a = actualSegments.get(i);
+                SegmentMetadataComparer.assertEquals("Recovered segment metadata mismatch", e, a);
+            }
+
+            // Validate read index is as it should. Here, we can only check if the read indices for evicted segments are
+            // no longer loaded; we do more thorough checks in the ContainerReadIndexTests suite.
+            Streams.concat(evictIds.stream(), deletedIds.stream())
+                    .forEach(segmentId ->
+                            Assert.assertNull("Not expecting a read index for an evicted or deleted segment.", readIndex.getIndex(segmentId)));
+
+            // Stop the processor.
+            durableLog.stopAsync().awaitTerminated();
+        }
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
@@ -9,13 +9,8 @@
  */
 package io.pravega.segmentstore.server.logs;
 
-import io.pravega.common.Exceptions;
-import io.pravega.common.util.BufferView;
 import io.pravega.common.util.ByteArraySegment;
-import io.pravega.segmentstore.contracts.ReadResult;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
-import io.pravega.segmentstore.server.CacheUtilizationProvider;
-import io.pravega.segmentstore.server.ContainerMetadata;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.ReadIndex;
@@ -27,22 +22,28 @@ import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
+import io.pravega.segmentstore.storage.ThrottleSourceListener;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
-import java.time.Duration;
-import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.mockito.invocation.InvocationOnMock;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for MemoryStateUpdater class.
@@ -61,59 +62,65 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
 
         // Add to MTL + Add to ReadIndex (append; beginMerge).
         InMemoryLog opLog = new InMemoryLog();
-        ArrayList<TestReadIndex.MethodInvocation> methodInvocations = new ArrayList<>();
-        TestReadIndex readIndex = new TestReadIndex(methodInvocations::add);
+        val readIndex = mock(ReadIndex.class);
+
+        val triggerSegmentIds = new ArrayList<Long>();
+        doAnswer(x -> {
+            triggerSegmentIds.clear();
+            triggerSegmentIds.addAll(x.getArgument(0));
+            return null;
+        }).when(readIndex).triggerFutureReads(anyCollection());
+
+        val invocations = new ArrayList<InvocationOnMock>();
+        doAnswer(invocations::add).when(readIndex).append(anyLong(), anyLong(), any());
+        doAnswer(invocations::add).when(readIndex).beginMerge(anyLong(), anyLong(), anyLong());
+
         MemoryStateUpdater updater = new MemoryStateUpdater(opLog, readIndex);
         ArrayList<Operation> operations = populate(updater, segmentCount, operationCountPerType);
 
         // Verify they were properly processed.
-        int triggerFutureCount = (int) methodInvocations.stream().filter(mi -> mi.methodName.equals(TestReadIndex.TRIGGER_FUTURE_READS)).count();
-        int addCount = methodInvocations.size() - triggerFutureCount;
-        Assert.assertEquals("Unexpected number of items added to ReadIndex.",
-                operations.size() - segmentCount * operationCountPerType, addCount);
-        Assert.assertEquals("Unexpected number of calls to the ReadIndex triggerFutureReads method.", 1, triggerFutureCount);
-
-        // Verify add calls.
         Queue<Operation> logIterator = opLog.poll(operations.size());
         int currentIndex = -1;
-        int currentReadIndex = -1;
+        val invocationIterator = invocations.iterator();
         while (!logIterator.isEmpty()) {
             currentIndex++;
             Operation expected = operations.get(currentIndex);
             Operation actual = logIterator.poll();
             if (expected instanceof StorageOperation) {
-                currentReadIndex++;
-                TestReadIndex.MethodInvocation invokedMethod = methodInvocations.get(currentReadIndex);
+                val invokedMethod = invocationIterator.next();
                 if (expected instanceof StreamSegmentAppendOperation) {
                     Assert.assertTrue("StreamSegmentAppendOperation was not added as a CachedStreamSegmentAppendOperation to the Memory Log.", actual instanceof CachedStreamSegmentAppendOperation);
                     StreamSegmentAppendOperation appendOp = (StreamSegmentAppendOperation) expected;
-                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was not added to the ReadIndex.", TestReadIndex.APPEND, invokedMethod.methodName);
-                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", appendOp.getStreamSegmentId(), invokedMethod.args.get("streamSegmentId"));
-                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", appendOp.getStreamSegmentOffset(), invokedMethod.args.get("offset"));
-                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", appendOp.getData(), invokedMethod.args.get("data"));
+                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was not added to the ReadIndex.",
+                            "append", invokedMethod.getMethod().getName());
+                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            appendOp.getStreamSegmentId(), (long) invokedMethod.getArgument(0));
+                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            appendOp.getStreamSegmentOffset(), (long) invokedMethod.getArgument(1));
+                    Assert.assertEquals("Append with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            appendOp.getData(), invokedMethod.getArgument(2));
                 } else if (expected instanceof MergeSegmentOperation) {
                     MergeSegmentOperation mergeOp = (MergeSegmentOperation) expected;
-                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was not added to the ReadIndex.", TestReadIndex.BEGIN_MERGE, invokedMethod.methodName);
-                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", mergeOp.getStreamSegmentId(), invokedMethod.args.get("targetStreamSegmentId"));
-                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", mergeOp.getStreamSegmentOffset(), invokedMethod.args.get("offset"));
-                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.", mergeOp.getSourceSegmentId(), invokedMethod.args.get("sourceStreamSegmentId"));
+                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was not added to the ReadIndex.",
+                            "beginMerge", invokedMethod.getMethod().getName());
+                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            mergeOp.getStreamSegmentId(), (long) invokedMethod.getArgument(0));
+                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            mergeOp.getStreamSegmentOffset(), (long) invokedMethod.getArgument(1));
+                    Assert.assertEquals("Merge with SeqNo " + expected.getSequenceNumber() + " was added to the ReadIndex with wrong arguments.",
+                            mergeOp.getSourceSegmentId(), (long) invokedMethod.getArgument(2));
                 }
             }
         }
 
         // Verify triggerFutureReads args.
-        @SuppressWarnings("unchecked")
-        Collection<Long> triggerSegmentIds = (Collection<Long>) methodInvocations
-                .stream()
-                .filter(mi -> mi.methodName.equals(TestReadIndex.TRIGGER_FUTURE_READS))
-                .findFirst().get()
-                .args.get("streamSegmentIds");
         val expectedSegmentIds = operations.stream()
-                                           .filter(op -> op instanceof SegmentOperation)
-                                           .map(op -> ((SegmentOperation) op).getStreamSegmentId())
-                                           .collect(Collectors.toSet());
+                .filter(op -> op instanceof SegmentOperation)
+                .map(op -> ((SegmentOperation) op).getStreamSegmentId())
+                .collect(Collectors.toSet());
 
-        AssertExtensions.assertContainsSameElements("ReadIndex.triggerFutureReads() was called with the wrong set of StreamSegmentIds.", expectedSegmentIds, triggerSegmentIds);
+        AssertExtensions.assertContainsSameElements("ReadIndex.triggerFutureReads() was called with the wrong set of StreamSegmentIds.",
+                expectedSegmentIds, triggerSegmentIds);
 
         // Test DataCorruptionException.
         AssertExtensions.assertThrows(
@@ -126,15 +133,14 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
      * Tests the functionality of the {@link MemoryStateUpdater#process} method with critical errors.
      */
     @Test
-    public void testProcessWithErrors() throws Exception {
+    public void testProcessWithErrors() {
         final int corruptAtIndex = 10;
         final int segmentCount = 10;
         final int operationCountPerType = 5;
 
         // Add to MTL + Add to ReadIndex (append; beginMerge).
         val opLog = new OperationLogTestBase.CorruptedMemoryOperationLog(corruptAtIndex);
-        ArrayList<TestReadIndex.MethodInvocation> methodInvocations = new ArrayList<>();
-        TestReadIndex readIndex = new TestReadIndex(methodInvocations::add);
+        val readIndex = mock(ReadIndex.class);
         MemoryStateUpdater updater = new MemoryStateUpdater(opLog, readIndex);
 
         AssertExtensions.assertThrows(
@@ -143,8 +149,7 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
                 ex -> ex instanceof DataCorruptionException);
 
         // Verify they were properly processed.
-        int triggerFutureCount = (int) methodInvocations.stream().filter(mi -> mi.methodName.equals(TestReadIndex.TRIGGER_FUTURE_READS)).count();
-        Assert.assertEquals("Not expecting any trigger-future-read invocations.", 0, triggerFutureCount);
+        verify(readIndex, never()).triggerFutureReads(anyCollection());
 
         Queue<Operation> logIterator = opLog.poll(corruptAtIndex * 2);
         int addCount = 0;
@@ -166,22 +171,33 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
     public void testRecoveryMode() throws Exception {
         // Check it's properly delegated to Read index.
         InMemoryLog opLog = new InMemoryLog();
-        ArrayList<TestReadIndex.MethodInvocation> methodInvocations = new ArrayList<>();
-        TestReadIndex readIndex = new TestReadIndex(methodInvocations::add);
+        val readIndex = mock(ReadIndex.class);
         MemoryStateUpdater updater = new MemoryStateUpdater(opLog, readIndex);
 
         UpdateableContainerMetadata metadata1 = new MetadataBuilder(1).build();
         updater.enterRecoveryMode(metadata1);
+        updater.cleanupReadIndex();
         updater.exitRecoveryMode(true);
 
-        Assert.assertEquals("Unexpected number of method invocations.", 2, methodInvocations.size());
-        TestReadIndex.MethodInvocation enterRecovery = methodInvocations.get(0);
-        Assert.assertEquals("ReadIndex.enterRecoveryMode was not called when expected.", TestReadIndex.ENTER_RECOVERY_MODE, enterRecovery.methodName);
-        Assert.assertEquals("ReadIndex.enterRecoveryMode was called with the wrong arguments.", metadata1, enterRecovery.args.get("recoveryMetadataSource"));
+        verify(readIndex).enterRecoveryMode(metadata1);
+        verify(readIndex).cleanup(null);
+        verify(readIndex).trimCache();
+        verify(readIndex).exitRecoveryMode(true);
+    }
 
-        TestReadIndex.MethodInvocation exitRecovery = methodInvocations.get(1);
-        Assert.assertEquals("ReadIndex.exitRecoveryMode was not called when expected.", TestReadIndex.EXIT_RECOVERY_MODE, exitRecovery.methodName);
-        Assert.assertEquals("ReadIndex.exitRecoveryMode was called with the wrong arguments.", true, exitRecovery.args.get("successfulRecovery"));
+    /**
+     * Tests {@link MemoryStateUpdater#registerReadListener} and {@link MemoryStateUpdater#notifyLogRead()}.
+     */
+    @Test
+    public void testReadListeners() {
+        val updater = new MemoryStateUpdater(new InMemoryLog(), mock(ReadIndex.class));
+        val l1 = mock(ThrottleSourceListener.class);
+        when(l1.isClosed()).thenReturn(false);
+        updater.registerReadListener(l1);
+        verify(l1).isClosed();
+
+        updater.notifyLogRead();
+        verify(l1).notifyThrottleSourceChanged();
     }
 
     private ArrayList<Operation> populate(MemoryStateUpdater updater, int segmentCount, int operationCountPerType) throws DataCorruptionException {
@@ -215,123 +231,5 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
         }
 
         return operations;
-    }
-
-    private static class TestReadIndex implements ReadIndex {
-        static final String APPEND = "append";
-        static final String BEGIN_MERGE = "beginMerge";
-        static final String COMPLETE_MERGE = "completeMerge";
-        static final String READ = "read";
-        static final String READ_DIRECT = "readDirect";
-        static final String TRIGGER_FUTURE_READS = "triggerFutureReads";
-        static final String CLEANUP = "cleanup";
-        static final String ENTER_RECOVERY_MODE = "enterRecoveryMode";
-        static final String EXIT_RECOVERY_MODE = "exitRecoveryMode";
-
-        private final Consumer<MethodInvocation> methodInvokeCallback;
-        private boolean closed;
-
-        TestReadIndex(Consumer<MethodInvocation> methodInvokeCallback) {
-            this.methodInvokeCallback = methodInvokeCallback;
-        }
-
-        @Override
-        public void append(long segmentId, long offset, BufferView data) {
-            invoke(new MethodInvocation(APPEND)
-                    .withArg("streamSegmentId", segmentId)
-                    .withArg("offset", offset)
-                    .withArg("data", data));
-        }
-
-        @Override
-        public void beginMerge(long targetStreamSegmentId, long offset, long sourceStreamSegmentId) {
-            invoke(new MethodInvocation(BEGIN_MERGE)
-                    .withArg("targetStreamSegmentId", targetStreamSegmentId)
-                    .withArg("offset", offset)
-                    .withArg("sourceStreamSegmentId", sourceStreamSegmentId));
-        }
-
-        @Override
-        public void completeMerge(long targetStreamSegmentId, long sourceStreamSegmentId) {
-            invoke(new MethodInvocation(COMPLETE_MERGE)
-                    .withArg("targetStreamSegmentId", targetStreamSegmentId)
-                    .withArg("sourceStreamSegmentId", sourceStreamSegmentId));
-        }
-
-        @Override
-        public BufferView readDirect(long streamSegmentId, long offset, int length) {
-            invoke(new MethodInvocation(READ_DIRECT)
-                    .withArg("offset", offset)
-                    .withArg("length", length));
-            return null;
-        }
-
-        @Override
-        public ReadResult read(long streamSegmentId, long offset, int maxLength, Duration timeout) {
-            invoke(new MethodInvocation(READ)
-                    .withArg("offset", offset)
-                    .withArg("maxLength", maxLength));
-            return null;
-        }
-
-        @Override
-        public void triggerFutureReads(Collection<Long> streamSegmentIds) {
-            invoke(new MethodInvocation(TRIGGER_FUTURE_READS)
-                    .withArg("streamSegmentIds", streamSegmentIds));
-        }
-
-        @Override
-        public void clear() {
-            throw new IllegalStateException("Not Implemented");
-        }
-
-        @Override
-        public void cleanup(Collection<Long> segmentIds) {
-            invoke(new MethodInvocation(CLEANUP));
-        }
-
-        @Override
-        public void enterRecoveryMode(ContainerMetadata recoveryMetadataSource) {
-            invoke(new MethodInvocation(ENTER_RECOVERY_MODE)
-                    .withArg("recoveryMetadataSource", recoveryMetadataSource));
-        }
-
-        @Override
-        public void exitRecoveryMode(boolean successfulRecovery) {
-            invoke(new MethodInvocation(EXIT_RECOVERY_MODE)
-                    .withArg("successfulRecovery", successfulRecovery));
-        }
-
-        @Override
-        public void close() {
-            this.closed = true;
-        }
-
-        @Override
-        public CacheUtilizationProvider getCacheUtilizationProvider() {
-            throw new UnsupportedOperationException();
-        }
-
-        private void invoke(MethodInvocation methodInvocation) {
-            Exceptions.checkNotClosed(this.closed, this);
-            if (this.methodInvokeCallback != null) {
-                this.methodInvokeCallback.accept(methodInvocation);
-            }
-        }
-
-        static class MethodInvocation {
-            final String methodName;
-            final AbstractMap<String, Object> args;
-
-            MethodInvocation(String name) {
-                this.methodName = name;
-                this.args = new HashMap<>();
-            }
-
-            MethodInvocation withArg(String name, Object value) {
-                this.args.put(name, value);
-                return this;
-            }
-        }
     }
 }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/OperationLogTestBase.java
@@ -218,7 +218,7 @@ abstract class OperationLogTestBase extends ThreadPooledTestSuite {
         return result;
     }
 
-    private ByteArraySegment generateAppendData(int appendId) {
+    protected ByteArraySegment generateAppendData(int appendId) {
         return new ByteArraySegment(String.format("Append_%d", appendId).getBytes());
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -1472,6 +1472,75 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
     }
 
     /**
+     * Tests the {@link ContainerReadIndex#trimCache()} method.
+     */
+    @Test
+    public void testTrimCache() throws Exception {
+        // Create a CachePolicy with a set number of generations and a known max size.
+        // Each generation contains exactly one entry, so the number of generations is also the number of entries.
+        // We append one byte at each time. This allows us to test edge cases as well by having the finest precision when
+        // it comes to selecting which bytes we want evicted and which kept.
+        final int appendCount = 100;
+        final int segmentId = 123;
+        final byte[] appendData = new byte[2];
+
+        val removedEntryCount = new AtomicInteger();
+        @Cleanup
+        TestContext context = new TestContext();
+        context.metadata.enterRecoveryMode();
+        context.readIndex.enterRecoveryMode(context.metadata);
+
+        // To ease our testing, we disable appends and instruct the TestCache to report the same value for UsedBytes as it
+        // has for StoredBytes. This shields us from having to know internal details about the layout of the cache.
+        context.cacheStorage.usedBytesSameAsStoredBytes = true;
+        context.cacheStorage.disableAppends = true;
+        context.cacheStorage.deleteCallback = e -> removedEntryCount.incrementAndGet();
+
+        createSegment(segmentId, context);
+        val metadata = context.metadata.getStreamSegmentMetadata(segmentId);
+        metadata.setLength(appendCount * appendData.length);
+        for (int i = 0; i < appendCount; i++) {
+            long offset = i * appendData.length;
+            context.readIndex.append(segmentId, offset, new ByteArraySegment(appendData));
+        }
+
+        // Gradually increase the StorageLength of the segment and invoke trimCache twice at every step. We want to verify
+        // that it also does not evict more than it should if it has nothing to do.
+        int deltaIncrease = 0;
+        while (metadata.getStorageLength() < metadata.getLength()) {
+            val trim1 = context.readIndex.trimCache();
+            Assert.assertEquals("Not expecting any bytes trimmed.", 0, trim1);
+
+            // Every time we trim, increase the StorageLength by a bigger amount - but make sure we don't exceed the length of the segment.
+            deltaIncrease = (int) Math.min(metadata.getLength() - metadata.getStorageLength(), deltaIncrease + appendData.length);
+            metadata.setStorageLength(Math.min(metadata.getLength(), metadata.getStorageLength() + deltaIncrease));
+            removedEntryCount.set(0);
+            val trim2 = context.readIndex.trimCache();
+            Assert.assertEquals("Unexpected number of bytes trimmed.", deltaIncrease, trim2);
+            Assert.assertEquals("Unexpected number of cache entries evicted.", deltaIncrease / appendData.length, removedEntryCount.get());
+        }
+
+        // Take the index out of recovery mode.
+        context.metadata.exitRecoveryMode();
+        context.readIndex.exitRecoveryMode(true);
+
+        // Verify that the entries have actually been evicted.
+        for (int i = 0; i < appendCount; i++) {
+            long offset = i * appendData.length;
+            @Cleanup
+            val readResult = context.readIndex.read(segmentId, offset, appendData.length, TIMEOUT);
+            val first = readResult.next();
+            Assert.assertEquals("", ReadResultEntryType.Storage, first.getType());
+        }
+
+        // Verify trimCache() doesn't work when we are not in recovery mode.
+        AssertExtensions.assertThrows(
+                "trimCache worked in non-recovery mode.",
+                context.readIndex::trimCache,
+                ex -> ex instanceof IllegalStateException);
+    }
+
+    /**
      * Tests the {@link ContainerReadIndex#cleanup} method as well as its handling of inactive segments.
      */
     @Test

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/ContainerReadIndexTests.java
@@ -886,7 +886,9 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
             BiConsumerWithException<TestContext, UpdateableSegmentMetadata> executeBetweenReads,
             BiConsumerWithException<TestContext, UpdateableSegmentMetadata> finalCheck) throws Exception {
         val maxAllowedStorageReads = 2 + extraAllowedStorageReads;
-        val cachePolicy = new CachePolicy(100, 0.01, 1.0, Duration.ofMillis(10), Duration.ofMillis(10));
+
+        // Set a cache size big enough to prevent the Cache Manager from enabling "essential-only" mode due to over-utilization.
+        val cachePolicy = new CachePolicy(10000, 0.01, 1.0, Duration.ofMillis(10), Duration.ofMillis(10));
         @Cleanup
         TestContext context = new TestContext(DEFAULT_CONFIG, cachePolicy);
 
@@ -1644,7 +1646,8 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         transactionWriteData.copyTo(writtenStream);
 
         // Clear the cache.
-        context.cacheManager.applyCachePolicy();
+        boolean evicted = context.cacheManager.applyCachePolicy();
+        Assert.assertTrue("Expected an eviction.", evicted);
 
         // Issue read from the parent.
         ReadResult rr = context.readIndex.read(parentId, mergeOffset, transactionWriteData.getLength(), TIMEOUT);
@@ -1797,9 +1800,11 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
     @Test
     public void testConcurrentReadTransactionStorageReadCacheFull() throws Exception {
         val appendLength = 4 * 1024; // Must equal Cache Block size for easy eviction.
-        CachePolicy cachePolicy = new CachePolicy(1, Duration.ZERO, Duration.ofMillis(1));
+        val maxCacheSize = 2 * 1024 * 1024;
+        // We set the policy's max size to a much higher value to avoid entering "essential-only" state.
+        CachePolicy cachePolicy = new CachePolicy(2 * maxCacheSize, Duration.ZERO, Duration.ofMillis(1));
         @Cleanup
-        TestContext context = new TestContext(DEFAULT_CONFIG, cachePolicy, 2 * appendLength);
+        TestContext context = new TestContext(DEFAULT_CONFIG, cachePolicy, maxCacheSize);
         val rnd = new Random(0);
 
         // Create parent segment and one transaction
@@ -2267,6 +2272,109 @@ public class ContainerReadIndexTests extends ThreadPooledTestSuite {
         // Release the delete blocker. If all goes well, all the other operations should be unblocked at this point.
         segment1Delete.release();
         append2Future.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Tests the ability of the Read Index to handle "Essential-Only" cache mode, where only cache entries that are not
+     * yet persisted to Storage may be added to the cache.
+     */
+    @Test
+    public void testCacheEssentialOnlyMode() throws Exception {
+        val rnd = new Random(0);
+        val appendSize = 4 * 1024; // Cache block size.
+        val segmentLength = 10 * appendSize;
+        // Setup a cache policy that will keep at most 4 blocks in the cache, and enter essential mode after 4 blocks too
+        // NOTE: blocks includes the metadata block (internal to the cache), so usable blocks is 3.
+        CachePolicy cachePolicy = new CachePolicy(segmentLength, 0.3, 0.4, Duration.ofHours(1000), Duration.ofSeconds(1));
+        @Cleanup
+        TestContext context = new TestContext(DEFAULT_CONFIG, cachePolicy);
+        context.cacheStorage.appendReturnBlocker = null; // Not blocking anything now.
+
+        // Create segment, generate some content for it, setup its metadata and write 40% of it to Storage.
+        long segmentId = createSegment(0, context);
+        val segmentMetadata = context.metadata.getStreamSegmentMetadata(segmentId);
+        createSegmentsInStorage(context);
+        val segmentData = new byte[segmentLength];
+        rnd.nextBytes(segmentData);
+        val part1 = new ByteArraySegment(segmentData, 0, appendSize);
+        val part2 = new ByteArraySegment(segmentData, appendSize, appendSize);
+        val part3 = new ByteArraySegment(segmentData, 2 * appendSize, appendSize);
+        val part4 = new ByteArraySegment(segmentData, 3 * appendSize, appendSize);
+        val part5 = new ByteArraySegment(segmentData, 4 * appendSize, appendSize);
+        segmentMetadata.setLength(segmentLength);
+        segmentMetadata.setStorageLength(part1.getLength() + part2.getLength());
+        context.storage.openWrite(segmentMetadata.getName())
+                .thenCompose(h -> context.storage.write(h, 0, new ByteArrayInputStream(segmentData),
+                        (int) segmentMetadata.getStorageLength(), TIMEOUT)).join();
+
+        val insertCount = new AtomicInteger(0);
+        val storageReadCount = new AtomicInteger(0);
+        context.cacheStorage.insertCallback = address -> insertCount.incrementAndGet();
+        context.storage.setReadInterceptor((segment, wrappedStorage) -> storageReadCount.incrementAndGet());
+
+        // Helper for reading a segment part.
+        BiConsumer<Long, BufferView> readPart = (partOffset, partContents) -> {
+            try {
+                @Cleanup
+                val rr = context.readIndex.read(segmentId, partOffset, partContents.getLength(), TIMEOUT);
+                val readData = rr.readRemaining(partContents.getLength(), TIMEOUT);
+                Assert.assertEquals(partContents, BufferView.wrap(readData));
+            } catch (Exception ex) {
+                throw new CompletionException(ex);
+            }
+        };
+
+        // Read parts 1 and 2 (separately). They should be cached as individual entries.
+        readPart.accept(0L, part1);
+        Assert.assertEquals(1, storageReadCount.get());
+
+        // Cache insertion is done async. Need to wait until we write
+        AssertExtensions.assertEventuallyEquals(1, insertCount::get, TIMEOUT.toMillis());
+        AssertExtensions.assertEventuallyEquals(1, context.readIndex.getIndex(segmentId).getSummary()::size, TIMEOUT.toMillis());
+
+        boolean evicted = context.cacheManager.applyCachePolicy(); // No eviction, but increase generation.
+        Assert.assertFalse("Not expected an eviction now.", evicted);
+
+        readPart.accept((long) part1.getLength(), part2);
+
+        // We expect 2 storage reads and also 2 cache inserts.
+        Assert.assertEquals(2, storageReadCount.get());
+        AssertExtensions.assertEventuallyEquals(2, insertCount::get, TIMEOUT.toMillis()); // This one is done asynchronously.
+        AssertExtensions.assertEventuallyEquals(2, context.readIndex.getIndex(segmentId).getSummary()::size, TIMEOUT.toMillis());
+
+        evicted = context.cacheManager.applyCachePolicy(); // No eviction, but increase generation.
+        Assert.assertFalse("Not expected an eviction now.", evicted);
+
+        // Append parts 3, 4 and 5.
+        context.readIndex.append(segmentId, segmentMetadata.getStorageLength(), part3);
+        Assert.assertEquals(3, insertCount.get()); // This insertion is done synchronously.
+        evicted = context.cacheManager.applyCachePolicy(); // Eviction (part 1) + increase generation.
+        Assert.assertTrue("Expected an eviction after writing 3 blocks.", evicted);
+
+        context.readIndex.append(segmentId, segmentMetadata.getStorageLength() + part3.getLength(), part4);
+        Assert.assertEquals("Expected an insertion for appends even in essential-only mode.", 4, insertCount.get());
+        evicted = context.cacheManager.applyCachePolicy(); // Eviction (part 2) + increase generation.
+        Assert.assertTrue("Expected an eviction after writing 4 blocks.", evicted);
+
+        context.readIndex.append(segmentId, segmentMetadata.getStorageLength() + part3.getLength() + part4.getLength(), part5);
+        Assert.assertEquals("Expected an insertion for appends even in essential-only mode.", 5, insertCount.get());
+        evicted = context.cacheManager.applyCachePolicy(); // Nothing to evict.
+        Assert.assertFalse("Not expecting an eviction after writing 5 blocks.", evicted);
+        Assert.assertTrue("Expected to be in essential-only mode after pinning 3 blocks.", context.cacheManager.isEssentialEntriesOnly());
+
+        // Verify that re-reading parts 1 and 2 results in no cache inserts.
+        insertCount.set(0);
+        storageReadCount.set(0);
+        int expectedReadCount = 0;
+        for (int i = 0; i < 5; i++) {
+            readPart.accept(0L, part1);
+            readPart.accept((long) part1.getLength(), part2);
+            expectedReadCount += 2;
+        }
+
+        Assert.assertTrue("Not expected to have exited essential-only mode.", context.cacheManager.isEssentialEntriesOnly());
+        Assert.assertEquals("Unexpected number of storage reads in essential-only mode.", expectedReadCount, storageReadCount.get());
+        Assert.assertEquals("Unexpected number of cache inserts in essential-only mode.", 0, insertCount.get());
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReaderTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReaderTests.java
@@ -303,7 +303,6 @@ public class AsyncTableEntryReaderTests extends ThreadPooledTestSuite {
 
         // Verify that we are not holding on to more buffer than we need.
         val allocatedKeySize = soughtKey.getKey().getAllocatedLength();
-        System.out.println(allocatedKeySize);
         if (expectCompaction) {
             Assert.assertEquals("", soughtKey.getKey().getLength(), soughtKey.getKey().getAllocatedLength());
         } else {
@@ -312,7 +311,6 @@ public class AsyncTableEntryReaderTests extends ThreadPooledTestSuite {
 
         if (soughtValue != null) {
             val allocatedValueSize = soughtValue.getAllocatedLength();
-            System.out.println(allocatedValueSize);
             if (expectCompaction) {
                 Assert.assertEquals("", soughtValue.getLength(), soughtValue.getAllocatedLength());
             } else {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
@@ -17,6 +17,7 @@ import io.pravega.segmentstore.storage.cache.CacheStorage;
 import io.pravega.segmentstore.storage.cache.DirectMemoryCache;
 import io.pravega.test.common.AssertExtensions;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
@@ -389,7 +391,7 @@ public class ContainerKeyCacheTests {
         for (int i = 0; i < keyCount; i++) {
             // We reuse the same key hash across multiple "segments", to make sure that segmentId does indeed partition
             // the cache.
-            keyCache.updateGenerations(i, 0);
+            keyCache.updateGenerations(i, 0, false);
             val keyHash = KEY_HASHER.hash(newTableKey(rnd).getKey());
             for (long segmentId = 0; segmentId < segmentCount; segmentId++) {
                 keyCache.includeExistingKey(segmentId, keyHash, (long) i);
@@ -409,7 +411,7 @@ public class ContainerKeyCacheTests {
         // Increase the generations to the newest one, while verifying that at each step we get some removal.
         int ng = initialStatus.getNewestGeneration() + 1;
         for (int og = 1; og <= ng; og++) {
-            boolean anythingRemoved = keyCache.updateGenerations(ng, og);
+            boolean anythingRemoved = keyCache.updateGenerations(ng, og, false);
             Assert.assertTrue("Expecting something to have been removed (gen).", anythingRemoved);
         }
 
@@ -421,7 +423,7 @@ public class ContainerKeyCacheTests {
         // Now update the Last Indexed Offset for a segment and verify that its entries are removed.
         for (long offset = 1; offset <= keyCount; offset++) {
             keyCache.updateSegmentIndexOffset(segmentIdByOffset, offset);
-            boolean anythingRemoved = keyCache.updateGenerations(ng, ng);
+            boolean anythingRemoved = keyCache.updateGenerations(ng, ng, false);
             Assert.assertTrue("Expecting something to have been removed (offset).", anythingRemoved);
         }
 
@@ -431,6 +433,96 @@ public class ContainerKeyCacheTests {
 
         // Verify the final state of the Cache. This should only contain one segment (segmentIdNoEviction).
         checkCache(expectedResult, keyCache);
+    }
+
+    /**
+     * Tests the {@link SegmentKeyCache} behavior when {@link ContainerKeyCache#updateGenerations} is called with "essentialOnly==false".
+     */
+    @Test
+    public void testNonEssentialCache() {
+        // We need one segment for each type of rules we are verifying (refer to this test's Javadoc for details).
+        final int keyCount = 25;
+        final long segmentId = 0L;
+
+        // Spy on our cache storage and record all insertions.
+        val spiedCacheStorage = Mockito.spy(this.cacheStorage);
+        val insertCount = new AtomicInteger(0);
+        Mockito.doAnswer(arg1 -> {
+            insertCount.incrementAndGet();
+            return arg1.callRealMethod();
+        }).when(spiedCacheStorage).replace(Mockito.anyInt(), Mockito.any());
+        Mockito.doAnswer(arg1 -> {
+            insertCount.incrementAndGet();
+            return arg1.callRealMethod();
+        }).when(spiedCacheStorage).insert(Mockito.any());
+
+        @Cleanup
+        val keyCache = new ContainerKeyCache(spiedCacheStorage);
+        val rnd = new Random(0);
+        val expectedResult = new HashMap<TestKey, CacheBucketOffset>();
+        val keys = new ArrayList<TableKey>();
+
+        // Initial cache population. Each Key in each segment gets its own generation.
+        val currentGeneration = new AtomicInteger(0);
+        val segmentOffset = new AtomicLong(0);
+        for (int i = 0; i < keyCount; i++) {
+            keyCache.updateGenerations(currentGeneration.getAndIncrement(), 0, false);
+            val key = newTableKey(rnd);
+            keys.add(key);
+            val keyHash = KEY_HASHER.hash(key.getKey());
+            val offset = segmentOffset.getAndIncrement();
+            keyCache.includeExistingKey(segmentId, keyHash, offset);
+            expectedResult.put(new TestKey(segmentId, keyHash), new CacheBucketOffset(offset, false));
+        }
+
+        checkCache(expectedResult, keyCache);
+        Assert.assertEquals("Unexpected number of initial insertions.", expectedResult.size(), insertCount.get());
+
+        // Now mark the cache as non-essential. These updates should effectively evict everything.
+        insertCount.set(0);
+        for (val k : keys) {
+            keyCache.updateGenerations(currentGeneration.getAndIncrement(), 0, true);
+            val keyHash = KEY_HASHER.hash(k.getKey());
+            keyCache.includeExistingKey(segmentId, keyHash, segmentOffset.getAndIncrement());
+        }
+
+        checkNotInCache(expectedResult.keySet(), keyCache);
+        Assert.assertEquals("Not expected any cache insertions with cache disabled.", 0, insertCount.get());
+
+        // Re-insert them, with "essential" == false.
+        for (val k : keys) {
+            keyCache.updateGenerations(currentGeneration.getAndIncrement(), 0, false);
+            val keyHash = KEY_HASHER.hash(k.getKey());
+            val offset = segmentOffset.getAndIncrement();
+            keyCache.includeExistingKey(segmentId, keyHash, offset);
+            expectedResult.put(new TestKey(segmentId, keyHash), new CacheBucketOffset(offset, false));
+        }
+
+        checkCache(expectedResult, keyCache);
+        Assert.assertEquals("Unexpected number of reinsertions.", expectedResult.size(), insertCount.get());
+        insertCount.set(0);
+
+        // Evict everything and set the "essential" state.
+        keyCache.updateSegmentIndexOffset(segmentId, segmentOffset.get());
+        boolean anyEvicted = keyCache.updateGenerations(currentGeneration.getAndIncrement(), currentGeneration.get(), true);
+        Assert.assertTrue(anyEvicted);
+        checkNotInCache(expectedResult.keySet(), keyCache);
+        expectedResult.clear();
+        keys.clear();
+
+        // Verify tail migration with the essential offset set (from the previous step).
+        val tailKey = newTableKey(rnd);
+        val tailKeyHash = KEY_HASHER.hash(tailKey.getKey());
+        val tailBatch = TableKeyBatch.update();
+        tailBatch.add(tailKey, tailKeyHash, tailKey.getKey().getLength());
+        keyCache.includeUpdateBatch(segmentId, tailBatch, segmentOffset.get());
+        expectedResult.put(new TestKey(segmentId, tailKeyHash), new CacheBucketOffset(segmentOffset.get(), tailBatch.isRemoval()));
+        checkCache(expectedResult, keyCache);
+
+        // The migration should not store this value anywhere in the cache since it's disabled.
+        keyCache.updateSegmentIndexOffset(segmentId, segmentOffset.get() + 1);
+        checkNotInCache(expectedResult.keySet(), keyCache);
+        Assert.assertEquals("Not expected any cache insertions with cache disabled (migration).", 0, insertCount.get());
     }
 
     /**
@@ -610,7 +702,7 @@ public class ContainerKeyCacheTests {
         }
     }
 
-    private void checkNotInCache(List<TestKey> keys, ContainerKeyCache keyCache) {
+    private void checkNotInCache(Collection<TestKey> keys, ContainerKeyCache keyCache) {
         for (val e : keys) {
             val result = keyCache.get(e.segmentId, e.keyHash);
             Assert.assertNull("Found key that is not supposed to be in the cache.", result);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyCacheTests.java
@@ -609,6 +609,42 @@ public class ContainerKeyCacheTests {
         }
     }
 
+    /**
+     * Test the {@link SegmentKeyCache.MigrationCandidate} class when cache is full.
+     */
+    @Test
+    public void testMigrationCandidateFailedCacheFull() {
+        @Cleanup
+        val fullCache = new DirectMemoryCache(10);
+        fullCache.insert(new ByteArraySegment(new byte[(int) (fullCache.getState().getMaxBytes() - fullCache.getBlockAlignment())]));
+
+        val keyCache = new SegmentKeyCache(1L, fullCache);
+        val rnd = new Random(0);
+
+        val batch = TableKeyBatch.update();
+        val key = newTableKey(rnd);
+        val keyHash = KEY_HASHER.hash(key.getKey());
+        batch.add(key, keyHash, key.getKey().getLength());
+        keyCache.includeUpdateBatch(batch, 0, 0);
+
+        List<SegmentKeyCache.CacheEntry> evictedEntries = null;
+        try {
+            // Migrate the tail index to a Cache Entry.
+            keyCache.setLastIndexedOffset(batch.getLength() + 1, 1);
+
+            // Try to evict all entries.
+            evictedEntries = keyCache.evictAll();
+
+            // We expect no evictions because we shouldn't have inserted anything.
+            Assert.assertEquals(0, evictedEntries.size());
+        } finally {
+            // Clean up the cache in case of an error. We do not want to leave data hanging around in the Cache.
+            if (evictedEntries != null) {
+                evictedEntries.forEach(SegmentKeyCache.CacheEntry::evict);
+            }
+        }
+    }
+
     private long batchInsert(long insertOffset, ContainerKeyCache keyCache, HashMap<TestKey, CacheBucketOffset> expectedResult, Random rnd) {
         val insertBatches = new HashMap<Long, TableKeyBatch>();
         long highestOffset = 0L;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ReadResultMock.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ReadResultMock.java
@@ -70,6 +70,7 @@ class ReadResultMock extends StreamSegmentReadResult implements ReadResult {
         Preconditions.checkState(isCopyOnRead(), "Copy-on-read required for all Table Segment read requests.");
         int relativeOffset = this.consumedLength;
         int length = Math.min(this.entryLength, Math.min(this.data.getLength(), getMaxResultLength()) - relativeOffset);
+        length = Math.min(length, getMaxReadAtOnce());
         this.consumedLength += length;
         return new Entry(relativeOffset, length);
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/WriterTableProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/WriterTableProcessorTests.java
@@ -252,14 +252,17 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
 
             // Flush.
             val initialNotifyCount = context.connector.notifyCount.get();
-            context.processor.flush(TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            val f1 = context.processor.flush(TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             AssertExtensions.assertGreaterThan("No calls to notifyIndexOffsetChanged().",
                     initialNotifyCount, context.connector.notifyCount.get());
+            Assert.assertTrue(f1.isAnythingFlushed());
 
             // Post-flush validation.
             Assert.assertFalse("Unexpected value from mustFlush() after call to flush().", context.processor.mustFlush());
+            val f2 = context.processor.flush(false, TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertEquals("Unexpected LUSN after call to flush().",
                     Operation.NO_SEQUENCE_NUMBER, context.processor.getLowestUncommittedSequenceNumber());
+            Assert.assertFalse(f2.isAnythingFlushed());
 
             // Verify correctness.
             batch.expectedEntries.keySet().forEach(k -> allKeys.put(k, context.keyHasher.hash(k)));

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/WriterStateTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/WriterStateTests.java
@@ -11,8 +11,12 @@ package io.pravega.segmentstore.server.writer;
 
 import io.pravega.segmentstore.server.ManualTimer;
 import io.pravega.segmentstore.server.WriterFlushResult;
+import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
+import io.pravega.segmentstore.server.logs.operations.Operation;
+import io.pravega.segmentstore.server.logs.operations.StorageMetadataCheckpointOperation;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestUtils;
+import java.util.LinkedList;
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
@@ -47,6 +51,28 @@ public class WriterStateTests {
 
         s.setLastReadSequenceNumber(123);
         Assert.assertEquals(123, s.getLastReadSequenceNumber());
+    }
+
+    /**
+     * Tests {@link WriterState#getLastRead()} and {@link WriterState#setLastRead}.
+     */
+    @Test
+    public void testLastRead() {
+        val s = new WriterState();
+        Assert.assertNull(s.getLastRead());
+
+        val q = new LinkedList<Operation>();
+        q.add(new MetadataCheckpointOperation());
+        q.add(new StorageMetadataCheckpointOperation());
+
+        s.setLastRead(q);
+        Assert.assertSame(q, s.getLastRead());
+
+        q.removeFirst();
+        Assert.assertEquals(1, s.getLastRead().size());
+
+        q.removeFirst();
+        Assert.assertNull(s.getLastRead());
     }
 
     /**

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/BookKeeperLog.java
@@ -29,14 +29,13 @@ import io.pravega.segmentstore.storage.DurableDataLogException;
 import io.pravega.segmentstore.storage.LogAddress;
 import io.pravega.segmentstore.storage.QueueStats;
 import io.pravega.segmentstore.storage.ThrottleSourceListener;
+import io.pravega.segmentstore.storage.ThrottlerSourceListenerCollection;
 import io.pravega.segmentstore.storage.WriteFailureException;
 import io.pravega.segmentstore.storage.WriteSettings;
 import io.pravega.segmentstore.storage.WriteTooLongException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
@@ -106,8 +105,7 @@ class BookKeeperLog implements DurableDataLog {
     private final SequentialAsyncProcessor rolloverProcessor;
     private final BookKeeperMetrics.BookKeeperLog metrics;
     private final ScheduledFuture<?> metricReporter;
-    @GuardedBy("queueStateChangeListeners")
-    private final HashSet<ThrottleSourceListener> queueStateChangeListeners;
+    private final ThrottlerSourceListenerCollection queueStateChangeListeners;
     //endregion
 
     //region Constructor
@@ -137,7 +135,7 @@ class BookKeeperLog implements DurableDataLog {
         this.rolloverProcessor = new SequentialAsyncProcessor(this::rollover, retry, this::handleRolloverFailure, this.executorService);
         this.metrics = new BookKeeperMetrics.BookKeeperLog(containerId);
         this.metricReporter = this.executorService.scheduleWithFixedDelay(this::reportMetrics, REPORT_INTERVAL, REPORT_INTERVAL, TimeUnit.MILLISECONDS);
-        this.queueStateChangeListeners = new HashSet<>();
+        this.queueStateChangeListeners = new ThrottlerSourceListenerCollection();
     }
 
     private Retry.RetryAndThrowBase<? extends Exception> createRetryPolicy(int maxWriteAttempts, int writeTimeout) {
@@ -360,14 +358,7 @@ class BookKeeperLog implements DurableDataLog {
 
     @Override
     public void registerQueueStateChangeListener(ThrottleSourceListener listener) {
-        if (listener.isClosed()) {
-            log.warn("{} Attempted to register a closed ThrottleSourceListener ({}).", this.traceObjectId, listener);
-            return;
-        }
-
-        synchronized (this.queueStateChangeListeners) {
-            this.queueStateChangeListeners.add(listener); // This is a Set, so we won't be adding the same listener twice.
-        }
+        this.queueStateChangeListeners.register(listener);
     }
 
     //endregion
@@ -411,7 +402,7 @@ class BookKeeperLog implements DurableDataLog {
             return false;
         } else {
             if (cleanupResult.getRemovedCount() > 0) {
-                notifyQueueChangeListeners();
+                this.queueStateChangeListeners.notifySourceChanged();
             }
 
             if (cleanupResult.getStatus() == WriteQueue.CleanupStatus.QueueEmpty) {
@@ -737,34 +728,6 @@ class BookKeeperLog implements DurableDataLog {
 
         log.info("{}: Truncated up to {}.", this.traceObjectId, upToAddress);
         LoggerHelpers.traceLeave(log, this.traceObjectId, "tryTruncate", traceId, upToAddress);
-    }
-
-    private void notifyQueueChangeListeners() {
-        ArrayList<ThrottleSourceListener> toNotify = new ArrayList<>();
-        ArrayList<ThrottleSourceListener> toRemove = new ArrayList<>();
-        synchronized (this.queueStateChangeListeners) {
-            for (ThrottleSourceListener l : this.queueStateChangeListeners) {
-                if (l.isClosed()) {
-                    toRemove.add(l);
-                } else {
-                    toNotify.add(l);
-                }
-            }
-
-            this.queueStateChangeListeners.removeAll(toRemove);
-        }
-
-        for (ThrottleSourceListener l : toNotify) {
-            try {
-                l.notifyThrottleSourceChanged();
-            } catch (Throwable ex) {
-                if (Exceptions.mustRethrow(ex)) {
-                    throw ex;
-                }
-
-                log.error("{}: Error while notifying queue listener {}.", this.traceObjectId, l, ex);
-            }
-        }
     }
 
     //endregion

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/ThrottlerSourceListenerCollection.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/ThrottlerSourceListenerCollection.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.pravega.common.Exceptions;
+import java.util.ArrayList;
+import java.util.HashSet;
+import javax.annotation.concurrent.GuardedBy;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A collection of {@link ThrottleSourceListener} objects.
+ */
+@Slf4j
+public class ThrottlerSourceListenerCollection {
+    @GuardedBy("listeners")
+    private final HashSet<ThrottleSourceListener> listeners = new HashSet<>();
+
+    @VisibleForTesting
+    int getListenerCount() {
+        synchronized (this.listeners) {
+            return this.listeners.size();
+        }
+    }
+
+    /**
+     * Registers a new {@link ThrottleSourceListener}.
+     *
+     * @param listener The listener to register. This listener will be automatically unregistered when {@link #notifySourceChanged()}
+     *                 is invoked and {@link ThrottleSourceListener#isClosed()} is true for it.
+     */
+    public void register(@NonNull ThrottleSourceListener listener) {
+        if (listener.isClosed()) {
+            log.warn("Attempted to register a closed ThrottleSourceListener ({}).", listener);
+            return;
+        }
+
+        synchronized (this.listeners) {
+            this.listeners.add(listener); // This is a Set, so we won't be adding the same listener twice.
+        }
+    }
+
+    /**
+     * Notifies all registered {@link ThrottleSourceListener} instances that something has changed.
+     */
+    public void notifySourceChanged() {
+        ArrayList<ThrottleSourceListener> toNotify = new ArrayList<>();
+        ArrayList<ThrottleSourceListener> toRemove = new ArrayList<>();
+        synchronized (this.listeners) {
+            for (ThrottleSourceListener l : this.listeners) {
+                if (l.isClosed()) {
+                    toRemove.add(l);
+                } else {
+                    toNotify.add(l);
+                }
+            }
+
+            this.listeners.removeAll(toRemove);
+        }
+
+        for (ThrottleSourceListener l : toNotify) {
+            try {
+                l.notifyThrottleSourceChanged();
+            } catch (Throwable ex) {
+                if (Exceptions.mustRethrow(ex)) {
+                    throw ex;
+                }
+
+                log.error("Error while notifying listener {}.", l, ex);
+            }
+        }
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/ThrottlerSourceListenerCollectionTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/ThrottlerSourceListenerCollectionTests.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.segmentstore.storage;
+
+import io.pravega.test.common.IntentionalException;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link ThrottlerSourceListenerCollection} class.
+ */
+public class ThrottlerSourceListenerCollectionTests {
+    /**
+     * Tests {@link ThrottlerSourceListenerCollection#register} and {@link ThrottlerSourceListenerCollection#notifySourceChanged()}.
+     */
+    @Test
+    public void testRegisterNotify() {
+        val c = new ThrottlerSourceListenerCollection();
+        val l1 = new TestListener();
+        val l2 = new TestListener();
+        val l3 = new TestListener();
+        l3.closed = true;
+        c.register(l1);
+        c.register(l2);
+        c.register(l3);
+        Assert.assertEquals("Not expecting closed listener to be added.", 2, c.getListenerCount());
+
+        l2.setClosed(true);
+        c.notifySourceChanged();
+        Assert.assertEquals("Expected listener to be invoked.", 1, l1.getCallCount());
+        Assert.assertEquals("Not expected closed listener to be invoked.", 0, l2.getCallCount());
+        c.register(l2); // This should have no effect.
+        Assert.assertEquals("Expected closed listener to be removed.", 1, c.getListenerCount());
+
+        // Now verify with errors.
+        c.register(new ThrottleSourceListener() {
+            @Override
+            public void notifyThrottleSourceChanged() {
+                throw new IntentionalException();
+            }
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+        });
+
+        c.notifySourceChanged(); // This should not throw.
+        Assert.assertEquals("Expected cleanup listener to be invoked the second time.", 2, l1.getCallCount());
+        Assert.assertEquals("Not expected removed listeners to be invoked.", 0, l2.getCallCount() + l3.getCallCount());
+    }
+
+    private static class TestListener implements ThrottleSourceListener {
+        @Getter
+        private int callCount = 0;
+        @Setter
+        @Getter
+        private boolean closed;
+
+        @Override
+        public void notifyThrottleSourceChanged() {
+            this.callCount++;
+        }
+    }
+}

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ByteBufWrapper.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ByteBufWrapper.java
@@ -100,6 +100,12 @@ public class ByteBufWrapper extends AbstractBufferView implements BufferView {
     }
 
     @Override
+    public int getAllocatedLength() {
+        // TODO: This won't give us what we want. Unfortunately ByteBuf does not expose this information and there's no way to get it otherwise.
+        return this.buf.capacity();
+    }
+
+    @Override
     public Reader getBufferViewReader() {
         return new ByteBufReader(this.buf.duplicate());
     }

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/ByteBufWrapperTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/ByteBufWrapperTests.java
@@ -99,6 +99,24 @@ public class ByteBufWrapperTests extends BufferViewTestBase {
         AssertExtensions.assertListEquals("", expectedBuffers, actualBuffers, ByteBuffer::equals);
     }
 
+    @Test
+    public void testAllocatedLength() {
+        val b1 = Unpooled.wrappedBuffer(new byte[100]).slice(10, 20);
+        val b2 = Unpooled.directBuffer(100).slice(10, 20);
+        val b3 = Unpooled.wrappedUnmodifiableBuffer(b1, b2);
+        System.out.println("100 " + b1.capacity() + " " + new ByteBufWrapper(b1).getAllocatedLength());
+        System.out.println("100 " + b2.capacity() + " " + new ByteBufWrapper(b2).getAllocatedLength());
+        System.out.println("200 " + b3.capacity() + " " + new ByteBufWrapper(b3).getAllocatedLength());
+    }
+
+    @Override
+    protected void checkAllocatedSize(BufferView slice, BufferView base) {
+        // We don't have a good way to extract the actual allocated size from a ByteBuf, so we can only verify that the
+        // allocated length is at least what the length of the buffer is.
+        AssertExtensions.assertGreaterThanOrEqual("Expected slice length to be at most the allocated length.",
+                slice.getLength(), slice.getAllocatedLength());
+    }
+
     @Override
     protected BufferView toBufferView(ArrayView data) {
         return new ByteBufWrapper(Unpooled.wrappedBuffer(data.array(), data.arrayOffset(), data.getLength()));

--- a/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/TruncateableArray.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/selftest/adapters/TruncateableArray.java
@@ -98,6 +98,11 @@ public class TruncateableArray implements ArrayView {
     }
 
     @Override
+    public int getAllocatedLength() {
+        return this.length;
+    }
+
+    @Override
     public byte[] array() {
         throw new UnsupportedOperationException("array() not supported.");
     }


### PR DESCRIPTION
**Change log description**  
Cherry-picking these PRs:
- #5841: Issue #5840: (SegmentStore) Fixed a deadlock in SegmentKeyCache.
- #5851: Issue #5850: (SegmentStore) Fixed a bug in WriterTableProcessor where it would attempt to flush to a deleted segment.
- #5586: Issue #5581: (SegmentStore) Disabling non-essential cache inserts if cache utilization is high 
- #5804: Issue #5789: (SegmentStore) Improving stability during Segment Container Recoveries
- #5811: Issue #5810: (SegmentStore) Fixed a StorageWriter bug that could lead to data loss 
- #5783: Issue #5771: (SegmentStore) Reducing the amount of heap memory used when doing Table Segment Reads.

**Purpose of the change**  
Fixes #5859.

**What the code does**  
Cherry-pick.

**How to verify it**  
Build must pass. Verify intended commits have been cherry-picked into this branch.
