### PR TITLE
Issue 5923: cherry pick to r0.9

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageFactory.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 @RequiredArgsConstructor
 public class ExtendedS3SimpleStorageFactory implements SimpleStorageFactory {
     @NonNull
+    @Getter
     private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig;
 
     @NonNull

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemSimpleStorageFactory.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ScheduledExecutorService;
 @RequiredArgsConstructor
 public class FileSystemSimpleStorageFactory implements SimpleStorageFactory {
     @NonNull
+    @Getter
     private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig;
 
     @NonNull

--- a/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSimpleStorageFactory.java
+++ b/bindings/src/main/java/io/pravega/storage/hdfs/HDFSSimpleStorageFactory.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ScheduledExecutorService;
 public class HDFSSimpleStorageFactory implements SimpleStorageFactory {
 
     @NonNull
+    @Getter
     private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig;
 
     @NonNull

--- a/bindings/src/test/java/io/pravega/storage/StorageFactoryTests.java
+++ b/bindings/src/test/java/io/pravega/storage/StorageFactoryTests.java
@@ -75,7 +75,7 @@ public class StorageFactoryTests extends ThreadPooledTestSuite {
         Assert.assertTrue(factory1 instanceof HDFSSimpleStorageFactory);
 
         @Cleanup
-        Storage storage1 = ((HDFSSimpleStorageFactory) factory1).createStorageAdapter(42, new InMemoryMetadataStore(executorService()));
+        Storage storage1 = ((HDFSSimpleStorageFactory) factory1).createStorageAdapter(42, new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
         Assert.assertTrue(storage1 instanceof ChunkedSegmentStorage);
 
         // Legacy Storage
@@ -122,7 +122,7 @@ public class StorageFactoryTests extends ThreadPooledTestSuite {
         Assert.assertTrue(factory1 instanceof ExtendedS3SimpleStorageFactory);
 
         @Cleanup
-        Storage storage1 = ((ExtendedS3SimpleStorageFactory) factory1).createStorageAdapter(42, new InMemoryMetadataStore(executorService()));
+        Storage storage1 = ((ExtendedS3SimpleStorageFactory) factory1).createStorageAdapter(42, new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
         Assert.assertTrue(storage1 instanceof ChunkedSegmentStorage);
 
         // Legacy Storage
@@ -165,7 +165,7 @@ public class StorageFactoryTests extends ThreadPooledTestSuite {
         Assert.assertTrue(factory1 instanceof FileSystemSimpleStorageFactory);
 
         @Cleanup
-        Storage storage1 = ((FileSystemSimpleStorageFactory) factory1).createStorageAdapter(42, new InMemoryMetadataStore(executorService()));
+        Storage storage1 = ((FileSystemSimpleStorageFactory) factory1).createStorageAdapter(42, new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
         Assert.assertTrue(storage1 instanceof ChunkedSegmentStorage);
 
         // Legacy Storage

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ExtendedS3IntegrationTest.java
@@ -115,6 +115,9 @@ public class ExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
         private final ExtendedS3StorageConfig config;
 
         @Getter
+        private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig = ChunkedSegmentStorageConfig.DEFAULT_CONFIG;
+
+        @Getter
         private final ScheduledExecutorService executor;
 
         LocalExtendedS3SimpleStorageFactory(ExtendedS3StorageConfig config, ScheduledExecutorService executor) {
@@ -137,7 +140,7 @@ public class ExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
                     new ExtendedS3ChunkStorage(client, this.config, executorService(), true, false),
                     metadataStore,
                     this.executor,
-                    ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+                    this.chunkedSegmentStorageConfig);
         }
 
         /**

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/NonAppendExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/NonAppendExtendedS3IntegrationTest.java
@@ -116,6 +116,11 @@ public class NonAppendExtendedS3IntegrationTest extends BookKeeperIntegrationTes
         private final ExtendedS3StorageConfig config;
 
         @Getter
+        private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                    .appendEnabled(false)
+                    .build();
+
+        @Getter
         private final ScheduledExecutorService executor;
 
         LocalExtendedS3SimpleStorageFactory(ExtendedS3StorageConfig config, ScheduledExecutorService executor) {
@@ -140,9 +145,7 @@ public class NonAppendExtendedS3IntegrationTest extends BookKeeperIntegrationTes
                     chunkStorage,
                     metadataStore,
                     this.executor,
-                    ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
-                            .appendEnabled(false)
-                            .build());
+                    this.chunkedSegmentStorageConfig);
             return storage;
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -172,7 +172,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
             ContainerTableExtension tableExtension = getExtension(ContainerTableExtension.class);
             String s = NameUtils.getStorageMetadataSegmentName(this.metadata.getContainerId());
 
-            val metadataStore = new TableBasedMetadataStore(s, tableExtension, simpleFactory.getExecutor());
+            val metadataStore = new TableBasedMetadataStore(s, tableExtension, simpleFactory.getChunkedSegmentStorageConfig(), simpleFactory.getExecutor());
 
             return simpleFactory.createStorageAdapter(this.metadata.getContainerId(), metadataStore);
         } else {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SimpleStorageFactory.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/SimpleStorageFactory.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.storage;
 
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
 
 import java.util.concurrent.Executor;
@@ -29,4 +30,10 @@ public interface SimpleStorageFactory extends StorageFactory {
      * @return Executor used by the factory.
      */
     Executor getExecutor();
+
+    /**
+     * Gets the ChunkedSegmentStorageConfig used by the factory.
+     * @return ChunkedSegmentStorageConfig used by the factory.
+     */
+    ChunkedSegmentStorageConfig getChunkedSegmentStorageConfig();
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageMetrics.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageMetrics.java
@@ -31,15 +31,19 @@ public class ChunkStorageMetrics {
 
     static final OpStatsLogger SLTS_READ_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_READ_LATENCY);
     static final OpStatsLogger SLTS_WRITE_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_WRITE_LATENCY);
+    static final OpStatsLogger SLTS_SYSTEM_READ_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_SYSTEM_READ_LATENCY);
+    static final OpStatsLogger SLTS_SYSTEM_WRITE_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_SYSTEM_WRITE_LATENCY);
     static final OpStatsLogger SLTS_CREATE_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_CREATE_LATENCY);
     static final OpStatsLogger SLTS_DELETE_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_DELETE_LATENCY);
     static final OpStatsLogger SLTS_CONCAT_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_CONCAT_LATENCY);
     static final OpStatsLogger SLTS_TRUNCATE_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_TRUNCATE_LATENCY);
     static final OpStatsLogger SLTS_READ_INDEX_SCAN_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_READ_INDEX_SCAN_LATENCY);
     static final OpStatsLogger SLTS_READ_INDEX_NUM_SCANNED = STATS_LOGGER.createStats(MetricsNames.SLTS_READ_INDEX_NUM_SCANNED);
+    static final OpStatsLogger SLTS_READ_INDEX_BLOCK_LOOKUP_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_READ_INDEX_BLOCK_LOOKUP_LATENCY);
 
     static final OpStatsLogger SLTS_SYS_READ_INDEX_SCAN_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_SYS_READ_INDEX_SCAN_LATENCY);
     static final OpStatsLogger SLTS_SYS_READ_INDEX_NUM_SCANNED = STATS_LOGGER.createStats(MetricsNames.SLTS_SYS_READ_INDEX_NUM_SCANNED);
