### PR TITLE
Issue 5928: Always upload logs from github actions builds.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Tar Reports
         run: tar --use-compress-program zstd -cf reports-${{github.job}}.tzst `echo ${{env.REPORTS_LOCATIONS}}`
       - name: Upload Reports
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: ${{github.job}}-reports
@@ -156,6 +157,7 @@ jobs:
       - name: Tar Reports
         run: tar --use-compress-program zstd -cf reports-${{github.job}}.tzst `echo ${{env.REPORTS_LOCATIONS}}`
       - name: Upload Reports
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: ${{github.job}}-reports
@@ -193,6 +195,7 @@ jobs:
       - name: Tar Reports
         run: tar --use-compress-program zstd -cf reports-${{github.job}}.tzst `echo ${{env.REPORTS_LOCATIONS}}`
       - name: Upload Reports
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: ${{github.job}}-reports
@@ -229,6 +232,7 @@ jobs:
       - name: Tar Reports
         run: tar --use-compress-program zstd -cf reports-${{github.job}}.tzst `echo ${{env.REPORTS_LOCATIONS}}`
       - name: Upload Reports
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: ${{github.job}}-reports
@@ -279,6 +283,7 @@ jobs:
       - name: Tar Reports
         run: tar --use-compress-program zstd -cf reports-${{github.job}}.tzst `echo ${{env.REPORTS_LOCATIONS}}`
       - name: Upload Reports
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: ${{github.job}}-reports


### PR DESCRIPTION
Signed-off-by: Tom Kaitchuck <tom.kaitchuck@emc.com>

**Change log description**  
Uploads artifacts from github actions even in the event of build failure.

**Purpose of the change**  
Fixes #5928

**What the code does**  
No code changes


