### PR TITLE
Issue 5890: Sporadic failure in test StreamRecreationTest.testStreamRecreation

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
@@ -99,13 +99,13 @@ public class StreamRecreationTest {
         zkTestServer.close();
     }
 
-    @Test(timeout = 40000)
+    @Test(timeout = 60000)
     @SuppressWarnings("deprecation")
     public void testStreamRecreation() throws Exception {
         final String myScope = "myScope";
         final String myStream = "myStream";
         final String myReaderGroup = "myReaderGroup";
-        final int numIterations = 10;
+        final int numIterations = 6;
 
         // Create the scope and the stream.
         @Cleanup


### PR DESCRIPTION
**Change log description**  
Reduce load in testStreamRecreation to prevent sporadic timeout exceptions to occur when running in slow instances.

**Purpose of the change**  
Fixes #5890.

**What the code does**  
The change basically reduces the number of test iterations (load) and increases the test timeout. The reason for this is that it has been seen failing once on a slow Jenkins instance. In the logs, the test was progressing correctly but slowly, which caused the timeout to occur.

**How to verify it**  
Test should pass reliably on slow instances.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>