+    static final OpStatsLogger SLTS_SYS_READ_INDEX_BLOCK_LOOKUP_LATENCY = STATS_LOGGER.createStats(MetricsNames.SLTS_SYS_READ_INDEX_BLOCK_LOOKUP_LATENCY);
 
     static final Counter READ_BYTES = STATS_LOGGER.createCounter(MetricsNames.STORAGE_READ_BYTES);
     static final Counter WRITE_BYTES = STATS_LOGGER.createCounter(MetricsNames.STORAGE_WRITE_BYTES);
@@ -51,12 +55,23 @@ public class ChunkStorageMetrics {
 
     static final Counter SLTS_READ_BYTES = STATS_LOGGER.createCounter(MetricsNames.SLTS_READ_BYTES);
     static final Counter SLTS_WRITE_BYTES = STATS_LOGGER.createCounter(MetricsNames.SLTS_WRITE_BYTES);
+    static final Counter SLTS_SYSTEM_READ_BYTES = STATS_LOGGER.createCounter(MetricsNames.SLTS_SYSTEM_READ_BYTES);
+    static final Counter SLTS_SYSTEM_WRITE_BYTES = STATS_LOGGER.createCounter(MetricsNames.SLTS_SYSTEM_WRITE_BYTES);
     static final Counter SLTS_CONCAT_BYTES = STATS_LOGGER.createCounter(MetricsNames.SLTS_CONCAT_BYTES);
+
+    static final OpStatsLogger SLTS_NUM_CHUNKS_READ = STATS_LOGGER.createStats(MetricsNames.SLTS_NUM_CHUNKS_READ);
+    static final OpStatsLogger SLTS_SYSTEM_NUM_CHUNKS_READ = STATS_LOGGER.createStats(MetricsNames.SLTS_SYSTEM_NUM_CHUNKS_READ);
+    static final OpStatsLogger SLTS_NUM_CHUNKS_ADDED = STATS_LOGGER.createStats(MetricsNames.SLTS_NUM_CHUNKS_ADDED);
+    static final OpStatsLogger SLTS_SYSTEM_NUM_CHUNKS_ADDED = STATS_LOGGER.createStats(MetricsNames.SLTS_SYSTEM_NUM_CHUNKS_ADDED);
+
+    static final OpStatsLogger SLTS_READ_INSTANT_TPUT = STATS_LOGGER.createStats(MetricsNames.SLTS_READ_INSTANT_TPUT);
+    static final OpStatsLogger SLTS_WRITE_INSTANT_TPUT = STATS_LOGGER.createStats(MetricsNames.SLTS_WRITE_INSTANT_TPUT);
 
     static final Counter SLTS_CREATE_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_CREATE_COUNT);
     static final Counter SLTS_DELETE_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_DELETE_COUNT);
     static final Counter SLTS_CONCAT_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_CONCAT_COUNT);
     static final Counter SLTS_TRUNCATE_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_TRUNCATE_COUNT);
+    static final Counter SLTS_SYSTEM_TRUNCATE_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_SYSTEM_TRUNCATE_COUNT);
 
     static final Counter LARGE_CONCAT_COUNT = STATS_LOGGER.createCounter(MetricsNames.STORAGE_LARGE_CONCAT_COUNT);
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -60,6 +60,8 @@ import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLT
 import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_CREATE_LATENCY;
 import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_DELETE_COUNT;
 import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_DELETE_LATENCY;
