### PR TITLE
Issue 5895: Increase timeout for Standalone tests.

### DIFF
--- a/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
@@ -50,7 +50,7 @@ public class AuthEnabledInProcPravegaClusterTest {
      * Note: The timeout being used for the test is kept rather large so that there is ample time for the expected
      * exception to be raised even in case of abnormal delays in test environments.
      */
-    @Test(timeout = 30000)
+    @Test(timeout = 50000)
     public void testCreateStreamFailsWithInvalidClientConfig() {
        ClientConfig clientConfig = ClientConfig.builder()
                 .credentials(new DefaultCredentials("", ""))
@@ -65,7 +65,7 @@ public class AuthEnabledInProcPravegaClusterTest {
                 e -> hasAuthExceptionAsRootCause(e));
     }
 
-    @Test(timeout = 30000)
+    @Test(timeout = 50000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
         testWriteAndReadAnEvent(scope, stream, msg, EMULATOR.getClientConfig());
     }

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -41,7 +41,7 @@ public class InProcPravegaClusterTest {
      * intended to also run as a unit test, but it could be moved to an integration test suite if and when necessary.
      *
      */
-    @Test(timeout = 30000)
+    @Test(timeout = 50000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
         testWriteAndReadAnEvent("TestScope", "TestStream", msg, EMULATOR.getClientConfig());
     }

--- a/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
@@ -33,7 +33,7 @@ public class SecurePravegaClusterTest {
     final String stream = "TlsAndAuthTestStream";
     final String msg = "Test message on the encrypted channel with auth credentials";
 
-    @Test(timeout = 30000)
+    @Test(timeout = 50000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
         testWriteAndReadAnEvent(scope, stream, msg, EMULATOR.getClientConfig());
     }

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -49,7 +49,7 @@ public class TlsEnabledInProcPravegaClusterTest {
      * Note: The timeout being used for the test is kept rather large so that there is ample time for the expected
      * exception to be raised even in case of abnormal delays in test environments.
      */
-    @Test(timeout = 30000)
+    @Test(timeout = 50000)
     public void testCreateStreamFailsWithInvalidClientConfig() {
         // Truststore for the TLS connection is missing.
         ClientConfig clientConfig = ClientConfig.builder()


### PR DESCRIPTION
**Change log description**  
- Increase timeout for Standalone tests.

**Purpose of the change**  
Workaround for #5895 

**What the code does**  
Increase the timeout of the tests to mitigate the issue of slow readergroup creation on the controller.

**How to verify it**  
The tests should reliably pass.
