### PR TITLE
Issue 5880: Reduce threads spawned while creating a StateSynchronizer and ReaderGroupManager.

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -95,7 +95,7 @@ public class ClientConfig implements Serializable {
      * An internal property that determines if the client config.
      */
     @Getter(AccessLevel.PACKAGE)
-    private final boolean canOverrideMaxConnectionsConfiguration;
+    private final boolean isDefaultMaxConnections;
 
     /**
      * An internal property that determines whether TLS enabled is derived from Controller URI. It cannot be set
@@ -193,7 +193,7 @@ public class ClientConfig implements Serializable {
         private boolean validateHostName = true;
 
         private boolean deriveTlsEnabledFromControllerURI = true;
-        private boolean canOverrideMaxConnectionsConfiguration = true;
+        private boolean isDefaultMaxConnections = true;
 
         /**
          * Note: by making this method private, we intend to hide the corresponding property
@@ -207,14 +207,9 @@ public class ClientConfig implements Serializable {
             return this;
         }
 
-        private ClientConfigBuilder canOverrideMaxConnectionsConfiguration(boolean value) {
-            this.canOverrideMaxConnectionsConfiguration = value;
-            return this;
-        }
-
         public ClientConfigBuilder maxConnectionsPerSegmentStore(int maxConnectionsPerSegmentStore) {
-            if (this.canOverrideMaxConnectionsConfiguration) {
-                this.canOverrideMaxConnectionsConfiguration(false);
+            if (this.isDefaultMaxConnections) {
+                this.isDefaultMaxConnections(false);
                 this.maxConnectionsPerSegmentStore = maxConnectionsPerSegmentStore;
             } else {
                 log.warn("Update to maxConnectionsPerSegmentStore configuration from {} to {} is ignored,", this.maxConnectionsPerSegmentStore, maxConnectionsPerSegmentStore);
@@ -243,7 +238,7 @@ public class ClientConfig implements Serializable {
                 maxConnectionsPerSegmentStore = DEFAULT_MAX_CONNECTIONS_PER_SEGMENT_STORE;
             }
             return new ClientConfig(controllerURI, credentials, trustStore, validateHostName, maxConnectionsPerSegmentStore,
-                    canOverrideMaxConnectionsConfiguration, deriveTlsEnabledFromControllerURI, enableTlsToController,
+                    isDefaultMaxConnections, deriveTlsEnabledFromControllerURI, enableTlsToController,
                     enableTlsToSegmentStore, metricListener);
         }
 

--- a/client/src/main/java/io/pravega/client/SynchronizerClientFactory.java
+++ b/client/src/main/java/io/pravega/client/SynchronizerClientFactory.java
@@ -36,8 +36,10 @@ public interface SynchronizerClientFactory extends AutoCloseable {
      * @return Instance of ClientFactory implementation.
      */
     static SynchronizerClientFactory withScope(String scope, ClientConfig config) {
-        val connectionFactory = new SocketConnectionFactoryImpl(config);
-        return new ClientFactoryImpl(scope, new ControllerImpl(ControllerImplConfig.builder().clientConfig(config).build(),
+        // Change the max number of number of allowed connections to the segment store to 1.
+        val updatedConfig = config.toBuilder().maxConnectionsPerSegmentStore(1).build();
+        val connectionFactory = new SocketConnectionFactoryImpl(updatedConfig, 1);
+        return new ClientFactoryImpl(scope, new ControllerImpl(ControllerImplConfig.builder().clientConfig(updatedConfig).build(),
                 connectionFactory.getInternalExecutor()), connectionFactory);
     }
 

--- a/client/src/main/java/io/pravega/client/SynchronizerClientFactory.java
+++ b/client/src/main/java/io/pravega/client/SynchronizerClientFactory.java
@@ -44,7 +44,7 @@ public interface SynchronizerClientFactory extends AutoCloseable {
                 .build();
         val connectionFactory = new SocketConnectionFactoryImpl(updatedConfig, 1);
         return new ClientFactoryImpl(scope, new ControllerImpl(ControllerImplConfig.builder().clientConfig(updatedConfig).build(),
-                connectionFactory.getInternalExecutor()), connectionFactory);
+                connectionFactory.getInternalExecutor()), updatedConfig, connectionFactory);
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/SynchronizerClientFactory.java
+++ b/client/src/main/java/io/pravega/client/SynchronizerClientFactory.java
@@ -37,7 +37,11 @@ public interface SynchronizerClientFactory extends AutoCloseable {
      */
     static SynchronizerClientFactory withScope(String scope, ClientConfig config) {
         // Change the max number of number of allowed connections to the segment store to 1.
-        val updatedConfig = config.toBuilder().maxConnectionsPerSegmentStore(1).build();
+        val updatedConfig = config.toBuilder()
+                .maxConnectionsPerSegmentStore(1)
+                .enableTlsToSegmentStore(config.isEnableTlsToSegmentStore())
+                .enableTlsToController(config.isEnableTlsToController())
+                .build();
         val connectionFactory = new SocketConnectionFactoryImpl(updatedConfig, 1);
         return new ClientFactoryImpl(scope, new ControllerImpl(ControllerImplConfig.builder().clientConfig(updatedConfig).build(),
                 connectionFactory.getInternalExecutor()), connectionFactory);

--- a/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
+++ b/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
@@ -16,7 +16,6 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Serializer;
-import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 import java.net.URI;

--- a/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
+++ b/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
@@ -16,6 +16,7 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Serializer;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 import java.net.URI;
@@ -45,7 +46,11 @@ public interface ReaderGroupManager extends AutoCloseable {
      */
     public static ReaderGroupManager withScope(String scope, ClientConfig clientConfig) {
         // Change the max number of number of allowed connections to the segment store to 1.
-        val updatedClientConfig = clientConfig.toBuilder().maxConnectionsPerSegmentStore(1).build();
+        val updatedClientConfig = clientConfig.toBuilder()
+                .maxConnectionsPerSegmentStore(1)
+                .enableTlsToSegmentStore(clientConfig.isEnableTlsToSegmentStore())
+                .enableTlsToController(clientConfig.isEnableTlsToController())
+                .build();
         return new ReaderGroupManagerImpl(scope, updatedClientConfig, new SocketConnectionFactoryImpl(updatedClientConfig, 1));
     }
 

--- a/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
+++ b/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
@@ -16,6 +16,8 @@ import io.pravega.client.stream.ReaderConfig;
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Serializer;
+import lombok.val;
+
 import java.net.URI;
 
 /**
@@ -42,7 +44,9 @@ public interface ReaderGroupManager extends AutoCloseable {
      * @return Instance of Stream Manager implementation.
      */
     public static ReaderGroupManager withScope(String scope, ClientConfig clientConfig) {
-        return new ReaderGroupManagerImpl(scope, clientConfig, new SocketConnectionFactoryImpl(clientConfig));
+        // Change the max number of number of allowed connections to the segment store to 1.
+        val updatedClientConfig = clientConfig.toBuilder().maxConnectionsPerSegmentStore(1).build();
+        return new ReaderGroupManagerImpl(scope, updatedClientConfig, new SocketConnectionFactoryImpl(updatedClientConfig, 1));
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/ReaderGroupManagerImpl.java
@@ -40,7 +40,9 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
 
+import lombok.AccessLevel;
 import lombok.Cleanup;
+import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,7 +58,10 @@ import static io.pravega.shared.NameUtils.getStreamForReaderGroup;
 public class ReaderGroupManagerImpl implements ReaderGroupManager {
 
     private final String scope;
+    @VisibleForTesting
+    @Getter(AccessLevel.PACKAGE)
     private final AbstractClientFactoryImpl clientFactory;
+
     private final Controller controller;
 
     public ReaderGroupManagerImpl(String scope, ClientConfig config, ConnectionFactory connectionFactory) {

--- a/client/src/main/java/io/pravega/client/connection/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/ConnectionPoolImpl.java
@@ -38,7 +38,6 @@ import io.pravega.shared.metrics.MetricNotifier;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
-import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;

--- a/client/src/main/java/io/pravega/client/connection/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/ConnectionPoolImpl.java
@@ -38,7 +38,9 @@ import io.pravega.shared.metrics.MetricNotifier;
 import io.pravega.shared.protocol.netty.ConnectionFailedException;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.ReplyProcessor;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -83,6 +85,8 @@ public class ConnectionPoolImpl implements ConnectionPool {
     }
 
     private final Object lock = new Object();
+    @VisibleForTesting
+    @Getter
     private final ClientConfig clientConfig;
     private final MetricNotifier metricNotifier;
     private final AtomicBoolean closed = new AtomicBoolean(false);

--- a/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ClientFactoryImpl.java
@@ -106,6 +106,20 @@ public class ClientFactoryImpl extends AbstractClientFactoryImpl implements Even
     public ClientFactoryImpl(String scope, Controller controller, ConnectionFactory connectionFactory) {
         this(scope, controller, new ConnectionPoolImpl(ClientConfig.builder().build(), connectionFactory));
     }
+
+    /**
+     * Creates a new instance of the ClientFactory class.
+     * Note: ConnectionFactory  and Controller is closed when {@link ClientFactoryImpl#close()} is invoked.
+     *
+     * @param scope             The scope string.
+     * @param controller        The reference to Controller.
+     * @param config            The client config.
+     * @param connectionFactory The reference to Connection Factory impl.
+     */
+    @VisibleForTesting
+    public ClientFactoryImpl(String scope, Controller controller, ClientConfig config, ConnectionFactory connectionFactory) {
+        this(scope, controller, new ConnectionPoolImpl(config, connectionFactory));
+    }
     
     /**
      * Creates a new instance of the ClientFactory class. Note: ConnectionFactory and Controller is

--- a/client/src/test/java/io/pravega/client/ClientConfigTest.java
+++ b/client/src/test/java/io/pravega/client/ClientConfigTest.java
@@ -113,4 +113,38 @@ public class ClientConfigTest {
                                    .build();
         assertNull("Metrics listener is not configured", clientConfig.getMetricListener());
     }
+
+    @Test
+    public void testOverrideMaxConnections() {
+        // create a client config with default number of for the max connections.
+        ClientConfig clientConfig = ClientConfig.builder()
+                .controllerURI(URI.create("//hostname:9090"))
+                .build();
+        assertEquals(ClientConfig.DEFAULT_MAX_CONNECTIONS_PER_SEGMENT_STORE, clientConfig.getMaxConnectionsPerSegmentStore());
+        assertTrue(clientConfig.isCanOverrideMaxConnectionsConfiguration());
+        ClientConfig clientConfigUpdated = clientConfig.toBuilder().maxConnectionsPerSegmentStore(1).build();
+        assertEquals(1, clientConfigUpdated.getMaxConnectionsPerSegmentStore());
+        assertFalse(clientConfigUpdated.isCanOverrideMaxConnectionsConfiguration());
+        assertEquals(clientConfig.isEnableTls(), clientConfigUpdated.isEnableTls());
+        assertEquals(clientConfig.isEnableTlsToController(), clientConfigUpdated.isEnableTlsToController());
+        assertEquals(clientConfig.isEnableTlsToSegmentStore(), clientConfigUpdated.isEnableTlsToSegmentStore());
+    }
+
+    @Test
+    public void testPreventOverrideMaxConnections() {
+        ClientConfig clientConfig = ClientConfig.builder()
+                .controllerURI(URI.create("//hostname:9090"))
+                .maxConnectionsPerSegmentStore(5)
+                .build();
+        assertFalse(clientConfig.isCanOverrideMaxConnectionsConfiguration());
+        // try resetting the number of connections to 1.
+        ClientConfig.ClientConfigBuilder clientConfigBuilder = clientConfig.toBuilder();
+        ClientConfig clientConfigUpdated = clientConfigBuilder.maxConnectionsPerSegmentStore(1).build();
+        // no changes expected with the max connection configuration.
+        assertEquals(5, clientConfigUpdated.getMaxConnectionsPerSegmentStore());
+        assertFalse(clientConfigUpdated.isCanOverrideMaxConnectionsConfiguration());
+        assertEquals(clientConfig.isEnableTls(), clientConfigUpdated.isEnableTls());
+        assertEquals(clientConfig.isEnableTlsToController(), clientConfigUpdated.isEnableTlsToController());
+        assertEquals(clientConfig.isEnableTlsToSegmentStore(), clientConfigUpdated.isEnableTlsToSegmentStore());
+    }
 }

--- a/client/src/test/java/io/pravega/client/ClientConfigTest.java
+++ b/client/src/test/java/io/pravega/client/ClientConfigTest.java
@@ -121,10 +121,10 @@ public class ClientConfigTest {
                 .controllerURI(URI.create("//hostname:9090"))
                 .build();
         assertEquals(ClientConfig.DEFAULT_MAX_CONNECTIONS_PER_SEGMENT_STORE, clientConfig.getMaxConnectionsPerSegmentStore());
-        assertTrue(clientConfig.isCanOverrideMaxConnectionsConfiguration());
+        assertTrue(clientConfig.isDefaultMaxConnections());
         ClientConfig clientConfigUpdated = clientConfig.toBuilder().maxConnectionsPerSegmentStore(1).build();
         assertEquals(1, clientConfigUpdated.getMaxConnectionsPerSegmentStore());
-        assertFalse(clientConfigUpdated.isCanOverrideMaxConnectionsConfiguration());
+        assertFalse(clientConfigUpdated.isDefaultMaxConnections());
         assertEquals(clientConfig.isEnableTls(), clientConfigUpdated.isEnableTls());
         assertEquals(clientConfig.isEnableTlsToController(), clientConfigUpdated.isEnableTlsToController());
         assertEquals(clientConfig.isEnableTlsToSegmentStore(), clientConfigUpdated.isEnableTlsToSegmentStore());
@@ -136,13 +136,13 @@ public class ClientConfigTest {
                 .controllerURI(URI.create("//hostname:9090"))
                 .maxConnectionsPerSegmentStore(5)
                 .build();
-        assertFalse(clientConfig.isCanOverrideMaxConnectionsConfiguration());
+        assertFalse(clientConfig.isDefaultMaxConnections());
         // try resetting the number of connections to 1.
         ClientConfig.ClientConfigBuilder clientConfigBuilder = clientConfig.toBuilder();
         ClientConfig clientConfigUpdated = clientConfigBuilder.maxConnectionsPerSegmentStore(1).build();
         // no changes expected with the max connection configuration.
         assertEquals(5, clientConfigUpdated.getMaxConnectionsPerSegmentStore());
-        assertFalse(clientConfigUpdated.isCanOverrideMaxConnectionsConfiguration());
+        assertFalse(clientConfigUpdated.isDefaultMaxConnections());
         assertEquals(clientConfig.isEnableTls(), clientConfigUpdated.isEnableTls());
         assertEquals(clientConfig.isEnableTlsToController(), clientConfigUpdated.isEnableTlsToController());
         assertEquals(clientConfig.isEnableTlsToSegmentStore(), clientConfigUpdated.isEnableTlsToSegmentStore());

--- a/client/src/test/java/io/pravega/client/admin/impl/ReaderGroupManagerImplTest.java
+++ b/client/src/test/java/io/pravega/client/admin/impl/ReaderGroupManagerImplTest.java
@@ -10,6 +10,9 @@
 package io.pravega.client.admin.impl;
 
 import com.google.common.collect.ImmutableMap;
+import io.pravega.client.ClientConfig;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.connection.impl.ConnectionPoolImpl;
 import io.pravega.client.control.impl.Controller;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.state.InitialUpdate;
@@ -33,12 +36,14 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -181,6 +186,16 @@ public class ReaderGroupManagerImplTest {
         verify(controller, times(1)).getReaderGroupConfig(SCOPE, GROUP_NAME);
         verify(controller, times(1)).deleteStream(SCOPE, NameUtils.getStreamForReaderGroup(GROUP_NAME));
         verify(controller, times(0)).deleteReaderGroup(SCOPE, GROUP_NAME, expectedConfig.getReaderGroupId());
+    }
+
+    @Test
+    public void testCreateReaderGroupManager() {
+        ClientConfig config = ClientConfig.builder().controllerURI(URI.create("tls://localhost:9090")).build();
+        ReaderGroupManagerImpl readerGroupMgr = (ReaderGroupManagerImpl) ReaderGroupManager.withScope(SCOPE, config);
+        ClientFactoryImpl factory = (ClientFactoryImpl) readerGroupMgr.getClientFactory();
+        ConnectionPoolImpl cp = (ConnectionPoolImpl) factory.getConnectionPool();
+        assertEquals(1, cp.getClientConfig().getMaxConnectionsPerSegmentStore());
+        assertEquals(config.isEnableTls(), cp.getClientConfig().isEnableTls());
     }
 
     private StreamCut createStreamCut(String streamName, int numberOfSegments) {

--- a/client/src/test/java/io/pravega/client/admin/impl/ReaderGroupManagerImplTest.java
+++ b/client/src/test/java/io/pravega/client/admin/impl/ReaderGroupManagerImplTest.java
@@ -28,6 +28,7 @@ import io.pravega.client.stream.impl.ReaderGroupNotFoundException;
 import io.pravega.client.stream.impl.ReaderGroupState;
 import io.pravega.client.stream.impl.StreamCutImpl;
 import io.pravega.shared.NameUtils;
+import lombok.Cleanup;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -191,6 +192,7 @@ public class ReaderGroupManagerImplTest {
     @Test
     public void testCreateReaderGroupManager() {
         ClientConfig config = ClientConfig.builder().controllerURI(URI.create("tls://localhost:9090")).build();
+        @Cleanup
         ReaderGroupManagerImpl readerGroupMgr = (ReaderGroupManagerImpl) ReaderGroupManager.withScope(SCOPE, config);
         ClientFactoryImpl factory = (ClientFactoryImpl) readerGroupMgr.getClientFactory();
         ConnectionPoolImpl cp = (ConnectionPoolImpl) factory.getConnectionPool();

--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -622,8 +622,8 @@ public class SynchronizerTest {
     @Test(timeout = 5000)
     public void testSynchronizerClientFactory() {
         ClientConfig config = ClientConfig.builder().controllerURI(URI.create("tls://localhost:9090")).build();
-        SynchronizerClientFactory factory1 = SynchronizerClientFactory.withScope("scope", config);
-        ClientFactoryImpl factory = (ClientFactoryImpl) factory1;
+        @Cleanup
+        ClientFactoryImpl factory = (ClientFactoryImpl) SynchronizerClientFactory.withScope("scope", config);
         ConnectionPoolImpl cp = (ConnectionPoolImpl) factory.getConnectionPool();
         assertEquals(1, cp.getClientConfig().getMaxConnectionsPerSegmentStore());
         assertEquals(config.isEnableTls(), cp.getClientConfig().isEnableTls());

--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -10,6 +10,8 @@
 package io.pravega.client.state.impl;
 
 import io.pravega.client.ClientConfig;
+import io.pravega.client.SynchronizerClientFactory;
+import io.pravega.client.connection.impl.ConnectionPoolImpl;
 import io.pravega.client.segment.impl.EndOfSegmentException;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.segment.impl.SegmentAttribute;
@@ -35,6 +37,7 @@ import io.pravega.client.stream.mock.MockSegmentStreamFactory;
 import io.pravega.common.util.ReusableLatch;
 import io.pravega.test.common.AssertExtensions;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.Iterator;
@@ -614,6 +617,16 @@ public class SynchronizerTest {
 
         syncA.fetchUpdates(); // invoke fetchUpdates which will encounter TruncatedDataException from RevisionedStreamClient.
         assertEquals("x", syncA.getState().getValue());
+    }
+
+    @Test(timeout = 5000)
+    public void testSynchronizerClientFactory() {
+        ClientConfig config = ClientConfig.builder().controllerURI(URI.create("tls://localhost:9090")).build();
+        SynchronizerClientFactory factory1 = SynchronizerClientFactory.withScope("scope", config);
+        ClientFactoryImpl factory = (ClientFactoryImpl) factory1;
+        ConnectionPoolImpl cp = (ConnectionPoolImpl) factory.getConnectionPool();
+        assertEquals(1, cp.getClientConfig().getMaxConnectionsPerSegmentStore());
+        assertEquals(config.isEnableTls(), cp.getClientConfig().isEnableTls());
     }
 
     private void createScopeAndStream(String streamName, String scope, Controller controller) {

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -110,13 +110,13 @@ plugins.withId('java') {
 
         onOutput { descriptor, event ->
             outputCache.add(event.getMessage())
-            while (outputCache.size() > 30000) outputCache.remove()
+            while (outputCache.size() > 300) outputCache.remove()
         }
 
         afterTest { descriptor, result ->
             if (result.resultType == TestResult.ResultType.FAILURE && outputCache.size() > 0) {
                 println()
-                println("Output of ${descriptor.getClassName()}.${descriptor.getDisplayName()} (Last 30000 lines):")
+                println("Output of ${descriptor.getClassName()}.${descriptor.getDisplayName()} (Last 300 lines):")
                 outputCache.each { print(" > $it") }
             }
         }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -105,13 +105,13 @@ plugins.withId('java') {
 
         onOutput { descriptor, event ->
             outputCache.add(event.getMessage())
-            while (outputCache.size() > 300) outputCache.remove()
+            while (outputCache.size() > 30000) outputCache.remove()
         }
 
         afterTest { descriptor, result ->
             if (result.resultType == TestResult.ResultType.FAILURE && outputCache.size() > 0) {
                 println()
-                println("Output of ${descriptor.getClassName()}.${descriptor.getDisplayName()} (Last 300 lines):")
+                println("Output of ${descriptor.getClassName()}.${descriptor.getDisplayName()} (Last 30000 lines):")
                 outputCache.each { print(" > $it") }
             }
         }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -110,13 +110,13 @@ plugins.withId('java') {
 
         onOutput { descriptor, event ->
             outputCache.add(event.getMessage())
-            while (outputCache.size() > 300) outputCache.remove()
+            while (outputCache.size() > 30000) outputCache.remove()
         }
 
         afterTest { descriptor, result ->
             if (result.resultType == TestResult.ResultType.FAILURE && outputCache.size() > 0) {
                 println()
-                println("Output of ${descriptor.getClassName()}.${descriptor.getDisplayName()} (Last 300 lines):")
+                println("Output of ${descriptor.getClassName()}.${descriptor.getDisplayName()} (Last 30000 lines):")
                 outputCache.each { print(" > $it") }
             }
         }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -105,13 +105,13 @@ plugins.withId('java') {
 
         onOutput { descriptor, event ->
             outputCache.add(event.getMessage())
-            while (outputCache.size() > 30000) outputCache.remove()
+            while (outputCache.size() > 300) outputCache.remove()
         }
 
         afterTest { descriptor, result ->
             if (result.resultType == TestResult.ResultType.FAILURE && outputCache.size() > 0) {
                 println()
-                println("Output of ${descriptor.getClassName()}.${descriptor.getDisplayName()} (Last 30000 lines):")
+                println("Output of ${descriptor.getClassName()}.${descriptor.getDisplayName()} (Last 300 lines):")
                 outputCache.each { print(" > $it") }
             }
         }


### PR DESCRIPTION
**Change log description**  
Reduce threads spawned while creating a StateSynchronizer and ReaderGroupManager.

**Purpose of the change**  
Fixes #5880 .

**What the code does**  
Reduce threads spawned while creating a StateSynchronizer and ReaderGroupManager.
- Configure connection pooling to use a max of 1 connection per segment store.
- Reduce the number of internal thread pools to 1.

**How to verify it**  
All the existing tests should continue to pass.

Note: Verification is in progress.
