### PR TITLE
Issue 5911: CLI commands to access a Segment directly in LTS

### DIFF
--- a/cli/admin/README.md
+++ b/cli/admin/README.md
@@ -149,7 +149,6 @@ Once in the pod, you can run the Pravega Admin CLI:
     OpenJDK 64-Bit Server VM warning: Option MaxRAMFraction was deprecated in version 10.0 and will likely be removed in a future release.
     Pravega Admin CLI.
     
-    Exception reading input properties file: null
     Initial configuration:
         pravegaservice.container.count=4
         bookkeeper.ledger.path=/pravega/pravega/bookkeeper/ledgers

--- a/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
@@ -49,6 +49,7 @@ import io.pravega.cli.admin.storage.ListSegmentAttributesCommand;
 import io.pravega.cli.admin.storage.ListTableEntriesIndexCommand;
 import io.pravega.cli.admin.storage.ReadSegmentCommand;
 import io.pravega.cli.admin.storage.ScanTableEntriesCommand;
+import io.pravega.cli.admin.storage.UpdateSegmentAttributesCommand;
 import io.pravega.cli.admin.utils.CLIControllerConfig;
 import io.pravega.common.Exceptions;
 import io.pravega.segmentstore.server.store.ServiceConfig;
@@ -274,6 +275,7 @@ public abstract class AdminCommand {
                         .put(ListTableEntriesIndexCommand::descriptor, ListTableEntriesIndexCommand::new)
                         .put(ScanTableEntriesCommand::descriptor, ScanTableEntriesCommand::new)
                         .put(GetTableEntryCommand::descriptor, GetTableEntryCommand::new)
+                        .put(UpdateSegmentAttributesCommand::descriptor, UpdateSegmentAttributesCommand::new)
                         .build());
 
         /**

--- a/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
@@ -28,6 +28,11 @@ import io.pravega.cli.admin.bookkeeper.BookKeeperDisableCommand;
 import io.pravega.cli.admin.bookkeeper.BookKeeperEnableCommand;
 import io.pravega.cli.admin.bookkeeper.BookKeeperListCommand;
 import io.pravega.cli.admin.bookkeeper.ContainerRecoverCommand;
+import io.pravega.cli.admin.cluster.GetClusterNodesCommand;
+import io.pravega.cli.admin.cluster.GetSegmentStoreByContainerCommand;
+import io.pravega.cli.admin.cluster.ListContainersCommand;
+import io.pravega.cli.admin.config.ConfigListCommand;
+import io.pravega.cli.admin.config.ConfigSetCommand;
 import io.pravega.cli.admin.controller.ControllerDescribeReaderGroupCommand;
 import io.pravega.cli.admin.controller.ControllerDescribeScopeCommand;
 import io.pravega.cli.admin.controller.ControllerDescribeStreamCommand;
@@ -37,11 +42,13 @@ import io.pravega.cli.admin.controller.ControllerListStreamsInScopeCommand;
 import io.pravega.cli.admin.dataRecovery.DurableLogRecoveryCommand;
 import io.pravega.cli.admin.dataRecovery.StorageListSegmentsCommand;
 import io.pravega.cli.admin.password.PasswordFileCreatorCommand;
-import io.pravega.cli.admin.cluster.GetClusterNodesCommand;
-import io.pravega.cli.admin.cluster.GetSegmentStoreByContainerCommand;
-import io.pravega.cli.admin.cluster.ListContainersCommand;
-import io.pravega.cli.admin.config.ConfigListCommand;
-import io.pravega.cli.admin.config.ConfigSetCommand;
+import io.pravega.cli.admin.storage.GetSegmentAttributesCommand;
+import io.pravega.cli.admin.storage.GetSegmentInfoCommand;
+import io.pravega.cli.admin.storage.GetTableEntryCommand;
+import io.pravega.cli.admin.storage.ListSegmentAttributesCommand;
+import io.pravega.cli.admin.storage.ListTableEntriesIndexCommand;
+import io.pravega.cli.admin.storage.ReadSegmentCommand;
+import io.pravega.cli.admin.storage.ScanTableEntriesCommand;
 import io.pravega.cli.admin.utils.CLIControllerConfig;
 import io.pravega.common.Exceptions;
 import io.pravega.segmentstore.server.store.ServiceConfig;
@@ -164,7 +171,13 @@ public abstract class AdminCommand {
     //region Arguments
 
     protected void ensureArgCount(int expectedCount) {
-        Preconditions.checkArgument(this.commandArgs.getArgs().size() == expectedCount, "Incorrect argument count.");
+        Preconditions.checkArgument(this.commandArgs.getArgs().size() == expectedCount,
+                "Incorrect argument count. Expected %s, actual %s.", expectedCount, this.commandArgs.getArgs().size());
+    }
+
+    protected void ensureArgCount(int minCount, int maxCount) {
+        Preconditions.checkArgument(this.commandArgs.getArgs().size() >= minCount && this.commandArgs.getArgs().size() <= maxCount,
+                "Incorrect argument count. Expected between %s and %s, actual %s.", minCount, maxCount, this.commandArgs.getArgs().size());
     }
 
     protected int getArgCount() {
@@ -175,7 +188,15 @@ public abstract class AdminCommand {
         return getArg(index, Integer::parseInt);
     }
 
-    private <T> T getArg(int index, Function<String, T> converter) {
+    protected long getLongArg(int index) {
+        return getArg(index, Long::parseLong);
+    }
+
+    protected String getArg(int index) {
+        return getArg(index, s -> s);
+    }
+
+    protected <T> T getArg(int index, Function<String, T> converter) {
         String s = null;
         try {
             s = this.commandArgs.getArgs().get(index);
@@ -246,6 +267,13 @@ public abstract class AdminCommand {
                         .put(PasswordFileCreatorCommand::descriptor, PasswordFileCreatorCommand::new)
                         .put(StorageListSegmentsCommand::descriptor, StorageListSegmentsCommand::new)
                         .put(DurableLogRecoveryCommand::descriptor, DurableLogRecoveryCommand::new)
+                        .put(GetSegmentInfoCommand::descriptor, GetSegmentInfoCommand::new)
+                        .put(ReadSegmentCommand::descriptor, ReadSegmentCommand::new)
+                        .put(GetSegmentAttributesCommand::descriptor, GetSegmentAttributesCommand::new)
+                        .put(ListSegmentAttributesCommand::descriptor, ListSegmentAttributesCommand::new)
+                        .put(ListTableEntriesIndexCommand::descriptor, ListTableEntriesIndexCommand::new)
+                        .put(ScanTableEntriesCommand::descriptor, ScanTableEntriesCommand::new)
+                        .put(GetTableEntryCommand::descriptor, GetTableEntryCommand::new)
                         .build());
 
         /**

--- a/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommandState.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommandState.java
@@ -29,7 +29,7 @@ public class AdminCommandState implements AutoCloseable {
     @Getter
     private final ServiceBuilderConfig.Builder configBuilder;
     @Getter
-    private final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(2, "password-tools");
+    private final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(2, "admin-cli");
 
     /**
      * Creates a new instance of the AdminCommandState class.
@@ -39,7 +39,7 @@ public class AdminCommandState implements AutoCloseable {
     public AdminCommandState() throws IOException {
         this.configBuilder = ServiceBuilderConfig.builder();
         try {
-            this.configBuilder.include(System.getProperty(ServiceBuilderConfig.CONFIG_FILE_PROPERTY_NAME, "conf/admin-cli.properties"));
+            this.configBuilder.include(System.getProperty(ServiceBuilderConfig.CONFIG_FILE_PROPERTY_NAME, "config/admin-cli.properties"));
         } catch (FileNotFoundException ex) {
             // Nothing to do here.
         }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/storage/GetSegmentAttributesCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/storage/GetSegmentAttributesCommand.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.storage;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.segmentstore.server.containers.DebugStorageSegment;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.val;
+
+/**
+ * Gets a set of Attributes for a Segment (based on Attribute Id).
+ */
+public class GetSegmentAttributesCommand extends StorageCommand {
+    public GetSegmentAttributesCommand(CommandArgs args) {
+        super(args);
+    }
+
+    public static CommandDescriptor descriptor() {
+        return new CommandDescriptor(COMPONENT, "get-attributes", "Gets a set of attributes for a segment.",
+                new ArgDescriptor("segment-name", "Fully qualified segment name (include scope and stream)"),
+                new ArgDescriptor("list-of-attribute-ids", "Space-separated list of attribute ids to retrieve."));
+    }
+
+    @Override
+    public void execute() throws Exception {
+        ensureArgCount(2, 1000);
+
+        final String segmentName = getArg(0);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(segmentName), "Invalid segment name");
+
+        val attributeIds = new ArrayList<UUID>();
+        for (int i = 1; i < getArgCount(); i++) {
+            attributeIds.add(getArg(i, UUID::fromString));
+        }
+
+        @Cleanup
+        val storage = this.storageFactory.createStorageAdapter();
+        storage.initialize(Integer.MAX_VALUE);
+        @Cleanup
+        val segment = new DebugStorageSegment(segmentName, storage, executorService());
+
+        val result = segment.getAttributes(attributeIds).get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        output("Listing %s/%s attribute(s):", result.size(), attributeIds.size());
+        for (val e : result.entrySet()) {
+            output("\t%s", formatAttribute(e));
+        }
+    }
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/storage/GetSegmentInfoCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/storage/GetSegmentInfoCommand.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.storage;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.pravega.cli.admin.AdminCommand;
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.segmentstore.server.containers.DebugStorageSegment;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.val;
+
+/**
+ * Gets information about a segment (it can be a main segment or attribute segment - as long as it's a valid LTS segment).
+ */
+public class GetSegmentInfoCommand extends StorageCommand {
+    public GetSegmentInfoCommand(CommandArgs args) {
+        super(args);
+    }
+
+    public static AdminCommand.CommandDescriptor descriptor() {
+        return new AdminCommand.CommandDescriptor(COMPONENT, "segment-info", "Gets information about a segment.",
+                new AdminCommand.ArgDescriptor("segment-name", "Fully qualified segment name (include scope and stream)"));
+    }
+
+    @Override
+    public void execute() throws Exception {
+        ensureArgCount(1);
+        final String segmentName = getArg(0);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(segmentName), "Invalid segment name");
+
+        @Cleanup
+        val storage = this.storageFactory.createStorageAdapter();
+        storage.initialize(Integer.MAX_VALUE);
+        @Cleanup
+        val segment = new DebugStorageSegment(segmentName, storage, executorService());
+
+        val info = segment.getSegmentInfo().get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        output("Segment Name: %s", info.getName());
+        output("Length      : %s", info.getLength());
+        output("Start Offset: %s", info.getStartOffset());
+        output("Sealed      : %s", info.isSealed());
+        output("Deleted     : %s", info.isDeleted());
+        output("Modified    : %s", info.getLastModified().asDate());
+        output("Attributes  : %s", info.getAttributes().size());
+    }
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/storage/GetTableEntryCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/storage/GetTableEntryCommand.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.storage;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.common.util.ByteArraySegment;
+import io.pravega.segmentstore.server.containers.DebugStorageSegment;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.val;
+
+/**
+ * Retrieves a single Table Entry from a Table Segment.
+ */
+public class GetTableEntryCommand extends StorageCommand {
+    public GetTableEntryCommand(CommandArgs args) {
+        super(args);
+    }
+
+    public static CommandDescriptor descriptor() {
+        return new CommandDescriptor(COMPONENT, "get-table-entry", "Gets a single table entry for a segment.",
+                new ArgDescriptor("segment-name", "Fully qualified segment name (include scope and stream)"),
+                new ArgDescriptor("key", "The key (in UTF-8) string form."));
+    }
+
+    @Override
+    public void execute() throws Exception {
+        ensureArgCount(2);
+
+        final String segmentName = getArg(0);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(segmentName), "Invalid segment name");
+
+        val key = new ByteArraySegment(getArg(1).getBytes(Charsets.UTF_8));
+
+        @Cleanup
+        val storage = this.storageFactory.createStorageAdapter();
+        storage.initialize(Integer.MAX_VALUE);
+        @Cleanup
+        val segment = new DebugStorageSegment(segmentName, storage, executorService());
+
+        val result = segment.getTableEntry(key).get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        output("Result: %s", formatTableEntry(result));
+    }
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/storage/ListSegmentAttributesCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/storage/ListSegmentAttributesCommand.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.storage;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.segmentstore.server.containers.DebugStorageSegment;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.Cleanup;
+import lombok.val;
+
+/**
+ * Lists all Attributes in a Segment's Attribute Index.
+ */
+public class ListSegmentAttributesCommand extends StorageCommand {
+    private static final int MAX_AT_ONCE = 1000;
+
+    public ListSegmentAttributesCommand(CommandArgs args) {
+        super(args);
+    }
+
+    public static CommandDescriptor descriptor() {
+        return new CommandDescriptor(COMPONENT, "list-attributes", "Lists all attributes for a segment (NOTE: may be a lot).",
+                new ArgDescriptor("segment-name", "Fully qualified segment name (include scope and stream)"),
+                new ArgDescriptor("output-file-path", "[Optional] Path to (local) file where to write the result"));
+    }
+
+    @Override
+    public void execute() throws Exception {
+        ensureArgCount(1, 2);
+
+        final String segmentName = getArg(0);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(segmentName), "Invalid segment name");
+
+        final String targetPath = getCommandArgs().getArgs().size() == 1 ? null : getArg(1);
+
+        @Cleanup
+        val storage = this.storageFactory.createStorageAdapter();
+        storage.initialize(Integer.MAX_VALUE);
+        @Cleanup
+        val segment = new DebugStorageSegment(segmentName, storage, executorService());
+
+        @Cleanup
+        val writer = targetPath == null ? new ConsoleWriter(MAX_AT_ONCE) : new FileWriter(Paths.get(targetPath));
+        if (!writer.initialize()) {
+            return;
+        }
+
+        val totalCount = new AtomicLong(0);
+        val iterator = segment.iterateAttributes().get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        boolean canContinue = true;
+        while (canContinue) {
+            val next = iterator.getNext().get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            if (next == null) {
+                break;
+            }
+
+            for (val attribute : next) {
+                totalCount.incrementAndGet();
+                if (!writer.write(formatAttribute(attribute))) {
+                    canContinue = false;
+                    break;
+                }
+            }
+        }
+
+        output("Found %s attribute(s).", totalCount);
+    }
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/storage/ListTableEntriesIndexCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/storage/ListTableEntriesIndexCommand.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.storage;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.segmentstore.server.containers.DebugStorageSegment;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.Cleanup;
+import lombok.val;
+
+/**
+ * Lists all Table Entries in a Table Segment that are still referenced from the index. Iterates through the index and
+ * then reads the Table Entries pointed to by the index entries.
+ */
+public class ListTableEntriesIndexCommand extends StorageCommand {
+    private static final int MAX_AT_ONCE = 10000;
+
+    public ListTableEntriesIndexCommand(CommandArgs args) {
+        super(args);
+    }
+
+    public static CommandDescriptor descriptor() {
+        return new CommandDescriptor(COMPONENT, "list-table-entries", "Lists all table entries for a table segment (NOTE: may be a lot).",
+                new ArgDescriptor("segment-name", "Fully qualified segment name (include scope and stream)"),
+                new ArgDescriptor("output-file-path", "[Optional] Path to (local) file where to write the result"));
+    }
+
+    @Override
+    public void execute() throws Exception {
+        ensureArgCount(1, 2);
+
+        final String segmentName = getArg(0);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(segmentName), "Invalid segment name");
+
+        final String targetPath = getCommandArgs().getArgs().size() == 1 ? null : getArg(1);
+
+        @Cleanup
+        val storage = this.storageFactory.createStorageAdapter();
+        storage.initialize(Integer.MAX_VALUE);
+        @Cleanup
+        val segment = new DebugStorageSegment(segmentName, storage, executorService());
+
+        @Cleanup
+        val writer = targetPath == null ? new ConsoleWriter(MAX_AT_ONCE) : new FileWriter(Paths.get(targetPath));
+        if (!writer.initialize()) {
+            return;
+        }
+
+        val totalCount = new AtomicLong(0);
+        val validCount = new AtomicLong(0);
+        val invalidCount = new AtomicLong(0);
+
+        val iterator = segment.iterateTableEntriesFromIndex().get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        boolean canContinue = true;
+        while (canContinue) {
+            val next = iterator.getNext().get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            if (next == null) {
+                break;
+            }
+
+            for (val entry : next) {
+                if (entry instanceof DebugStorageSegment.ValidTableEntryInfo) {
+                    validCount.incrementAndGet();
+                } else {
+                    invalidCount.incrementAndGet();
+                }
+                totalCount.incrementAndGet();
+                if (!writer.write(formatTableEntry(entry))) {
+                    canContinue = false;
+                    break;
+                }
+            }
+        }
+
+        output("Entries: %s, Valid: %s, Invalid: %s", totalCount, validCount, invalidCount);
+    }
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/storage/ReadSegmentCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/storage/ReadSegmentCommand.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.storage;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.segmentstore.server.containers.DebugStorageSegment;
+import java.nio.channels.FileChannel;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.val;
+
+/**
+ * Reads (and downloads) a range of bytes from a segment (it can be a main segment or attribute segment, as long as it's
+ * a valid LTS segment).
+ */
+public class ReadSegmentCommand extends StorageCommand {
+    private static final long REPORT_FREQUENCY = 10 * 1024 * 1024;
+
+    public ReadSegmentCommand(CommandArgs args) {
+        super(args);
+    }
+
+    public static CommandDescriptor descriptor() {
+        return new CommandDescriptor(COMPONENT, "read-segment", "Reads the contents of a segment from Storage.",
+                new ArgDescriptor("segment-name", "Fully qualified segment name (include scope and stream)"),
+                new ArgDescriptor("offset", "Offset to start reading at"),
+                new ArgDescriptor("length", "Number of bytes to read"),
+                new ArgDescriptor("output-file-path", "Path to (local) file where to write the result"));
+    }
+
+    @Override
+    public void execute() throws Exception {
+        ensureArgCount(4);
+        final String segmentName = getArg(0);
+        final long offset = getLongArg(1);
+        final int length = getIntArg(2);
+        final String targetPath = getArg(3);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(segmentName), "Invalid segment name");
+        val targetFile = Paths.get(targetPath).toFile();
+        if (!maybeCreateFile(targetFile)) {
+            return;
+        }
+
+        @Cleanup
+        val storage = this.storageFactory.createStorageAdapter();
+        storage.initialize(Integer.MAX_VALUE);
+        @Cleanup
+        val segment = new DebugStorageSegment(segmentName, storage, executorService());
+
+        @Cleanup
+        val readResult = segment.read(offset, length).get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+
+        long bytesWritten = 0L;
+        long lastReport = 0L;
+        try (FileChannel channel = FileChannel.open(targetFile.toPath(), StandardOpenOption.WRITE)) {
+            while (readResult.hasNext()) {
+                val entry = readResult.next();
+                entry.requestContent(DEFAULT_TIMEOUT);
+                val content = entry.getContent().get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                val bufferIterator = content.iterateBuffers();
+                while (bufferIterator.hasNext()) {
+                    val buffer = bufferIterator.next();
+                    while (buffer.hasRemaining()) {
+                        int c = channel.write(buffer);
+                        assert c > 0;
+                        bytesWritten += c;
+                        if (bytesWritten - lastReport >= REPORT_FREQUENCY) {
+                            output("Read %s bytes into '%s'.", bytesWritten, targetFile);
+                            lastReport = bytesWritten;
+                        }
+                    }
+                }
+            }
+        }
+
+        output("Read a total of %s bytes into '%s'.", bytesWritten, targetFile);
+    }
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/storage/ScanTableEntriesCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/storage/ScanTableEntriesCommand.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.storage;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.segmentstore.server.containers.DebugStorageSegment;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.Cleanup;
+import lombok.val;
+
+/**
+ * Scans a Table Segment for Table Entries (valid or invalid).
+ */
+public class ScanTableEntriesCommand extends StorageCommand {
+    private static final int MAX_AT_ONCE = 10000;
+
+    public ScanTableEntriesCommand(CommandArgs args) {
+        super(args);
+    }
+
+    public static CommandDescriptor descriptor() {
+        return new CommandDescriptor(COMPONENT, "scan-table-entries", "Scans a table entries for entries.",
+                new ArgDescriptor("segment-name", "Fully qualified segment name (include scope and stream)"),
+                new ArgDescriptor("start-offset", "Offset within the table segment to start scanning at"),
+                new ArgDescriptor("max-length", "Maximum number of bytes to scan"),
+                new ArgDescriptor("output-file-path", "[Optional] Path to (local) file where to write the result"));
+    }
+
+    @Override
+    public void execute() throws Exception {
+        ensureArgCount(3, 4);
+
+        final String segmentName = getArg(0);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(segmentName), "Invalid segment name");
+        final long startOffset = getLongArg(1);
+        Preconditions.checkArgument(startOffset >= 0, "start-offset must be non-negative");
+        final int maxLength = getIntArg(2);
+        Preconditions.checkArgument(maxLength > 0, "max-length must be a positive integer");
+
+        final String targetPath = getCommandArgs().getArgs().size() < 4 ? null : getArg(3);
+
+        @Cleanup
+        val storage = this.storageFactory.createStorageAdapter();
+        storage.initialize(Integer.MAX_VALUE);
+        @Cleanup
+        val segment = new DebugStorageSegment(segmentName, storage, executorService());
+
+        @Cleanup
+        val writer = targetPath == null ? new ConsoleWriter(MAX_AT_ONCE) : new FileWriter(Paths.get(targetPath));
+        if (!writer.initialize()) {
+            return;
+        }
+
+        val totalCount = new AtomicLong(0);
+        val validCount = new AtomicLong(0);
+        val invalidCount = new AtomicLong(0);
+
+        val iterator = segment.scanTableSegment(startOffset, maxLength).get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        while (iterator.hasNext()) {
+            val entry = iterator.next();
+            if (entry instanceof DebugStorageSegment.ValidTableEntryInfo) {
+                validCount.incrementAndGet();
+            } else {
+                invalidCount.incrementAndGet();
+            }
+            totalCount.incrementAndGet();
+            if (!writer.write(formatTableEntry(entry))) {
+                break;
+            }
+        }
+
+        output("Entries: %s, Valid: %s, Invalid: %s", totalCount, validCount, invalidCount);
+    }
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/storage/StorageCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/storage/StorageCommand.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.storage;
+
+import com.google.common.base.Charsets;
+import io.pravega.cli.admin.AdminCommand;
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.segmentstore.contracts.tables.TableKey;
+import io.pravega.segmentstore.server.containers.DebugStorageSegment;
+import io.pravega.segmentstore.server.host.StorageLoader;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.storage.StorageFactory;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.val;
+
+/**
+ * Base class for any {@link AdminCommand} that deals directly with LTS Storage.
+ */
+public abstract class StorageCommand extends AdminCommand {
+    protected final static String COMPONENT = "storage";
+    protected static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+    protected final StorageFactory storageFactory;
+
+    /**
+     * Creates a new instance of the DataRecoveryCommand class.
+     *
+     * @param args The arguments for the command.
+     */
+    StorageCommand(CommandArgs args) {
+        super(args);
+        this.storageFactory = createStorageFactory(executorService());
+    }
+
+    protected ScheduledExecutorService executorService() {
+        return getCommandArgs().getState().getExecutor();
+    }
+
+    /**
+     * Creates the {@link StorageFactory} instance by reading the config values.
+     *
+     * @param executorService A thread pool for execution.
+     * @return A newly created {@link StorageFactory} instance.
+     */
+    private StorageFactory createStorageFactory(ScheduledExecutorService executorService) {
+        ServiceBuilder.ConfigSetupHelper configSetupHelper = new ServiceBuilder.ConfigSetupHelper(getCommandArgs().getState().getConfigBuilder().build());
+        StorageLoader loader = new StorageLoader();
+        return loader.load(configSetupHelper, getServiceConfig().getStorageImplementation().toString(),
+                getServiceConfig().getStorageLayout(), executorService);
+    }
+
+    protected boolean maybeCreateFile(File file) throws Exception {
+        if (file.exists()) {
+            output("Target path '%s' exists. Proceeding with the command will OVERWRITE it.", file);
+            if (!confirmContinue()) {
+                return false;
+            }
+        }
+
+        if (file.exists()) {
+            file.delete();
+            output("Deleted existing file '%s'.", file);
+        }
+
+        file.createNewFile();
+        output("Created empty file '%s'.", file);
+        return true;
+    }
+
+    protected String formatAttribute(Map.Entry<UUID, Long> attribute) {
+        return String.format("%s: %s", attribute.getKey(), attribute.getValue());
+    }
+
+    protected String formatTableEntry(DebugStorageSegment.TableEntryInfo e) {
+        if (e == null) {
+            return "(null)";
+        }
+
+        if (e instanceof DebugStorageSegment.ValidTableEntryInfo) {
+            val ve = (DebugStorageSegment.ValidTableEntryInfo) e;
+            String r = String.format("Bucket=[%s, %s], EntryOffset=%s, Key=%s, ",
+                    e.getBucketHash(), e.getBucketOffset(), ve.getEntryOffset(), formatKey(ve.getEntry().getKey()));
+            if (ve.isDeleted()) {
+                r += "DELETED";
+            } else {
+                r += String.format("Value=(%s bytes)", ve.getEntry().getValue().getLength());
+            }
+            if (ve.getExtraInfo() != null) {
+                r += ", " + ve.getExtraInfo();
+            }
+            return r;
+        } else if (e instanceof DebugStorageSegment.InvalidTableEntryInfo) {
+            val ie = (DebugStorageSegment.InvalidTableEntryInfo) e;
+            return String.format("Bucket=[%s, %s], EntryOffset=%s, Exception=%s",
+                    e.getBucketHash(), e.getBucketOffset(), ie.getEntryOffset(),
+                    ie.getException());
+        }
+        return e.toString();
+    }
+
+    private String formatKey(TableKey key) {
+        return String.format("[%s, %s]", key.getVersion(), new String(key.getKey().getCopy(), Charsets.UTF_8));
+    }
+
+    //region ResultWriter and implementations
+
+    protected static abstract class ResultWriter implements AutoCloseable {
+        @Override
+        public void close() {
+        }
+
+        boolean initialize() {
+            return true;
+        }
+
+        abstract boolean write(String data);
+    }
+
+    @RequiredArgsConstructor
+    protected class ConsoleWriter extends ResultWriter {
+        private final int maxAtOnce;
+        private int countSinceLastConfirm = 0;
+
+        @Override
+        boolean write(String data) {
+            output("\t%s", data);
+            if (++this.countSinceLastConfirm >= this.maxAtOnce) {
+                if (!confirmContinue()) {
+                    return false;
+                }
+                this.countSinceLastConfirm = 0;
+            }
+            return true;
+        }
+    }
+
+    @RequiredArgsConstructor
+    protected class FileWriter extends ResultWriter {
+        private final Path path;
+        private FileChannel channel;
+
+        @SneakyThrows(Exception.class)
+        boolean initialize() {
+            val targetFile = this.path.toFile();
+            if (!maybeCreateFile(targetFile)) {
+                return false;
+            }
+            this.channel = FileChannel.open(this.path, StandardOpenOption.WRITE);
+            return true;
+        }
+
+        @Override
+        @SneakyThrows(IOException.class)
+        public void close() {
+            val c = this.channel;
+            if (c != null) {
+                c.close();
+            }
+        }
+
+        @Override
+        @SneakyThrows(IOException.class)
+        boolean write(String data) {
+            if (!data.endsWith(System.lineSeparator())) {
+                data = data + System.lineSeparator();
+            }
+            this.channel.write(ByteBuffer.wrap(data.getBytes(Charsets.UTF_8)));
+            return true;
+        }
+    }
+
+    //endregion
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/storage/UpdateSegmentAttributesCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/storage/UpdateSegmentAttributesCommand.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.storage;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.segmentstore.server.containers.DebugStorageSegment;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.Cleanup;
+import lombok.val;
+
+/**
+ * Updates a set of attributes on a segment.
+ */
+public class UpdateSegmentAttributesCommand extends StorageCommand {
+    public UpdateSegmentAttributesCommand(CommandArgs args) {
+        super(args);
+    }
+
+    public static CommandDescriptor descriptor() {
+        return new CommandDescriptor(COMPONENT, "update-attributes", "Updates a set of attributes for a segment.",
+                new ArgDescriptor("segment-name", "Fully qualified segment name (include scope and stream)"),
+                new ArgDescriptor("list-of-attribute-updates", "Space-separated list of attribute ids to values to update " +
+                        "(i.e., 'attribute1=value1 attribute2=value2 attribute3=value3' (value should be omitted for removals)."));
+    }
+
+    @Override
+    public void execute() throws Exception {
+        ensureArgCount(2, 1000);
+
+        final String segmentName = getArg(0);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(segmentName), "Invalid segment name");
+
+        val updatedValues = new HashMap<UUID, Long>();
+        output("These attributes are about to be updated:");
+        for (int i = 1; i < getArgCount(); i++) {
+            Map.Entry<UUID, Long> e = getArg(i, a -> {
+                int pos = a.lastIndexOf('=');
+                Preconditions.checkArgument(pos > 0, "Expected format of attribute=value");
+                val attributeId = UUID.fromString(a.substring(0, pos));
+                val value = (pos == a.length() - 1) ? null : Long.parseLong(a.substring(pos + 1));
+                return new AbstractMap.SimpleImmutableEntry<>(attributeId, value);
+            });
+            updatedValues.put(e.getKey(), e.getValue());
+            output("\t %s: %s", e.getKey(), e.getValue());
+        }
+
+        if (!confirmContinue()) {
+            return;
+        }
+
+        @Cleanup
+        val storage = this.storageFactory.createStorageAdapter();
+        storage.initialize(Integer.MAX_VALUE);
+        @Cleanup
+        val segment = new DebugStorageSegment(segmentName, storage, executorService());
+
+        segment.updateAttributes(updatedValues).get(DEFAULT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        output("Values updated successfully.");
+    }
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/utils/ConfigUtils.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/utils/ConfigUtils.java
@@ -15,8 +15,8 @@
  */
 package io.pravega.cli.admin.utils;
 
+import com.google.common.base.Strings;
 import io.pravega.cli.admin.AdminCommandState;
-
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Properties;
@@ -34,15 +34,20 @@ public class ConfigUtils {
     public static void loadProperties(AdminCommandState state) {
         Properties pravegaProperties = new Properties();
         // First, load the properties from file, if any.
-        try (InputStream input = new FileInputStream(System.getProperty(CONFIG_FILE_PROPERTY_NAME))) {
-            pravegaProperties.load(input);
-        } catch (Exception e) {
-            System.err.println("Exception reading input properties file: " + e.getMessage());
-            pravegaProperties.clear();
+        String configFileName = System.getProperty(CONFIG_FILE_PROPERTY_NAME);
+        if (!Strings.isNullOrEmpty(configFileName)) {
+            try (InputStream input = new FileInputStream(configFileName)) {
+                pravegaProperties.load(input);
+            } catch (Exception e) {
+                System.err.println("Exception reading input properties file: " + e.getMessage());
+                pravegaProperties.clear();
+            }
+
+            System.out.println(String.format("Loaded config from file '%s'.", configFileName));
         }
 
         // Second, load properties from command line if any.
-        for (String propertyName: System.getProperties().stringPropertyNames()) {
+        for (String propertyName : System.getProperties().stringPropertyNames()) {
             if (propertyName.startsWith(PRAVEGA_SERVICE_PROPERTY_NAME)
                     || propertyName.startsWith(CLI_PROPERTY_NAME)
                     || propertyName.startsWith(BOOKKEEPER_PROPERTY_NAME)) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStorageSegment.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStorageSegment.java
@@ -1,0 +1,447 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.server.containers;
+
+import io.pravega.common.TimeoutTimer;
+import io.pravega.common.concurrent.Futures;
+import io.pravega.common.io.SerializationException;
+import io.pravega.common.util.AsyncIterator;
+import io.pravega.common.util.BufferView;
+import io.pravega.segmentstore.contracts.AttributeUpdate;
+import io.pravega.segmentstore.contracts.ReadResult;
+import io.pravega.segmentstore.contracts.SegmentProperties;
+import io.pravega.segmentstore.contracts.tables.TableEntry;
+import io.pravega.segmentstore.contracts.tables.TableKey;
+import io.pravega.segmentstore.server.AttributeIndex;
+import io.pravega.segmentstore.server.AttributeIterator;
+import io.pravega.segmentstore.server.CacheManager;
+import io.pravega.segmentstore.server.CachePolicy;
+import io.pravega.segmentstore.server.DirectSegmentAccess;
+import io.pravega.segmentstore.server.attributes.AttributeIndexConfig;
+import io.pravega.segmentstore.server.attributes.ContainerAttributeIndex;
+import io.pravega.segmentstore.server.attributes.ContainerAttributeIndexFactoryImpl;
+import io.pravega.segmentstore.server.reading.StreamSegmentStorageReader;
+import io.pravega.segmentstore.server.tables.AsyncTableEntryReader;
+import io.pravega.segmentstore.server.tables.EntrySerializer;
+import io.pravega.segmentstore.server.tables.IndexReader;
+import io.pravega.segmentstore.server.tables.KeyHasher;
+import io.pravega.segmentstore.server.tables.TableBucketReader;
+import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.cache.NoOpCache;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+/**
+ * Provides direct access to a Segment (main segment or attribute segment) in LTS Storage. This class should be used
+ * for debugging/diagnosing purposes only. NEVER USE IT FOR PRODUCTION PURPOSES (i.e., on the main path).
+ */
+public class DebugStorageSegment implements AutoCloseable {
+    //region Members
+
+    private static final EntrySerializer TABLE_SEGMENT_SERIALIZER = new EntrySerializer();
+    private static final KeyHasher TABLE_SEGMENT_KEY_HASHER = KeyHasher.sha256();
+    private static final int READ_BLOCK_SIZE = 1024 * 1024;
+    private static final int CONTAINER_ID = 9999;
+    private static final long SEGMENT_ID = 99999L; // Used for artificially mapping a segment to this ID.
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
+    private final String segmentName;
+    private final Storage storage;
+    private final ScheduledExecutorService executor;
+    private final CacheManager cacheManager;
+    private final ContainerAttributeIndex containerAttributeIndex;
+    private final StreamSegmentContainerMetadata containerMetadata;
+
+    //endregion
+
+    //region Constructor
+
+    /**
+     * Creates a new instance of the {@link DebugStorageSegment} class.
+     * @param segmentName The name of the segment.
+     * @param storage A {@link Storage} adapter implementation.
+     * @param executor A {@link ScheduledExecutorService}.
+     */
+    public DebugStorageSegment(@NonNull String segmentName, @NonNull Storage storage, @NonNull ScheduledExecutorService executor) {
+        this.segmentName = segmentName;
+        this.storage = storage;
+        this.executor = executor;
+
+        this.containerMetadata = new StreamSegmentContainerMetadata(CONTAINER_ID, 1000);
+        this.containerMetadata.mapStreamSegmentId(segmentName, SEGMENT_ID);
+        this.cacheManager = new CacheManager(CachePolicy.INFINITE, new NoOpCache(), executor);
+        val attributeIndexFactory = new ContainerAttributeIndexFactoryImpl(AttributeIndexConfig.builder().build(), this.cacheManager, executor);
+        this.containerAttributeIndex = attributeIndexFactory.createContainerAttributeIndex(this.containerMetadata, this.storage);
+    }
+
+    //endregion
+
+    //region AutoCloseable implementation
+
+    @Override
+    public void close() {
+        this.containerAttributeIndex.close();
+        this.cacheManager.close();
+    }
+
+    //endregion
+
+    //region Segment Operations
+
+    /**
+     * Gets Segment Information for the Segment.
+     * NOTE: this is applicable both for main segments and attribute index segments.
+     *
+     * @return A CompletableFuture which will contain a {@link SegmentProperties} representing the info about the segment.
+     */
+    public CompletableFuture<SegmentProperties> getSegmentInfo() {
+        return this.storage.getStreamSegmentInfo(this.segmentName, DEFAULT_TIMEOUT);
+    }
+
+    /**
+     * Reads a range of bytes from the Segment.
+     * NOTE: this is applicable both for main segments and attribute index segments.
+     *
+     * @param offset    The offset to begin reading from.
+     * @param maxLength The maximum number of bytes to read.
+     * @return A CompletableFuture which will contain a {@link ReadResult} to read from.
+     */
+    public CompletableFuture<ReadResult> read(long offset, int maxLength) {
+        return asDirectSegmentAccess()
+                .thenApplyAsync(s -> s.read(offset, maxLength, DEFAULT_TIMEOUT), this.executor);
+    }
+
+    /**
+     * Retrieves a set of Segment Attributes from the Segment.
+     * NOTE: this is applicable only for main segments (attribute segment index will be derived if necessary).
+     *
+     * @param keys A Collection of Attribute Ids to fetch.
+     * @return A CompletableFuture which will contain the result.
+     */
+    public CompletableFuture<Map<UUID, Long>> getAttributes(@NonNull Collection<UUID> keys) {
+        // No need to close the index. It will be auto-closed when we close this class instance.
+        return asDirectSegmentAccess()
+                .thenComposeAsync(s -> s.getAttributes(keys, false, DEFAULT_TIMEOUT), this.executor);
+    }
+
+    /**
+     * Iterates through all the Segment Attributes for a Segment.
+     * NOTE: this is applicable only for main segments (attribute segment index will be derived if necessary).
+     *
+     * @return A CompletableFuture which will contain an {@link AttributeIterator}.
+     */
+    public CompletableFuture<AttributeIterator> iterateAttributes() {
+        return asDirectSegmentAccess()
+                .thenComposeAsync(s -> s.attributeIterator(new UUID(Long.MIN_VALUE, Long.MIN_VALUE), new UUID(Long.MAX_VALUE, Long.MAX_VALUE), DEFAULT_TIMEOUT), this.executor);
+    }
+
+    /**
+     * Retrieves a single {@link TableEntry} from a Table Segment.
+     * NOTE: this is applicable only for main segments that are of type TableSegment.
+     *
+     * @param key The key to retrieve.
+     * @return A CompletableFuture which will contain the result.
+     */
+    public CompletableFuture<TableEntryInfo> getTableEntry(@NonNull BufferView key) {
+        val indexReader = new IndexReader(this.executor);
+        return asDirectSegmentAccess().thenComposeAsync(s -> {
+            val bucketReader = TableBucketReader.entry(s, indexReader::getBackpointerOffset, this.executor);
+            val hash = TABLE_SEGMENT_KEY_HASHER.hash(key);
+            return indexReader.locateBuckets(s, Collections.singleton(hash), new TimeoutTimer(DEFAULT_TIMEOUT))
+                    .thenComposeAsync(buckets -> {
+                        val b = buckets.get(hash);
+                        if (b == null) {
+                            return CompletableFuture.completedFuture(null);
+                        }
+                        return bucketReader.find(key, b.getSegmentOffset(), new TimeoutTimer(DEFAULT_TIMEOUT))
+                                .thenApply(e -> new ValidTableEntryInfo(b.getHash(), b.getSegmentOffset(), e, b.getSegmentOffset()));
+                    }, this.executor);
+        });
+    }
+
+    /**
+     * Iterates through all the {@link TableEntry} instances in a Table Segment that are accessible from the index.
+     * NOTE: this is applicable only for main segments that are of type TableSegment.
+     * NOTE: this is different from {@link #scanTableSegment}. This method only returns entries that are accessible from
+     * the index.
+     *
+     * @return A CompletableFuture which will contain an {@link AsyncIterator}.
+     */
+    public CompletableFuture<AsyncIterator<List<TableEntryInfo>>> iterateTableEntriesFromIndex() {
+        val indexReader = new IndexReader(this.executor);
+        return asDirectSegmentAccess().thenComposeAsync(
+                s -> s.attributeIterator(KeyHasher.MIN_HASH, KeyHasher.MAX_HASH, DEFAULT_TIMEOUT)
+                        .thenApplyAsync(ai -> ai.thenCompose(buckets -> {
+                            val bucketReader = TableBucketReader.entry(s, indexReader::getBackpointerOffset, this.executor);
+                            val result = Collections.synchronizedList(new ArrayList<TableEntryInfo>());
+                            return Futures.loop(buckets,
+                                    bucket -> iterateBucket(bucket, bucketReader, result::add).thenApply(v -> true),
+                                    this.executor)
+                                    .thenApply(v -> result);
+                        }), this.executor),
+                this.executor);
+    }
+
+    private CompletableFuture<Void> iterateBucket(Map.Entry<UUID, Long> bucket, TableBucketReader<TableEntry> bucketReader,
+                                                  Consumer<TableEntryInfo> acceptEntry) {
+        BiConsumer<TableEntry, Long> findEntry = (entry, offset) -> {
+            val keyHash = TABLE_SEGMENT_KEY_HASHER.hash(entry.getKey().getKey());
+            val r = new ValidTableEntryInfo(bucket.getKey(), bucket.getValue(), entry, offset);
+            if (keyHash != bucket.getKey()) {
+                r.extraInfo("IndexHash/KeyHash mismatch. Actual hash: %s", keyHash);
+            }
+
+            acceptEntry.accept(new ValidTableEntryInfo(bucket.getKey(), bucket.getValue(), entry, offset));
+        };
+        return bucketReader.findAll(bucket.getValue(), findEntry, new TimeoutTimer(DEFAULT_TIMEOUT))
+                .exceptionally(ex -> {
+                    acceptEntry.accept(new InvalidTableEntryInfo(bucket.getKey(), bucket.getValue(), ex, -1L, -1L));
+                    return null;
+                });
+    }
+
+    /**
+     * Iterates through all the {@link TableEntry} instances in a Table Segment by reading the Table Segment file.
+     * NOTE: this is applicable only for main segments that are of type TableSegment.
+     * NOTE: this is different from {@link #iterateTableEntriesFromIndex()}. This method reads from the main segment, which
+     * may include deleted or updated entries.
+     * @param startOffset Offset to start scanning at.
+     * @param maxLength   Maximum number of bytes to read.
+     *
+     * @return A CompletableFuture which will contain an {@link AsyncIterator}.
+     */
+    public CompletableFuture<Iterator<TableEntryInfo>> scanTableSegment(long startOffset, int maxLength) {
+        return asDirectSegmentAccess()
+                .thenApplyAsync(s -> s.read(startOffset, maxLength, DEFAULT_TIMEOUT), this.executor)
+                .thenApplyAsync(rr -> {
+                    val buffers = rr.readRemaining(maxLength, DEFAULT_TIMEOUT);
+                    val builder = BufferView.builder();
+                    buffers.forEach(builder::add);
+                    return new TableEntryIterator(builder.build(), startOffset);
+                }, this.executor);
+    }
+
+    /**
+     * Returns a {@link DirectSegmentAccess} implementation that can be used to access the underlying segment.
+     *
+     * @return A CompletableFuture that will contain a {@link DirectSegmentAccess} instance.
+     */
+    public CompletableFuture<DirectSegmentAccess> asDirectSegmentAccess() {
+        return getSegmentInfo().thenApply(DirectSegmentWrapper::new);
+    }
+
+    private CompletableFuture<AttributeIndex> getAttributeIndex() {
+        return this.containerAttributeIndex.forSegment(SEGMENT_ID, DEFAULT_TIMEOUT);
+    }
+
+    //endregion
+
+    //region TableEntryIterator
+
+    private static class TableEntryIterator implements Iterator<TableEntryInfo> {
+        private BufferView buffer;
+        private long startOffset;
+
+        TableEntryIterator(@NonNull BufferView buffer, long startOffset) {
+            this.buffer = buffer;
+            this.startOffset = startOffset;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return this.buffer.getLength() > 0;
+        }
+
+        @Override
+        public TableEntryInfo next() {
+            val entryOffset = this.startOffset;
+            try {
+                try {
+                    val e = AsyncTableEntryReader.readEntryComponents(this.buffer.getBufferViewReader(), entryOffset, TABLE_SEGMENT_SERIALIZER);
+
+                    // If we made it this far, we have a valid entry.
+                    advance(e.getHeader().getTotalLength());
+                    if (e.getValue() == null) {
+                        // Removal
+                        return new ValidTableEntryInfo(TABLE_SEGMENT_KEY_HASHER.hash(e.getKey()), entryOffset, TableKey.versioned(e.getKey(), e.getVersion()), entryOffset);
+                    } else {
+                        return new ValidTableEntryInfo(TABLE_SEGMENT_KEY_HASHER.hash(e.getKey()), entryOffset, TableEntry.versioned(e.getKey(), e.getValue(), e.getVersion()), entryOffset);
+                    }
+                } catch (SerializationException ex) {
+                    // Invalid entry - scan for next one.
+                    long skipCount = 1;
+                    advance(1);
+                    while (hasNext()) {
+                        try {
+                            AsyncTableEntryReader.readEntryComponents(this.buffer.getBufferViewReader(), this.startOffset, TABLE_SEGMENT_SERIALIZER);
+                            break;
+                        } catch (SerializationException ex2) {
+                            skipCount++;
+                            advance(1);
+                        }
+                    }
+                    return new InvalidTableEntryInfo(null, -1, ex, entryOffset, skipCount);
+                }
+            } catch (BufferView.Reader.OutOfBoundsException oob) {
+                int len = this.buffer.getLength();
+                this.buffer = BufferView.empty();
+                return new InvalidTableEntryInfo(null, -1, oob, entryOffset, len);
+            }
+        }
+
+        private void advance(int skipBytes) {
+            this.buffer = this.buffer.slice(skipBytes, this.buffer.getLength() - skipBytes);
+            this.startOffset += skipBytes;
+        }
+    }
+
+    //endregion
+
+    //region DirectSegmentWrapper
+
+    @Data
+    private class DirectSegmentWrapper implements DirectSegmentAccess {
+        private final SegmentProperties info;
+
+        @Override
+        public long getSegmentId() {
+            return SEGMENT_ID;
+        }
+
+        @Override
+        public ReadResult read(long offset, int maxLength, Duration timeout) {
+            return StreamSegmentStorageReader.read(this.info, offset, maxLength, READ_BLOCK_SIZE, DebugStorageSegment.this.storage);
+        }
+
+        @Override
+        public CompletableFuture<Map<UUID, Long>> getAttributes(Collection<UUID> attributeIds, boolean cache, Duration timeout) {
+            return getAttributeIndex()
+                    .thenComposeAsync(idx -> idx.get(attributeIds, DEFAULT_TIMEOUT), DebugStorageSegment.this.executor);
+        }
+
+        @Override
+        public CompletableFuture<AttributeIterator> attributeIterator(UUID fromId, UUID toId, Duration timeout) {
+            return getAttributeIndex()
+                    .thenApplyAsync(idx -> idx.iterator(fromId, toId, DEFAULT_TIMEOUT), DebugStorageSegment.this.executor);
+        }
+
+        //region Unsupported Operations
+
+        @Override
+        public CompletableFuture<Long> append(BufferView data, Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Long> append(BufferView data, Collection<AttributeUpdate> attributeUpdates, long offset, Duration timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Void> updateAttributes(Collection<AttributeUpdate> attributeUpdates, Duration timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Long> seal(Duration timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Void> truncate(long offset, Duration timeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        //endregion
+    }
+
+    //endregion
+
+    //region TableEntryIfo and derived classes
+
+    /**
+     * Contextual information about a Table Entry.
+     */
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @Data
+    public static class TableEntryInfo {
+        private final UUID bucketHash;
+        private final long bucketOffset;
+        private final long entryOffset;
+        private final long length;
+    }
+
+    /**
+     * Represents a valid Table Entry (whether an update or removal).
+     */
+    @Getter
+    public static class ValidTableEntryInfo extends TableEntryInfo {
+        private final TableEntry entry;
+        private final boolean deleted;
+        private String extraInfo;
+
+        private ValidTableEntryInfo(UUID bucketHash, long bucketOffset, @NonNull TableEntry entry, long entryOffset) {
+            super(bucketHash, bucketOffset, entryOffset, TABLE_SEGMENT_SERIALIZER.getUpdateLength(entry));
+            this.entry = entry;
+            this.deleted = false;
+        }
+
+        private ValidTableEntryInfo(UUID bucketHash, long bucketOffset, @NonNull TableKey removedKey, long keyOffset) {
+            super(bucketHash, bucketOffset, keyOffset, TABLE_SEGMENT_SERIALIZER.getRemovalLength(removedKey));
+            this.entry = TableEntry.versioned(removedKey.getKey(), BufferView.empty(), removedKey.getVersion());
+            this.deleted = true;
+        }
+
+        private ValidTableEntryInfo extraInfo(String msgFormat, Object... args) {
+            val e = String.format(msgFormat, args);
+            this.extraInfo = this.extraInfo == null ? e : this.extraInfo + "; " + e;
+            return this;
+        }
+    }
+
+    /**
+     * Represents a segment range that cannot be interpreted as a valid Table Entry.
+     */
+    @Getter
+    public static class InvalidTableEntryInfo extends TableEntryInfo {
+        /**
+         * The exception that was thrown when attempting to deserialize this segment range and interpret as Table Entry.
+         */
+        private final Throwable exception;
+
+        private InvalidTableEntryInfo(UUID bucketHash, long bucketOffset, @NonNull Throwable exception, long entryOffset, long length) {
+            super(bucketHash, bucketOffset, entryOffset, length);
+            this.exception = exception;
+        }
+    }
+
+    //endregion
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStorageSegment.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/DebugStorageSegment.java
@@ -391,7 +391,7 @@ public class DebugStorageSegment implements AutoCloseable {
      * Contextual information about a Table Entry.
      */
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-    @Data
+    @Getter
     public static class TableEntryInfo {
         private final UUID bucketHash;
         private final long bucketOffset;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/AsyncTableEntryReader.java
@@ -46,7 +46,7 @@ import lombok.val;
  *
  * @param <ResultT> The type of the result.
  */
-abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler {
+public abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler {
     //region Members
     static final int INITIAL_READ_LENGTH = EntrySerializer.HEADER_LENGTH + EntrySerializer.MAX_KEY_LENGTH;
 
@@ -120,7 +120,7 @@ abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler 
      * @return A {@link DeserializedEntry} that contains all the components of the {@link TableEntry}.
      * @throws SerializationException If an Exception occurred while deserializing the {@link DeserializedEntry}.
      */
-    static DeserializedEntry readEntryComponents(BufferView.Reader input, long segmentOffset, EntrySerializer serializer) throws SerializationException {
+    public static DeserializedEntry readEntryComponents(BufferView.Reader input, long segmentOffset, EntrySerializer serializer) throws SerializationException {
         val h = serializer.readHeader(input);
         long version = getKeyVersion(h, segmentOffset);
         BufferView key = input.readSlice(h.getKeyLength());
@@ -145,7 +145,7 @@ abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler 
     /**
      * Completes the result with the given value.
      */
-    protected void complete(ResultT result) {
+    void complete(ResultT result) {
         this.result.complete(result);
     }
 
@@ -348,7 +348,7 @@ abstract class AsyncTableEntryReader<ResultT> implements AsyncReadResultHandler 
 
     @Getter
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-    static class DeserializedEntry {
+    public static class DeserializedEntry {
         /**
          * The Entry's Header.
          */

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/EntrySerializer.java
@@ -42,7 +42,7 @@ import lombok.val;
  * We can't use VersionedSerializer here because in most cases we need to read only key and not the value. VersionedSerializer
  * requires us to read the whole thing before retrieving anything.
  */
-class EntrySerializer {
+public class EntrySerializer {
     static final int HEADER_LENGTH = 1 + Integer.BYTES * 2 + Long.BYTES; // Serialization Version, Key Length, Value Length, Entry Version.
     static final int MAX_KEY_LENGTH = TableStore.MAXIMUM_KEY_LENGTH;
     /**
@@ -71,7 +71,7 @@ class EntrySerializer {
      * @param entry The {@link TableEntry} to serialize.
      * @return The number of bytes required to serialize.
      */
-    int getUpdateLength(@NonNull TableEntry entry) {
+    public int getUpdateLength(@NonNull TableEntry entry) {
         return HEADER_LENGTH + entry.getKey().getKey().getLength() + entry.getValue().getLength();
     }
 
@@ -128,7 +128,7 @@ class EntrySerializer {
      * @param key The {@link TableKey} to serialize for removal.
      * @return The number of bytes required to serialize.
      */
-    int getRemovalLength(@NonNull TableKey key) {
+    public int getRemovalLength(@NonNull TableKey key) {
         return HEADER_LENGTH + key.getKey().getLength();
     }
 
@@ -192,7 +192,7 @@ class EntrySerializer {
      * Defines a serialized Entry's Header.
      */
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-    static class Header {
+    public static class Header {
         private final byte serializationVersion;
         @Getter
         private final int keyLength;
@@ -210,7 +210,7 @@ class EntrySerializer {
             return HEADER_LENGTH + this.keyLength;
         }
 
-        int getTotalLength() {
+        public int getTotalLength() {
             return HEADER_LENGTH + this.keyLength + Math.max(0, this.valueLength);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IndexReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/IndexReader.java
@@ -59,7 +59,7 @@ import lombok.val;
  * -- They begin from the {@link TableBucket}'s SegmentOffset and are chained up until there are no more Table Entries left.
  */
 @RequiredArgsConstructor
-class IndexReader {
+public class IndexReader {
     //region Members
 
     @NonNull
@@ -138,7 +138,7 @@ class IndexReader {
      * @param timer     Timer for the operation.
      * @return A CompletableFuture that, when completed, will contain the requested Bucket information.
      */
-    CompletableFuture<Map<UUID, TableBucket>> locateBuckets(DirectSegmentAccess segment, Collection<UUID> keyHashes, TimeoutTimer timer) {
+    public CompletableFuture<Map<UUID, TableBucket>> locateBuckets(DirectSegmentAccess segment, Collection<UUID> keyHashes, TimeoutTimer timer) {
         return segment
                 .getAttributes(keyHashes, false, timer.getRemaining())
                 .thenApply(attributes -> attributes.entrySet().stream()
@@ -153,7 +153,7 @@ class IndexReader {
      * @param timeout Timeout for the operation.
      * @return A CompletableFuture that, when completed, will contain the backpointer offset, or -1 if no such pointer exists.
      */
-    CompletableFuture<Long> getBackpointerOffset(DirectSegmentAccess segment, long offset, Duration timeout) {
+    public CompletableFuture<Long> getBackpointerOffset(DirectSegmentAccess segment, long offset, Duration timeout) {
         UUID key = getBackpointerAttributeKey(offset);
         return segment.getAttributes(Collections.singleton(key), false, timeout)
                       .thenApply(attributes -> {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyHasher.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/KeyHasher.java
@@ -31,21 +31,21 @@ import lombok.val;
 /**
  * Defines a Hasher for a Table Key.
  */
-abstract class KeyHasher {
-    /**
-     * Size of the Hash, in bytes.
-     */
-    static final int HASH_SIZE_BYTES = Long.BYTES + Long.BYTES; // UUID length.
-
+public abstract class KeyHasher {
     /**
      * Minimum value for any Key Hash, when compared using {@link UUID#compareTo}.
      */
-    static final UUID MIN_HASH = new UUID(TableBucket.CORE_ATTRIBUTE_PREFIX + 1, Long.MIN_VALUE);
+    public static final UUID MIN_HASH = new UUID(TableBucket.CORE_ATTRIBUTE_PREFIX + 1, Long.MIN_VALUE);
 
     /**
      * Maximum value for any Key Hash, when compared using {@link UUID#compareTo}.
      */
-    static final UUID MAX_HASH = new UUID(TableBucket.BACKPOINTER_PREFIX - 1, Long.MAX_VALUE);
+    public static final UUID MAX_HASH = new UUID(TableBucket.BACKPOINTER_PREFIX - 1, Long.MAX_VALUE);
+
+    /**
+     * Size of the Hash, in bytes.
+     */
+    static final int HASH_SIZE_BYTES = Long.BYTES + Long.BYTES; // UUID length.
 
     /**
      * Generates a new Key Hash for the given Key.
@@ -120,7 +120,7 @@ abstract class KeyHasher {
      *
      * @return A new instance of the KeyHasher class.
      */
-    static KeyHasher sha256() {
+    public static KeyHasher sha256() {
         return new Sha256Hasher();
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucket.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucket.java
@@ -17,6 +17,7 @@ package io.pravega.segmentstore.server.tables;
 
 import io.pravega.segmentstore.contracts.Attributes;
 import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +26,8 @@ import lombok.RequiredArgsConstructor;
  * Represents a Table Bucket, which is identified by its unique Hash ({@link #getHash} and which is a collection of one
  * or more Table Entries. The Table Bucket points to the Table Entry with highest offset in the Segment.
  */
-@RequiredArgsConstructor
-class TableBucket {
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class TableBucket {
     /**
      * The MSB 64 bits of the Attribute Keys that represent Core Attributes.
      */

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucketReader.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableBucketReader.java
@@ -42,7 +42,7 @@ import lombok.val;
  * @param <ResultT> Type of the objects returned by an instance of this class.
  */
 @RequiredArgsConstructor
-abstract class TableBucketReader<ResultT> {
+public abstract class TableBucketReader<ResultT> {
     //region Members
 
     protected final EntrySerializer serializer = new EntrySerializer();
@@ -63,7 +63,7 @@ abstract class TableBucketReader<ResultT> {
      * @param executor       An Executor for async operations.
      * @return A new instance of the {@link TableBucketReader} class.
      */
-    static TableBucketReader<TableEntry> entry(@NonNull DirectSegmentAccess segment,
+    public static TableBucketReader<TableEntry> entry(@NonNull DirectSegmentAccess segment,
                                                @NonNull GetBackpointer getBackpointer, @NonNull Executor executor) {
         return new TableBucketReader.Entry(segment, getBackpointer, executor);
     }
@@ -77,7 +77,7 @@ abstract class TableBucketReader<ResultT> {
      * @param executor       An Executor for async operations.
      * @return A new instance of the {@link TableBucketReader} class.
      */
-    static TableBucketReader<TableKey> key(@NonNull DirectSegmentAccess segment,
+    public static TableBucketReader<TableKey> key(@NonNull DirectSegmentAccess segment,
                                            @NonNull GetBackpointer getBackpointer, @NonNull Executor executor) {
         return new TableBucketReader.Key(segment, getBackpointer, executor);
     }
@@ -119,7 +119,7 @@ abstract class TableBucketReader<ResultT> {
      * @param timer        A {@link TimeoutTimer} for the operation.
      * @return A CompletableFuture that, when completed, will indicate the operation completed.
      */
-    CompletableFuture<Void> findAll(long bucketOffset, BiConsumer<ResultT, Long> handler, TimeoutTimer timer) {
+    public CompletableFuture<Void> findAll(long bucketOffset, BiConsumer<ResultT, Long> handler, TimeoutTimer timer) {
         AtomicLong offset = new AtomicLong(bucketOffset);
         return Futures.loop(
                 () -> offset.get() >= 0,
@@ -151,7 +151,7 @@ abstract class TableBucketReader<ResultT> {
      * @return A CompletableFuture that, when completed, will contain the desired result, or null of no such result
      * was found.
      */
-    CompletableFuture<ResultT> find(BufferView soughtKey, long bucketOffset, TimeoutTimer timer) {
+    public CompletableFuture<ResultT> find(BufferView soughtKey, long bucketOffset, TimeoutTimer timer) {
         int maxReadLength = getMaxReadLength();
 
         // Read the Key at the current offset and check it against the sought one.
@@ -328,7 +328,7 @@ abstract class TableBucketReader<ResultT> {
     }
 
     @FunctionalInterface
-    interface GetBackpointer {
+    public interface GetBackpointer {
         CompletableFuture<Long> apply(DirectSegmentAccess segment, long offset, Duration timeout);
     }
 


### PR DESCRIPTION
**Change log description**  
Added new CLI commands to read (download) a segment range, get/iterate its attributes, and for table segments, get/iterate/scan table entries (all from LTS).

**Purpose of the change**  
Fixes #5911.

**What the code does**  
Fixed a few pre-existing bugs relating to config loading in CLI:
- README.md: removed erroneous line.
- Fixed default config path (which was used only on developer machines)
- Enhanced `ConfigUtils` to not throw an error if the default config file does not exist - it will now print a user-friendly message on the console.
New commands:
- Added a `DebugStorageSegment` class within the Segment Store core that provides access to a Segment on LTS. This exposes a friendly `DirectSegmentAccess` wrapper that is already used by many other components (this should enable it to be plugged in to other components to do our work for us).
- Added a new set of Storage-related commands that operate directly on LTS Storage. Made necessary visibility adjustments in core classes within the Segment Store. All these make use of `DebugStorageSegment` above.

**How to verify it**  
Unit tests.