### PR TITLE
Issue 5919: Cherry-pick #5908 into r0.9

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
@@ -81,7 +81,7 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
      * defaults from {@link TableAttributes#DEFAULT_VALUES}.
      */
     @VisibleForTesting
-    static final Map<UUID, Long> DEFAULT_COMPACTION_ATTRIBUTES = ImmutableMap.of(TableAttributes.MIN_UTILIZATION, 75L,
+    public static final Map<UUID, Long> DEFAULT_COMPACTION_ATTRIBUTES = ImmutableMap.of(TableAttributes.MIN_UTILIZATION, 75L,
             Attributes.ROLLOVER_SIZE, 4L * DEFAULT_MAX_COMPACTION_SIZE);
 
     private final SegmentContainer segmentContainer;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/TableMetadataStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/TableMetadataStoreTests.java
@@ -10,9 +10,12 @@
 package io.pravega.segmentstore.server.containers;
 
 import io.pravega.common.util.BufferView;
+import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.SegmentType;
+import io.pravega.segmentstore.contracts.tables.TableAttributes;
 import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.server.TableStoreMock;
+import io.pravega.segmentstore.server.tables.ContainerTableExtensionImpl;
 import io.pravega.shared.NameUtils;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ErrorInjector;
@@ -27,7 +30,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
 import lombok.Getter;
 import lombok.SneakyThrows;
+import lombok.val;
+import org.junit.Assert;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.Timeout;
 
 /**
@@ -48,6 +54,15 @@ public class TableMetadataStoreTests extends MetadataStoreTestBase {
                 "createSegment did not fail when random exception was thrown.",
                 () -> context.getMetadataStore().createSegment(segmentName, SegmentType.STREAM_SEGMENT, null, TIMEOUT),
                 ex -> ex instanceof IntentionalException);
+    }
+
+    @Test
+    public void testSegmentCompactionAttributes() {
+        @Cleanup
+        TableTestContext context = (TableTestContext) createTestContext();
+        val si = context.metadataStore.getSegmentInfo(NameUtils.getMetadataSegmentName(context.connector.getContainerMetadata().getContainerId()), TIMEOUT).join();
+        Assert.assertEquals(ContainerTableExtensionImpl.DEFAULT_COMPACTION_ATTRIBUTES.get(Attributes.ROLLOVER_SIZE), si.getAttributes().get(Attributes.ROLLOVER_SIZE));
+        Assert.assertEquals(ContainerTableExtensionImpl.DEFAULT_COMPACTION_ATTRIBUTES.get(TableAttributes.MIN_UTILIZATION), si.getAttributes().get(TableAttributes.MIN_UTILIZATION));
     }
 
     @Override


### PR DESCRIPTION
**Change log description**  
Cherry-picking #5908 into this branch. An actual cherry-pick was not possible because of significant changes between the branches; select code has been picked and adapted instead.

**Purpose of the change**  
Fixes #5919.

**What the code does**  
This is not your typical cherry-pick. There is significant difference in the code between r0.9 and the current master so a pure cherry-pick was not possible (needed to add several other classes and touch a lot of unrelated code). I have only picked select lines of code and brought them into this branch.

**How to verify it**  
Build must pass. A cursory check against the current master branch for affected files may be done to verify appropriate code has been cherrypicked.