+import static io.pravega.shared.MetricsNames.STORAGE_METADATA_NUM_CHUNKS;
+import static io.pravega.shared.MetricsNames.STORAGE_METADATA_SIZE;
 
 /**
  * Implements storage for segments using {@link ChunkStorage} and {@link ChunkMetadataStore}.
@@ -721,6 +723,16 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         for (long offset = firstBlock * config.getIndexBlockSize(); offset < endOffset; offset += config.getIndexBlockSize()) {
             txn.delete(NameUtils.getSegmentReadIndexBlockName(segmentName, offset));
         }
+    }
+
+    /**
+     * Report size related metrics for the given system segment.
+     * @param segmentMetadata Segment metadata.
+     */
+    void reportMetricsForSystemSegment(SegmentMetadata segmentMetadata) {
+        val name = segmentMetadata.getName().substring(segmentMetadata.getName().lastIndexOf('/') + 1).replace('$', '_');
+        ChunkStorageMetrics.DYNAMIC_LOGGER.reportGaugeValue(STORAGE_METADATA_SIZE + name, segmentMetadata.getLength() - segmentMetadata.getStartOffset());
+        ChunkStorageMetrics.DYNAMIC_LOGGER.reportGaugeValue(STORAGE_METADATA_NUM_CHUNKS + name, segmentMetadata.getChunkCount());
     }
 
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
@@ -44,6 +44,8 @@ public class ChunkedSegmentStorageConfig {
     public static final Property<Integer> GARBAGE_COLLECTION_MAX_QUEUE_SIZE = Property.named("garbage.collection.queue.size.max", 16 * 1024);
     public static final Property<Integer> GARBAGE_COLLECTION_SLEEP = Property.named("garbage.collection.sleep.millis", 10);
     public static final Property<Integer> GARBAGE_COLLECTION_MAX_ATTEMPTS = Property.named("garbage.collection.attempts.max", 3);
+    public static final Property<Integer> MAX_METADATA_ENTRIES_IN_BUFFER = Property.named("metadata.buffer.size.max", 1024);
+    public static final Property<Integer> MAX_METADATA_ENTRIES_IN_CACHE = Property.named("metadata.cache.size.max", 5000);
 
 
     /**
@@ -67,6 +69,8 @@ public class ChunkedSegmentStorageConfig {
             .garbageCollectionSleep(Duration.ofMillis(10))
             .garbageCollectionMaxAttempts(3)
             .indexBlockSize(1024 * 1024)
+            .maxEntriesInCache(5000)
+            .maxEntriesInTxnBuffer(1024)
             .build();
 
     static final String COMPONENT_CODE = "storage";
@@ -178,6 +182,18 @@ public class ChunkedSegmentStorageConfig {
     final private int garbageCollectionMaxAttempts;
 
     /**
+     * Maximum number of metadata entries to keep in recent transaction buffer.
+     */
+    @Getter
+    final private int maxEntriesInTxnBuffer;
+
+    /**
+     * Maximum number of metadata entries to keep in recent transaction buffer.
+     */
+    @Getter
+    final private int maxEntriesInCache;
+
+    /**
      * Creates a new instance of the ChunkedSegmentStorageConfig class.
      *
      * @param properties The TypedProperties object to read Properties from.
@@ -202,6 +218,8 @@ public class ChunkedSegmentStorageConfig {
         this.garbageCollectionSleep = Duration.ofMillis(properties.getInt(GARBAGE_COLLECTION_SLEEP));
         this.garbageCollectionMaxAttempts = properties.getInt(GARBAGE_COLLECTION_MAX_ATTEMPTS);
         this.indexBlockSize = properties.getLong(READ_INDEX_BLOCK_SIZE);
+        this.maxEntriesInTxnBuffer = properties.getInt(MAX_METADATA_ENTRIES_IN_BUFFER);
+        this.maxEntriesInCache = properties.getInt(MAX_METADATA_ENTRIES_IN_CACHE);
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ReadOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ReadOperation.java
@@ -33,12 +33,19 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_NUM_CHUNKS_READ;
 import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_READ_BYTES;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_READ_INDEX_BLOCK_LOOKUP_LATENCY;
 import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_READ_INDEX_NUM_SCANNED;
 import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_READ_INDEX_SCAN_LATENCY;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_READ_INSTANT_TPUT;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_READ_LATENCY;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_SYSTEM_NUM_CHUNKS_READ;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_SYSTEM_READ_BYTES;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_SYSTEM_READ_LATENCY;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_SYS_READ_INDEX_BLOCK_LOOKUP_LATENCY;
 import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_SYS_READ_INDEX_NUM_SCANNED;
 import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_SYS_READ_INDEX_SCAN_LATENCY;
-import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_READ_LATENCY;
 
 @Slf4j
 class ReadOperation implements Callable<CompletableFuture<Integer>> {
@@ -61,6 +68,7 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
     private volatile boolean isLoopExited;
     private final AtomicInteger cntScanned = new AtomicInteger();
     private volatile int bytesToRead;
+    private final AtomicInteger cntChunksRead = new AtomicInteger();
 
     ReadOperation(ChunkedSegmentStorage chunkedSegmentStorage, SegmentHandle handle, long offset, byte[] buffer, int bufferOffset, int length) {
         this.handle = handle;
@@ -115,7 +123,18 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
     private void logEnd() {
         Duration elapsed = timer.getElapsed();
         SLTS_READ_LATENCY.reportSuccessEvent(elapsed);
+        SLTS_NUM_CHUNKS_READ.reportSuccessValue(cntChunksRead.get());
         SLTS_READ_BYTES.add(length);
+        if (segmentMetadata.isStorageSystemSegment()) {
+            SLTS_SYSTEM_READ_LATENCY.reportSuccessEvent(elapsed);
+            SLTS_SYSTEM_NUM_CHUNKS_READ.reportSuccessValue(cntChunksRead.get());
+            SLTS_SYSTEM_READ_BYTES.add(length);
+        }
+        if (elapsed.toMillis() > 0) {
+            val bytesPerSecond = 1000L * length / elapsed.toMillis();
+            SLTS_READ_INSTANT_TPUT.reportSuccessValue(bytesPerSecond);
+        }
+
         if (chunkedSegmentStorage.getConfig().getLateWarningThresholdInMillis() < elapsed.toMillis()) {
             log.warn("{} read - late op={}, segment={}, offset={}, bytesRead={}, latency={}.",
                     chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, totalBytesRead, elapsed.toMillis());
@@ -162,6 +181,7 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
                                     currentOffset.get() - startOffsetForCurrentChunk.get(),
                                     bytesToRead,
                                     currentBufferOffset.get());
+                            cntChunksRead.incrementAndGet();
                             bytesRemaining.addAndGet(-bytesToRead);
                             currentOffset.addAndGet(bytesToRead);
                             currentBufferOffset.addAndGet(bytesToRead);
@@ -213,8 +233,8 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
 
         // Find the first chunk that contains the data.
         startOffsetForCurrentChunk.set(segmentMetadata.getFirstChunkStartOffset());
-        val readIndexTimer = new Timer();
-        if (offset >= segmentMetadata.getLastChunkStartOffset()) {
+        boolean shouldOnlyReadLastChunk = offset >= segmentMetadata.getLastChunkStartOffset();
+        if (shouldOnlyReadLastChunk) {
             startOffsetForCurrentChunk.set(segmentMetadata.getLastChunkStartOffset());
             currentChunkName = segmentMetadata.getLastChunk();
         } else {
@@ -226,10 +246,10 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
             }
         }
 
-        val floorBlock = offset / chunkedSegmentStorage.getConfig().getIndexBlockSize();
-        val floorBlockStartOffset = floorBlock * chunkedSegmentStorage.getConfig().getIndexBlockSize();
+        final long floorBlockStartOffset = getFloorBlockStartOffset(offset);
         CompletableFuture<Void>  f;
-        if (!segmentMetadata.isStorageSystemSegment() && startOffsetForCurrentChunk.get() < floorBlockStartOffset) {
+        if (!shouldOnlyReadLastChunk && !segmentMetadata.isStorageSystemSegment() && startOffsetForCurrentChunk.get() < floorBlockStartOffset) {
+            val indexLookupTimer = new Timer();
             f = txn.get(NameUtils.getSegmentReadIndexBlockName(segmentMetadata.getName(), floorBlockStartOffset))
                     .thenAcceptAsync(storageMetadata -> {
                         if (null != storageMetadata) {
@@ -240,17 +260,33 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
                                 log.debug("{} read - found block index to start scanning - op={}, segment={}, chunk={}, startOffset={}, offset={}.",
                                         chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this),
                                         handle.getSegmentName(), currentChunkName, startOffsetForCurrentChunk.get(), offset);
+
+                                // Note: This just is prefetch call. Do not wait.
+                                val nextBlock = getFloorBlockStartOffset(offset + length);
+                                if (nextBlock >  floorBlockStartOffset + chunkedSegmentStorage.getConfig().getIndexBlockSize()) {
+                                    // We read multiple blocks already
+                                    txn.get(NameUtils.getSegmentReadIndexBlockName(segmentMetadata.getName(), nextBlock));
+                                } else {
+                                    // Prefetch next block index entry.
+                                    txn.get(NameUtils.getSegmentReadIndexBlockName(segmentMetadata.getName(), floorBlockStartOffset + chunkedSegmentStorage.getConfig().getIndexBlockSize()));
+                                }
                             } else {
                                 log.warn("{} read - block entry offset must be floor to requested offset. op={} segment={} offset={} length={} block={}",
                                         chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this),
                                         segmentMetadata, offset, length, blockMetadata);
                             }
                         }
+                        if (segmentMetadata.isStorageSystemSegment()) {
+                            SLTS_SYS_READ_INDEX_BLOCK_LOOKUP_LATENCY.reportSuccessEvent(indexLookupTimer.getElapsed());
+                        } else {
+                            SLTS_READ_INDEX_BLOCK_LOOKUP_LATENCY.reportSuccessEvent(indexLookupTimer.getElapsed());
+                        }
                     });
         } else {
            f = CompletableFuture.completedFuture(null);
         }
 
+        val readIndexTimer = new Timer();
         // Navigate to the chunk that contains the first byte of requested data.
         return f.thenComposeAsync( vv -> Futures.loop(
                 () -> currentChunkName != null && !isLoopExited,
@@ -286,11 +322,24 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
                         SLTS_READ_INDEX_SCAN_LATENCY.reportSuccessEvent(elapsed);
                         SLTS_READ_INDEX_NUM_SCANNED.reportSuccessValue(cntScanned.get());
                     }
+
+                    // Prefetch possible chunks for next read.
+                    if (chunkToReadFrom.getNextChunk() != null) {
+                        // Do not wait.
+                        txn.get(chunkToReadFrom.getNextChunk());
+                    }
+
                     log.debug("{} read - chunk lookup - op={}, segment={}, offset={}, scanned={}, latency={}.",
                             chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this),
                             handle.getSegmentName(), offset, cntScanned.get(), elapsed.toMillis());
                 }, chunkedSegmentStorage.getExecutor()),
         chunkedSegmentStorage.getExecutor());
+    }
+
+    private long getFloorBlockStartOffset(long offsetToRead) {
+        val floorBlock = offsetToRead / chunkedSegmentStorage.getConfig().getIndexBlockSize();
+        val floorBlockStartOffset = floorBlock * chunkedSegmentStorage.getConfig().getIndexBlockSize();
+        return floorBlockStartOffset;
     }
 
     private void checkState() {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/WriteOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/WriteOperation.java
@@ -38,7 +38,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_NUM_CHUNKS_ADDED;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_SYSTEM_NUM_CHUNKS_ADDED;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_SYSTEM_WRITE_BYTES;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_SYSTEM_WRITE_LATENCY;
 import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_WRITE_BYTES;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_WRITE_INSTANT_TPUT;
 import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_WRITE_LATENCY;
 
 /**
@@ -158,6 +163,17 @@ class WriteOperation implements Callable<CompletableFuture<Void>> {
         val elapsed = timer.getElapsed();
         SLTS_WRITE_LATENCY.reportSuccessEvent(elapsed);
         SLTS_WRITE_BYTES.add(length);
+        SLTS_NUM_CHUNKS_ADDED.reportSuccessValue(chunksAddedCount.get());
+        if (segmentMetadata.isStorageSystemSegment()) {
+            SLTS_SYSTEM_WRITE_LATENCY.reportSuccessEvent(elapsed);
+            SLTS_SYSTEM_WRITE_BYTES.add(length);
+            SLTS_SYSTEM_NUM_CHUNKS_ADDED.reportSuccessValue(chunksAddedCount.get());
+            chunkedSegmentStorage.reportMetricsForSystemSegment(segmentMetadata);
+        }
+        if (elapsed.toMillis() > 0) {
+            val bytesPerSecond = 1000L * length / elapsed.toMillis();
+            SLTS_WRITE_INSTANT_TPUT.reportSuccessValue(bytesPerSecond);
+        }
         if (chunkedSegmentStorage.getConfig().getLateWarningThresholdInMillis() < elapsed.toMillis()) {
             log.warn("{} write - late op={}, segment={}, offset={}, length={}, latency={}.",
                     chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, length, elapsed.toMillis());

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
@@ -22,6 +22,7 @@ import io.pravega.common.concurrent.Futures;
 import io.pravega.common.io.serialization.RevisionDataInput;
 import io.pravega.common.io.serialization.RevisionDataOutput;
 import io.pravega.common.io.serialization.VersionedSerializer;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
@@ -121,16 +122,6 @@ import static io.pravega.shared.MetricsNames.STORAGE_METADATA_CACHE_SIZE;
 @Beta
 abstract public class BaseMetadataStore implements ChunkMetadataStore {
     /**
-     * Maximum number of metadata entries to keep in recent transaction buffer.
-     */
-    private static final int MAX_ENTRIES_IN_TXN_BUFFER = 1000;
-
-    /**
-     * Maximum number of metadata entries to keep in cache.
-     */
-    private static final int MAX_ENTRIES_IN_CACHE = 5000;
-
-    /**
      * Percentage of cache evicted at any time. (1 / CACHE_EVICTION_RATIO) entries are evicted at once.
      */
     private static final int CACHE_EVICTION_RATIO = 10;
@@ -179,14 +170,14 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
      */
     @Getter
     @Setter
-    int maxEntriesInTxnBuffer = MAX_ENTRIES_IN_TXN_BUFFER;
+    private int maxEntriesInTxnBuffer;
 
     /**
      * Maximum number of metadata entries to keep in recent transaction buffer.
      */
     @Getter
     @Setter
-    int maxEntriesInCache = MAX_ENTRIES_IN_CACHE;
+    private int maxEntriesInCache;
 
     /**
      * Keep count of records in buffer. ConcurrentHashMap.size() is an expensive operation.
@@ -204,19 +195,29 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
     private final Object evictionLock = new Object();
 
     /**
+     * Configuration options for this instance.
+     */
+    @Getter
+    private final ChunkedSegmentStorageConfig config;
+
+    /**
      * Constructs a BaseMetadataStore object.
      *
+     * @param config Configuration options for this instance.
      * @param executor Executor to use for async operations.
      */
-    public BaseMetadataStore(Executor executor) {
+    public BaseMetadataStore(ChunkedSegmentStorageConfig config, Executor executor) {
+        this.config = Preconditions.checkNotNull(config, "config");
+        this.executor = Preconditions.checkNotNull(executor, "executor");
         version = new AtomicLong(System.currentTimeMillis()); // Start with unique number.
         fenced = new AtomicBoolean(false);
         bufferedTxnData = new ConcurrentHashMap<>(); // Don't think we need anything fancy here. But we'll measure and see.
         activeKeys = ConcurrentHashMultiset.create();
+        maxEntriesInTxnBuffer = config.getMaxEntriesInTxnBuffer();
+        maxEntriesInCache = config.getMaxEntriesInCache();
         cache = CacheBuilder.newBuilder()
                 .maximumSize(maxEntriesInCache)
                 .build();
-        this.executor = Preconditions.checkNotNull(executor, "executor");
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStore.java
@@ -23,6 +23,7 @@ import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.contracts.tables.TableKey;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.storage.DataLogWriterNotPrimaryException;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -64,13 +65,13 @@ public class TableBasedMetadataStore extends BaseMetadataStore {
 
     /**
      * Constructor.
-     *
      * @param tableName  Name of the table segment.
      * @param tableStore Instance of the {@link TableStore}.
+     * @param config Configuration options for this instance.
      * @param executor Executor to use for async operations.
      */
-    public TableBasedMetadataStore(String tableName, TableStore tableStore, Executor executor) {
-        super(executor);
+    public TableBasedMetadataStore(String tableName, TableStore tableStore, ChunkedSegmentStorageConfig config, Executor executor) {
+        super(config, executor);
         this.tableStore = Preconditions.checkNotNull(tableStore, "tableStore");
         this.tableName = Preconditions.checkNotNull(tableName, "tableName");
     }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryMetadataStore.java
@@ -11,6 +11,7 @@
 package io.pravega.segmentstore.storage.mocks;
 
 import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.segmentstore.storage.metadata.BaseMetadataStore;
 import lombok.Getter;
 import lombok.Setter;
@@ -53,10 +54,11 @@ public class InMemoryMetadataStore extends BaseMetadataStore {
     /**
      * Creates a new instance.
      *
+     * @param config Configuration options for this instance.
      * @param executor Executor to use.
      */
-    public InMemoryMetadataStore(Executor executor) {
-        super(executor);
+    public InMemoryMetadataStore(ChunkedSegmentStorageConfig config, Executor executor) {
+        super(config, executor);
     }
 
     /**
@@ -134,7 +136,7 @@ public class InMemoryMetadataStore extends BaseMetadataStore {
      * @return Clone of given instance.
      */
     public static InMemoryMetadataStore clone(InMemoryMetadataStore original) {
-        InMemoryMetadataStore cloneStore = new InMemoryMetadataStore(original.getExecutor());
+        InMemoryMetadataStore cloneStore = new InMemoryMetadataStore(original.getConfig(), original.getExecutor());
         synchronized (original) {
             synchronized (cloneStore) {
                 cloneStore.setVersion(original.getVersion());

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageFactory.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageFactory.java
@@ -25,12 +25,16 @@ import java.util.concurrent.ScheduledExecutorService;
  */
 public class InMemorySimpleStorageFactory implements SimpleStorageFactory {
     @Getter
+    protected ChunkedSegmentStorageConfig chunkedSegmentStorageConfig;
+
+    @Getter
     protected ScheduledExecutorService executor;
 
     private Storage singletonStorage;
     private boolean reuseStorage;
 
-    public InMemorySimpleStorageFactory(ScheduledExecutorService executor, boolean reuseStorage) {
+    public InMemorySimpleStorageFactory(ChunkedSegmentStorageConfig config, ScheduledExecutorService executor, boolean reuseStorage) {
+        this.chunkedSegmentStorageConfig = Preconditions.checkNotNull(config, "config");
         this.executor = Preconditions.checkNotNull(executor, "executor");
         this.reuseStorage = reuseStorage;
     }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageFactoryCreator.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryStorageFactoryCreator.java
@@ -14,6 +14,7 @@ import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.StorageFactoryCreator;
 import io.pravega.segmentstore.storage.StorageFactoryInfo;
 import io.pravega.segmentstore.storage.StorageLayoutType;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import lombok.val;
 
 import java.util.concurrent.ScheduledExecutorService;
@@ -23,7 +24,7 @@ public class InMemoryStorageFactoryCreator implements StorageFactoryCreator {
     @Override
     public StorageFactory createFactory(StorageFactoryInfo storageFactoryInfo, ConfigSetup setup, ScheduledExecutorService executor) {
         if (storageFactoryInfo.getStorageLayoutType().equals(StorageLayoutType.CHUNKED_STORAGE)) {
-            val factory = new InMemorySimpleStorageFactory(executor, true);
+            val factory = new InMemorySimpleStorageFactory(setup.getConfig(ChunkedSegmentStorageConfig::builder), executor, true);
             return factory;
         } else {
             InMemoryStorageFactory factory = new InMemoryStorageFactory(executor);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedRollingStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedRollingStorageTests.java
@@ -66,7 +66,7 @@ public abstract class ChunkedRollingStorageTests extends RollingStorageTestBase 
      * @throws Exception If any unexpected error occurred.
      */
     protected ChunkMetadataStore getMetadataStore() throws Exception {
-        return new InMemoryMetadataStore(executorService());
+        return new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
     }
 
     @Override

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
@@ -39,6 +39,8 @@ public class ChunkedSegmentStorageConfigTests {
         props.setProperty(ChunkedSegmentStorageConfig.GARBAGE_COLLECTION_SLEEP.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "12");
         props.setProperty(ChunkedSegmentStorageConfig.GARBAGE_COLLECTION_MAX_ATTEMPTS.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "13");
         props.setProperty(ChunkedSegmentStorageConfig.READ_INDEX_BLOCK_SIZE.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "14");
+        props.setProperty(ChunkedSegmentStorageConfig.MAX_METADATA_ENTRIES_IN_BUFFER.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "15");
+        props.setProperty(ChunkedSegmentStorageConfig.MAX_METADATA_ENTRIES_IN_CACHE.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "16");
 
         TypedProperties typedProperties = new TypedProperties(props, "storage");
         ChunkedSegmentStorageConfig config = new ChunkedSegmentStorageConfig(typedProperties);
@@ -59,6 +61,8 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertEquals(config.getGarbageCollectionSleep().toMillis(), 12);
         Assert.assertEquals(config.getGarbageCollectionMaxAttempts(), 13);
         Assert.assertEquals(config.getIndexBlockSize(), 14);
+        Assert.assertEquals(config.getMaxEntriesInTxnBuffer(), 15);
+        Assert.assertEquals(config.getMaxEntriesInCache(), 16);
     }
 
     @Test
@@ -88,6 +92,8 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertEquals(config.getGarbageCollectionSleep(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getGarbageCollectionSleep());
         Assert.assertEquals(config.getGarbageCollectionMaxAttempts(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getGarbageCollectionMaxAttempts());
         Assert.assertEquals(config.getIndexBlockSize(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getIndexBlockSize());
+        Assert.assertEquals(config.getMaxEntriesInTxnBuffer(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxEntriesInTxnBuffer());
+        Assert.assertEquals(config.getMaxEntriesInCache(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxEntriesInCache());
     }
 
     @Test

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageMockTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageMockTests.java
@@ -70,7 +70,7 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
         val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().defaultRollingPolicy(policy).build();
 
         @Cleanup
-        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(executorService()));
+        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new NoOpChunkStorage(executorService()));
         @Cleanup
@@ -214,7 +214,7 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
         SegmentRollingPolicy policy = new SegmentRollingPolicy(2); // Force rollover after every 2 byte.
         val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().defaultRollingPolicy(policy).build();
         @Cleanup
-        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(executorService()));
+        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
         spyMetadataStore.setMaxEntriesInTxnBuffer(0);
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new NoOpChunkStorage(executorService()));
@@ -305,7 +305,7 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
         val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().defaultRollingPolicy(policy).build();
 
         @Cleanup
-        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(executorService()));
+        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new NoOpChunkStorage(executorService()));
         ((NoOpChunkStorage) spyChunkStorage).setShouldSupportConcat(false);
@@ -341,7 +341,7 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
                 .garbageCollectionDelay(Duration.ZERO)
                 .build();
         @Cleanup
-        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(executorService()));
+        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new NoOpChunkStorage(executorService()));
         ((NoOpChunkStorage) spyChunkStorage).setShouldSupportConcat(false);
@@ -375,7 +375,7 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
                 .garbageCollectionDelay(Duration.ZERO)
                 .build();
         @Cleanup
-        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(executorService()));
+        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new NoOpChunkStorage(executorService()));
         ((NoOpChunkStorage) spyChunkStorage).setShouldSupportConcat(false);
@@ -402,11 +402,10 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
 
     @Test
     public void testReport() {
-        SegmentRollingPolicy policy = new SegmentRollingPolicy(2); // Force rollover after every 2 byte.
-        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().defaultRollingPolicy(policy).build();
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG;
 
         @Cleanup
-        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(executorService()));
+        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(config, executorService()));
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new NoOpChunkStorage(executorService()));
         @Cleanup

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -92,7 +92,7 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
     }
 
     public ChunkMetadataStore createMetadataStore() throws Exception {
-        return new InMemoryMetadataStore(executorService());
+        return new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
     }
 
     public TestContext getTestContext() throws Exception {
@@ -2907,7 +2907,7 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
          * Gets {@link ChunkMetadataStore} to use for the tests.
          */
         public ChunkMetadataStore createMetadataStore() throws Exception {
-            return new InMemoryMetadataStore(executor);
+            return new InMemoryMetadataStore(config, executor);
         }
 
         /**

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollectorTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollectorTests.java
@@ -65,7 +65,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
     }
 
     protected ChunkMetadataStore getMetadataStore() throws Exception {
-        return new InMemoryMetadataStore(executorService());
+        return new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
     }
 
     protected ChunkStorage getChunkStorage() throws Exception {

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SimpleStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SimpleStorageTests.java
@@ -76,7 +76,7 @@ public abstract class SimpleStorageTests extends StorageTestBase {
         ChunkedSegmentStorage forkedChunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, storage.getChunkStorage(),
                 getCloneMetadataStore(storage.getMetadataStore()),
                 executor,
-                ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+                storage.getConfig());
         return forkedChunkedSegmentStorage;
     }
 
@@ -87,7 +87,7 @@ public abstract class SimpleStorageTests extends StorageTestBase {
      * @throws Exception Exceptions in case of any errors.
      */
     protected ChunkMetadataStore getMetadataStore() throws Exception {
-        return new InMemoryMetadataStore(executorService());
+        return new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
     }
 
     /**

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -54,7 +54,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
     }
 
     protected ChunkMetadataStore getMetadataStore() throws Exception {
-        return new InMemoryMetadataStore(executorService());
+        return new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
     }
 
     protected ChunkStorage getChunkStorage() throws Exception {

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
@@ -11,6 +11,7 @@ package io.pravega.segmentstore.storage.metadata;
 
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
 import io.pravega.segmentstore.storage.mocks.MockStorageMetadata;
 import io.pravega.test.common.AssertExtensions;
@@ -57,7 +58,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
     @Before
     public void setUp() throws Exception {
         super.before();
-        metadataStore = new InMemoryMetadataStore(executorService());
+        metadataStore = new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
     }
 
     @After
@@ -1428,7 +1429,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
                 () -> metadataStore.get(null, KEY0),
                 ex -> ex instanceof IllegalArgumentException);
         AssertExtensions.assertThrows("get should throw an exception",
-                () -> metadataStore.beginTransaction(true, null),
+                () -> metadataStore.beginTransaction(true, (String[]) null),
                 ex -> ex instanceof NullPointerException);
         AssertExtensions.assertThrows("get should throw an exception",
                 () -> metadataStore.beginTransaction(true, new String[0]),

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStoreMockTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStoreMockTests.java
@@ -15,6 +15,7 @@ import io.pravega.segmentstore.contracts.tables.BadKeyVersionException;
 import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.storage.DataLogWriterNotPrimaryException;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.segmentstore.storage.mocks.InMemoryTableStore;
 import io.pravega.segmentstore.storage.mocks.MockStorageMetadata;
 import io.pravega.test.common.AssertExtensions;
@@ -44,7 +45,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testIllegalStateExceptionDuringRead() {
         TableStore mockTableStore = mock(TableStore.class);
-        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, executorService());
+        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
 
         when(mockTableStore.createSegment(any(), any(), any())).thenReturn(Futures.failedFuture(new CompletionException(new StreamSegmentExistsException("test"))));
         when(mockTableStore.get(anyString(), any(), any())).thenThrow(new IllegalStateException());
@@ -57,7 +58,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testBadReadExceptionDuringRead() {
         TableStore mockTableStore = mock(TableStore.class);
-        TableBasedMetadataStore tableBasedMetadataStore = spy(new TableBasedMetadataStore("test", mockTableStore, executorService()));
+        TableBasedMetadataStore tableBasedMetadataStore = spy(new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
 
         when(mockTableStore.createSegment(any(), any(), any())).thenReturn(Futures.failedFuture(new CompletionException(new StreamSegmentExistsException("test"))));
         when(tableBasedMetadataStore.read("test")).thenReturn(CompletableFuture.completedFuture(null));
@@ -71,7 +72,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testBadReadMissingDbObjectDuringRead() {
         TableStore mockTableStore = mock(TableStore.class);
-        TableBasedMetadataStore tableBasedMetadataStore = spy(new TableBasedMetadataStore("test", mockTableStore, executorService()));
+        TableBasedMetadataStore tableBasedMetadataStore = spy(new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
 
         when(mockTableStore.createSegment(any(), any(), any())).thenReturn(Futures.failedFuture(new CompletionException(new StreamSegmentExistsException("test"))));
         when(tableBasedMetadataStore.read("test")).thenReturn(CompletableFuture.completedFuture(BaseMetadataStore.TransactionData.builder()
@@ -87,7 +88,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testBadReadMissingNoVersionDuringRead() {
         TableStore mockTableStore = mock(TableStore.class);
-        TableBasedMetadataStore tableBasedMetadataStore = spy(new TableBasedMetadataStore("test", mockTableStore, executorService()));
+        TableBasedMetadataStore tableBasedMetadataStore = spy(new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
 
         when(mockTableStore.createSegment(any(), any(), any())).thenReturn(Futures.failedFuture(new CompletionException(new StreamSegmentExistsException("test"))));
         when(tableBasedMetadataStore.read("test")).thenReturn(CompletableFuture.completedFuture(BaseMetadataStore.TransactionData.builder()
@@ -105,7 +106,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testRandomExceptionDuringRead() {
         TableStore mockTableStore = mock(TableStore.class);
-        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, executorService());
+        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
 
         when(mockTableStore.createSegment(any(), any(), any())).thenReturn(Futures.failedFuture(new CompletionException(new StreamSegmentExistsException("test"))));
         // Throw random exception
@@ -122,7 +123,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testDataLogWriterNotPrimaryExceptionDuringWrite() {
         TableStore mockTableStore = mock(TableStore.class);
-        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, executorService());
+        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
 
         when(mockTableStore.createSegment(any(), any(), any())).thenReturn(Futures.failedFuture(new CompletionException(new StreamSegmentExistsException("test"))));
 
@@ -142,7 +143,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testBadKeyVersionExceptionDuringWrite() {
         TableStore mockTableStore = mock(TableStore.class);
-        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, executorService());
+        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
 
         when(mockTableStore.createSegment(any(), any(), any())).thenReturn(Futures.failedFuture(new CompletionException(new StreamSegmentExistsException("test"))));
 
@@ -162,7 +163,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testRandomRuntimeExceptionDuringWrite() {
         TableStore mockTableStore = mock(TableStore.class);
-        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, executorService());
+        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
 
         when(mockTableStore.createSegment(any(), any(), any())).thenReturn(Futures.failedFuture(new CompletionException(new StreamSegmentExistsException("test"))));
 
@@ -182,7 +183,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testExceptionDuringRemove() throws Exception {
         TableStore mockTableStore = mock(TableStore.class);
-        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, executorService());
+        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
 
         when(mockTableStore.createSegment(any(), any(), any())).thenReturn(Futures.failedFuture(new CompletionException(new StreamSegmentExistsException("test"))));
 
@@ -201,7 +202,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testExceptionDuringRemoveWithSpy() throws Exception {
         TableStore mockTableStore = spy(new InMemoryTableStore(executorService()));
-        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, executorService());
+        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
 
         // Step 1 - set up keys
         try (val txn = tableBasedMetadataStore.beginTransaction(false, "TEST")) {
@@ -259,7 +260,7 @@ public class TableBasedMetadataStoreMockTests extends ThreadPooledTestSuite {
     @Test
     public void testRandomExceptionDuringWrite() {
         TableStore mockTableStore = mock(TableStore.class);
-        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, executorService());
+        TableBasedMetadataStore tableBasedMetadataStore = new TableBasedMetadataStore("test", mockTableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
 
         when(mockTableStore.createSegment(any(), any(), any())).thenReturn(Futures.failedFuture(new CompletionException(new StreamSegmentExistsException("test"))));
 

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStoreTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStoreTests.java
@@ -12,6 +12,7 @@ package io.pravega.segmentstore.storage.metadata;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.storage.chunklayer.ChunkStorage;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedRollingStorageTests;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageTests;
 import io.pravega.segmentstore.storage.chunklayer.SimpleStorageTests;
 import io.pravega.segmentstore.storage.mocks.InMemoryChunkStorage;
@@ -28,7 +29,7 @@ public class TableBasedMetadataStoreTests extends ChunkMetadataStoreTests {
     @Before
     public void setUp() throws Exception {
         val tableStore = new InMemoryTableStore(executorService());
-        metadataStore = new TableBasedMetadataStore("TEST", tableStore, executorService());
+        metadataStore = new TableBasedMetadataStore("TEST", tableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
     }
 
     /**
@@ -43,7 +44,7 @@ public class TableBasedMetadataStoreTests extends ChunkMetadataStoreTests {
         protected ChunkMetadataStore getMetadataStore() throws Exception {
             TableStore tableStore = new InMemoryTableStore(executorService());
             String tableName = "TableBasedMetadataSimpleStorageTests";
-            return new TableBasedMetadataStore(tableName, tableStore, executorService());
+            return new TableBasedMetadataStore(tableName, tableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
         }
 
         @Override
@@ -51,7 +52,7 @@ public class TableBasedMetadataStoreTests extends ChunkMetadataStoreTests {
             TableBasedMetadataStore tableBasedMetadataStore = (TableBasedMetadataStore) metadataStore;
             TableStore tableStore = InMemoryTableStore.clone((InMemoryTableStore) tableBasedMetadataStore.getTableStore());
             String tableName =  tableBasedMetadataStore.getTableName();
-            val retValue = new TableBasedMetadataStore(tableName, tableStore, executorService());
+            val retValue = new TableBasedMetadataStore(tableName, tableStore, tableBasedMetadataStore.getConfig(), executorService());
             TableBasedMetadataStore.copyVersion(tableBasedMetadataStore, retValue);
             return retValue;
         }
@@ -68,7 +69,7 @@ public class TableBasedMetadataStoreTests extends ChunkMetadataStoreTests {
         protected ChunkMetadataStore getMetadataStore() throws Exception {
             TableStore tableStore = new InMemoryTableStore(executorService());
             String tableName = "TableBasedMetadataSimpleStorageTests";
-            return new TableBasedMetadataStore(tableName, tableStore, executorService());
+            return new TableBasedMetadataStore(tableName, tableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
         }
     }
 
@@ -80,7 +81,7 @@ public class TableBasedMetadataStoreTests extends ChunkMetadataStoreTests {
         public ChunkMetadataStore createMetadataStore() throws Exception {
             TableStore tableStore = new InMemoryTableStore(executorService());
             String tableName = "TableBasedMetadataSimpleStorageTests";
-            return new TableBasedMetadataStore(tableName, tableStore, executorService());
+            return new TableBasedMetadataStore(tableName, tableStore, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
         }
 
         public TestContext getTestContext() throws Exception {
@@ -110,7 +111,7 @@ public class TableBasedMetadataStoreTests extends ChunkMetadataStoreTests {
                 val thisMetadataStore = (TableBasedMetadataStore) this.metadataStore;
                 TableStore tableStore = InMemoryTableStore.clone((InMemoryTableStore) thisMetadataStore.getTableStore());
                 String tableName =  thisMetadataStore.getTableName();
-                val retValue = new TableBasedMetadataStore(tableName, tableStore, executor);
+                val retValue = new TableBasedMetadataStore(tableName, tableStore, config, executor);
                 TableBasedMetadataStore.copyVersion(thisMetadataStore, retValue);
                 return retValue;
             }
@@ -118,7 +119,7 @@ public class TableBasedMetadataStoreTests extends ChunkMetadataStoreTests {
             private ChunkMetadataStore createChunkMetadataStore() {
                 TableStore tableStore = new InMemoryTableStore(executor);
                 String tableName = "TableBasedMetadataSimpleStorageTests";
-                return new TableBasedMetadataStore(tableName, tableStore, executor);
+                return new TableBasedMetadataStore(tableName, tableStore, config, executor);
             }
         }
     }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageFactoryTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageFactoryTests.java
@@ -18,6 +18,8 @@ import io.pravega.segmentstore.storage.StorageFactoryInfo;
 import io.pravega.segmentstore.storage.StorageLayoutType;
 import io.pravega.segmentstore.storage.SyncStorage;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorage;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
+import io.pravega.test.common.AssertExtensions;
 import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
@@ -55,18 +57,17 @@ public class InMemorySimpleStorageFactoryTests {
 
         // Simple Storage
         ConfigSetup configSetup1 = mock(ConfigSetup.class);
-        val config = new Object();
-        when(configSetup1.getConfig(any())).thenReturn(config);
+        when(configSetup1.getConfig(any())).thenReturn(ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
         val factory1 = factoryCreator.createFactory(expected[0], configSetup1, executor);
         Assert.assertTrue(factory1 instanceof InMemorySimpleStorageFactory);
 
         @Cleanup
-        Storage storage1 = ((InMemorySimpleStorageFactory) factory1).createStorageAdapter(42, new InMemoryMetadataStore(executor));
+        Storage storage1 = ((InMemorySimpleStorageFactory) factory1).createStorageAdapter(42, new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executor));
         Assert.assertTrue(storage1 instanceof ChunkedSegmentStorage);
 
         // Legacy Storage
         ConfigSetup configSetup2 = mock(ConfigSetup.class);
-        when(configSetup2.getConfig(any())).thenReturn(config);
+        when(configSetup2.getConfig(any())).thenReturn(ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
         val factory2 = factoryCreator.createFactory(expected[1], configSetup2, executor);
 
         Assert.assertTrue(factory2 instanceof InMemoryStorageFactory);
@@ -81,12 +82,12 @@ public class InMemorySimpleStorageFactoryTests {
     public void testReuse() {
         @Cleanup("shutdownNow")
         val executor = ExecutorServiceHelpers.newScheduledThreadPool(1, "test");
-        val factory = new InMemorySimpleStorageFactory(executor, true);
+        val factory = new InMemorySimpleStorageFactory(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executor, true);
 
         @Cleanup
-        val s1 = (ChunkedSegmentStorage) factory.createStorageAdapter(42, new InMemoryMetadataStore(executor));
+        val s1 = (ChunkedSegmentStorage) factory.createStorageAdapter(42, new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executor));
         @Cleanup
-        val s2 = (ChunkedSegmentStorage) factory.createStorageAdapter(42, new InMemoryMetadataStore(executor));
+        val s2 = (ChunkedSegmentStorage) factory.createStorageAdapter(42, new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executor));
 
         Assert.assertEquals(s1.getChunkStorage(), s2.getChunkStorage());
     }
@@ -95,13 +96,27 @@ public class InMemorySimpleStorageFactoryTests {
     public void testNoReuse() {
         @Cleanup("shutdownNow")
         val executor = ExecutorServiceHelpers.newScheduledThreadPool(1, "test");
-        val factory = new InMemorySimpleStorageFactory(executor, false);
+        val factory = new InMemorySimpleStorageFactory(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executor, false);
 
         @Cleanup
-        val s1 = (ChunkedSegmentStorage) factory.createStorageAdapter(42, new InMemoryMetadataStore(executor));
+        val s1 = (ChunkedSegmentStorage) factory.createStorageAdapter(42, new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executor));
         @Cleanup
-        val s2 = (ChunkedSegmentStorage) factory.createStorageAdapter(42, new InMemoryMetadataStore(executor));
+        val s2 = (ChunkedSegmentStorage) factory.createStorageAdapter(42, new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executor));
 
         Assert.assertNotEquals(s1.getChunkStorage(), s2.getChunkStorage());
+    }
+
+    @Test
+    public void testNull() {
+        @Cleanup("shutdownNow")
+        val executor = ExecutorServiceHelpers.newScheduledThreadPool(1, "test");
+        AssertExtensions.assertThrows(
+                " should throw exception.",
+                () -> new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, null),
+                ex -> ex instanceof NullPointerException);
+        AssertExtensions.assertThrows(
+                " should throw exception.",
+                () -> new InMemoryMetadataStore(null, executor),
+                ex -> ex instanceof NullPointerException);
     }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -115,14 +115,26 @@ public final class MetricsNames {
     // SLTS stats
     public static final String SLTS_READ_LATENCY = PREFIX + "segmentstore.storage.slts.read_latency_ms";            // Histogram
     public static final String SLTS_WRITE_LATENCY = PREFIX + "segmentstore.storage.slts.write_latency_ms";          // Histogram
+    public static final String SLTS_SYSTEM_READ_LATENCY = PREFIX + "segmentstore.storage.slts.system_read_latency_ms";      // Histogram
+    public static final String SLTS_SYSTEM_WRITE_LATENCY = PREFIX + "segmentstore.storage.slts.system_write_latency_ms";    // Histogram
     public static final String SLTS_CREATE_LATENCY = PREFIX + "segmentstore.storage.slts.create_latency_ms";        // Histogram
     public static final String SLTS_DELETE_LATENCY = PREFIX + "segmentstore.storage.slts.delete_latency_ms";        // Histogram
     public static final String SLTS_CONCAT_LATENCY = PREFIX + "segmentstore.storage.slts.concat_latency_ms";        // Histogram
     public static final String SLTS_TRUNCATE_LATENCY = PREFIX + "segmentstore.storage.slts.truncate_latency_ms";    // Histogram
 
+    public static final String SLTS_NUM_CHUNKS_READ = PREFIX + "segmentstore.storage.slts.num_chunks_read";         // Histogram
+    public static final String SLTS_SYSTEM_NUM_CHUNKS_READ = PREFIX + "segmentstore.storage.slts.system_num_chunks_read"; // Histogram
+    public static final String SLTS_NUM_CHUNKS_ADDED = PREFIX + "segmentstore.storage.slts.num_chunks_added";         // Histogram
+    public static final String SLTS_SYSTEM_NUM_CHUNKS_ADDED = PREFIX + "segmentstore.storage.slts.system_num_chunks_added"; // Histogram
+
+    public static final String SLTS_READ_INSTANT_TPUT = PREFIX + "segmentstore.storage.slts.read_instant_tput";       // Histogram
+    public static final String SLTS_WRITE_INSTANT_TPUT = PREFIX + "segmentstore.storage.slts.write_instant_tput";     // Histogram
+
     public static final String SLTS_READ_INDEX_SCAN_LATENCY = PREFIX + "segmentstore.storage.slts.read_index.scan_latency_ms";              // Histogram
+    public static final String SLTS_READ_INDEX_BLOCK_LOOKUP_LATENCY = PREFIX + "segmentstore.storage.slts.read_index.block_lookup_latency_ms";    // Histogram
     public static final String SLTS_READ_INDEX_NUM_SCANNED = PREFIX + "segmentstore.storage.slts.read_index.num_scanned";                   // Histogram
     public static final String SLTS_SYS_READ_INDEX_SCAN_LATENCY = PREFIX + "segmentstore.storage.slts.read_index.system_scan_latency_ms";   // Histogram
+    public static final String SLTS_SYS_READ_INDEX_BLOCK_LOOKUP_LATENCY = PREFIX + "segmentstore.storage.slts.read_index.system_block_lookup_latency_ms";   // Histogram
     public static final String SLTS_SYS_READ_INDEX_NUM_SCANNED = PREFIX + "segmentstore.storage.slts.read_index.system_num_scanned";        // Histogram
 
     public static final String SLTS_READ_INDEX_SEGMENT_INDEX_SIZE = PREFIX + "segmentstore.storage.slts.read_index.segment_index_size";     // Gauge
@@ -131,15 +143,20 @@ public final class MetricsNames {
 
     public static final String SLTS_READ_BYTES = PREFIX + "segmentstore.storage.slts.read_bytes";          // Counter
     public static final String SLTS_WRITE_BYTES = PREFIX + "segmentstore.storage.slts.write_bytes";        // Counter
+    public static final String SLTS_SYSTEM_READ_BYTES = PREFIX + "segmentstore.storage.slts.system_read_bytes";     // Counter
+    public static final String SLTS_SYSTEM_WRITE_BYTES = PREFIX + "segmentstore.storage.slts.system_write_bytes";   // Counter
     public static final String SLTS_CONCAT_BYTES = PREFIX + "segmentstore.storage.slts.concat_bytes";      // Counter
     public static final String SLTS_CREATE_COUNT = PREFIX + "segmentstore.storage.slts.create_count";      // Counter
     public static final String SLTS_DELETE_COUNT = PREFIX + "segmentstore.storage.slts.delete_count";      // Counter
     public static final String SLTS_CONCAT_COUNT = PREFIX + "segmentstore.storage.slts.concat_count";      // Counter
     public static final String SLTS_TRUNCATE_COUNT = PREFIX + "segmentstore.storage.slts.truncate_count";  // Counter
+    public static final String SLTS_SYSTEM_TRUNCATE_COUNT = PREFIX + "segmentstore.storage.slts.system_truncate_count";  // Counter
 
     public static final String SLTS_GC_QUEUE_SIZE = PREFIX + "segmentstore.storage.slts.GC_queue_record_count";  // Counter
 
     // SLTS Metadata stats
+    public static final String STORAGE_METADATA_SIZE = PREFIX + "segmentstore.storage.size.";
+    public static final String STORAGE_METADATA_NUM_CHUNKS = PREFIX + "segmentstore.storage.num_chunks.";
     public static final String STORAGE_METADATA_GET_LATENCY = PREFIX + "segmentstore.storage.metadata_get_latency_ms";                  // Histogram
     public static final String STORAGE_METADATA_COMMIT_LATENCY = PREFIX + "segmentstore.storage.metadata_commit_latency_ms";            // Histogram
     public static final String STORAGE_METADATA_TABLE_GET_LATENCY = PREFIX + "segmentstore.storage.metadata_table_get_latency_ms";      // Histogram


### PR DESCRIPTION
**Change log description**  
Cherry pick SLTS changes from master to r0.9

**Purpose of the change**  
Cherry-pick SLTS changes from master to r0.9
Fixes https://github.com/pravega/pravega/issues/5923

Expected commits ( in chronological order)

- Issue 5861: (SLTS) Make metadata buffer size and metadata cache size configurable. (#5862)

- Issue 5902: SLTS - Metrics Improvements and minor perf improvements (#5903)

**What the code does**  
Cherry pick r0.9

**How to verify it**  
Build should pass.
