### PR TITLE
Issue 5846: Create exception to force Segment Container shutdown

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/bookkeeper/ContainerRecoverCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/bookkeeper/ContainerRecoverCommand.java
@@ -77,6 +77,7 @@ public class ContainerRecoverCommand extends ContainerCommand {
             ex.printStackTrace(getOut());
             Throwable cause = Exceptions.unwrap(ex);
             if (cause instanceof ServiceHaltException) {
+                // Covers DataCorruptionException
                 unwrapServiceHaltException((ServiceHaltException) cause);
             }
         }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/bookkeeper/ContainerRecoverCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/bookkeeper/ContainerRecoverCommand.java
@@ -19,7 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import io.pravega.cli.admin.CommandArgs;
 import io.pravega.common.Exceptions;
-import io.pravega.segmentstore.server.DataCorruptionException;
+import io.pravega.segmentstore.server.ServiceHaltException;
 import io.pravega.segmentstore.server.logs.DataFrame;
 import io.pravega.segmentstore.server.logs.DataFrameRecord;
 import io.pravega.segmentstore.server.logs.DebugRecoveryProcessor;
@@ -76,15 +76,15 @@ public class ContainerRecoverCommand extends ContainerCommand {
                     recoveryState.dataFrameCount, recoveryState.operationCount);
             ex.printStackTrace(getOut());
             Throwable cause = Exceptions.unwrap(ex);
-            if (cause instanceof DataCorruptionException) {
-                unwrapDataCorruptionException((DataCorruptionException) cause);
+            if (cause instanceof ServiceHaltException) {
+                unwrapServiceHaltException((ServiceHaltException) cause);
             }
         }
     }
 
     @VisibleForTesting
-    void unwrapDataCorruptionException(DataCorruptionException dce) {
-        Object[] context = dce.getAdditionalData();
+    void unwrapServiceHaltException(ServiceHaltException ex) {
+        Object[] context = ex.getAdditionalData();
         if (context == null || context.length == 0) {
             return;
         }

--- a/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
@@ -20,6 +20,7 @@ import io.pravega.cli.admin.CommandArgs;
 import io.pravega.cli.admin.utils.TestUtils;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.segmentstore.server.DataCorruptionException;
+import io.pravega.segmentstore.server.ServiceHaltException;
 import io.pravega.segmentstore.server.logs.DataFrameRecord;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.storage.DataLogNotAvailableException;
@@ -188,9 +189,9 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
         CommandArgs args = new CommandArgs(Collections.singletonList("0"), STATE.get());
         ContainerRecoverCommand command = new ContainerRecoverCommand(args);
         // Test unwrap exception options.
-        command.unwrapDataCorruptionException(new DataCorruptionException("test"));
-        command.unwrapDataCorruptionException(new DataCorruptionException("test", "test"));
-        command.unwrapDataCorruptionException(new DataCorruptionException("test", Arrays.asList("test", "test")));
+        command.unwrapServiceHaltException(new ServiceHaltException("test"));
+        command.unwrapServiceHaltException(new ServiceHaltException("test", "test"));
+        command.unwrapServiceHaltException(new ServiceHaltException("test", Arrays.asList("test", "test")));
         // Check that exception is thrown if ZK is not available.
         this.zkUtil.stopCluster();
         AssertExtensions.assertThrows(DataLogNotAvailableException.class, () -> TestUtils.executeCommand("container recover 0", STATE.get()));

--- a/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
@@ -192,6 +192,8 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
         command.unwrapServiceHaltException(new ServiceHaltException("test"));
         command.unwrapServiceHaltException(new ServiceHaltException("test", "test"));
         command.unwrapServiceHaltException(new ServiceHaltException("test", Arrays.asList("test", "test")));
+        command.unwrapServiceHaltException(new ServiceHaltException("test", null));
+        command.unwrapServiceHaltException(new ServiceHaltException("test", null, false, false));
         // Check that exception is thrown if ZK is not available.
         this.zkUtil.stopCluster();
         AssertExtensions.assertThrows(DataLogNotAvailableException.class, () -> TestUtils.executeCommand("container recover 0", STATE.get()));

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ServiceHaltException.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ServiceHaltException.java
@@ -18,6 +18,10 @@ package io.pravega.segmentstore.server;
 import io.pravega.segmentstore.contracts.StreamingException;
 import lombok.Getter;
 
+/**
+ * Exception that is thrown whenever we detect an unrecoverable state.
+ * Usually, after this is thrown, our only resolution will be to shut down the Segment Container, DurableLog and StorageWriter.
+ */
 public class ServiceHaltException extends StreamingException {
     /**
      *

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ServiceHaltException.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ServiceHaltException.java
@@ -15,38 +15,45 @@
  */
 package io.pravega.segmentstore.server;
 
-/**
- * Exception that is thrown whenever we detect an unrecoverable data corruption.
- * Usually, after this is thrown, our only resolution may be to suspend processing in the container or completely bring it offline.
- */
-public class DataCorruptionException extends ServiceHaltException {
+import io.pravega.segmentstore.contracts.StreamingException;
+import lombok.Getter;
+
+public class ServiceHaltException extends StreamingException {
     /**
      *
      */
     private static final long serialVersionUID = 1L;
 
     /**
-     * Creates a new instance of the DataCorruptionException class.
+     * Gets an array of objects that may contain additional context-related information.
+     */
+    @Getter
+    private final Object[] additionalData;
+
+    /**
+     * Creates a new instance of the ServiceHaltException class.
      *
      * @param message        The message for the exception.
      * @param additionalData An array of objects that contain additional debugging information.
      */
-    public DataCorruptionException(String message, Object... additionalData) {
-        super(message, additionalData);
+    public ServiceHaltException(String message, Object... additionalData) {
+        this(message, null, additionalData);
     }
 
     /**
-     * Creates a new instance of the DataCorruptionException class.
+     * Creates a new instance of the ServiceHaltException class.
      *
      * @param message        The message for the exception.
      * @param cause          The causing exception.
      * @param additionalData An array of objects that contain additional debugging information.
      */
-    public DataCorruptionException(String message, Throwable cause, Object... additionalData) {
-        super(message, cause, additionalData);
+    public ServiceHaltException(String message, Throwable cause, Object... additionalData) {
+        super(message, cause);
+        this.additionalData = additionalData;
     }
 
-    public DataCorruptionException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    public ServiceHaltException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
+        this.additionalData = null;
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterSegmentProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/WriterSegmentProcessor.java
@@ -50,12 +50,13 @@ public interface WriterSegmentProcessor extends AutoCloseable {
      * Adds the given {@link SegmentOperation} to the Processor.
      *
      * @param operation the SegmentOperation to add.
-     * @throws DataCorruptionException  If the validation of the given Operation indicates a possible data corruption in
-     *                                  the code (offset gaps, out-of-order operations, etc.)
+     * @throws ServiceHaltException     If the validation of the given Operation indicates a possible data corruption in
+     *                                  the code (offset gaps, out-of-order operations, etc.) or state in which the
+     *                                  operation has been already acknowledged.
      * @throws IllegalArgumentException If the validation of the given Operation indicates a possible non-corrupting bug
      *                                  in the code.
      */
-    void add(SegmentOperation operation) throws DataCorruptionException;
+    void add(SegmentOperation operation) throws ServiceHaltException;
 
     /**
      * Flushes the contents of the Processor.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DebugRecoveryProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DebugRecoveryProcessor.java
@@ -20,8 +20,8 @@ import io.pravega.common.function.Callbacks;
 import io.pravega.common.util.AbstractDrainingQueue;
 import io.pravega.segmentstore.server.CacheManager;
 import io.pravega.segmentstore.server.CachePolicy;
-import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.ReadIndexFactory;
+import io.pravega.segmentstore.server.ServiceHaltException;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.containers.ContainerConfig;
 import io.pravega.segmentstore.server.containers.StreamSegmentContainerMetadata;
@@ -107,7 +107,7 @@ public class DebugRecoveryProcessor extends RecoveryProcessor implements AutoClo
     //region RecoveryProcessor Overrides
 
     @Override
-    protected void recoverOperation(DataFrameRecord<Operation> dataFrameRecord, OperationMetadataUpdater metadataUpdater) throws DataCorruptionException {
+    protected void recoverOperation(DataFrameRecord<Operation> dataFrameRecord, OperationMetadataUpdater metadataUpdater) throws ServiceHaltException {
         if (this.callbacks.beginRecoverOperation != null) {
             Callbacks.invokeSafely(this.callbacks.beginRecoverOperation, dataFrameRecord.getItem(), dataFrameRecord.getFrameEntries(), null);
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -228,10 +228,10 @@ public class DurableLog extends AbstractService implements OperationLog {
             log.error("{} Recovery FAILED.", this.traceObjectId, ex);
             Throwable cause = Exceptions.unwrap(ex);
             if (cause instanceof ServiceHaltException || cause instanceof DataLogCorruptedException) {
-                // ServiceHaltException during recovery means we will be unable to execute the recovery successfully
-                // regardless how many times we try. We need to disable the log so that future instances of this class
-                // will not attempt to do so indefinitely (which could wipe away useful debugging information before
-                // someone can manually fix the problem).
+                // ServiceHaltException (also covers DataCorruptionException) during recovery means we will be unable to
+                // execute the recovery successfully regardless how many times we try. We need to disable the log so that
+                // future instances of this class will not attempt to do so indefinitely (which could wipe away useful
+                // debugging information before someone can manually fix the problem).
                 try {
                     this.durableDataLog.disable();
                     log.info("{} Log disabled due to {} during recovery.", this.traceObjectId, cause.getClass().getSimpleName());

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -228,7 +228,7 @@ public class DurableLog extends AbstractService implements OperationLog {
             log.error("{} Recovery FAILED.", this.traceObjectId, ex);
             Throwable cause = Exceptions.unwrap(ex);
             if (cause instanceof ServiceHaltException || cause instanceof DataLogCorruptedException) {
-                // DataCorruptionException during recovery means we will be unable to execute the recovery successfully
+                // ServiceHaltException during recovery means we will be unable to execute the recovery successfully
                 // regardless how many times we try. We need to disable the log so that future instances of this class
                 // will not attempt to do so indefinitely (which could wipe away useful debugging information before
                 // someone can manually fix the problem).

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -28,10 +28,10 @@ import io.pravega.common.concurrent.Services;
 import io.pravega.common.util.Retry;
 import io.pravega.segmentstore.contracts.StreamingException;
 import io.pravega.segmentstore.server.ContainerOfflineException;
-import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.IllegalContainerStateException;
 import io.pravega.segmentstore.server.OperationLog;
 import io.pravega.segmentstore.server.ReadIndex;
+import io.pravega.segmentstore.server.ServiceHaltException;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
@@ -227,7 +227,7 @@ public class DurableLog extends AbstractService implements OperationLog {
         } catch (Exception ex) {
             log.error("{} Recovery FAILED.", this.traceObjectId, ex);
             Throwable cause = Exceptions.unwrap(ex);
-            if (cause instanceof DataCorruptionException || cause instanceof DataLogCorruptedException) {
+            if (cause instanceof ServiceHaltException || cause instanceof DataLogCorruptedException) {
                 // DataCorruptionException during recovery means we will be unable to execute the recovery successfully
                 // regardless how many times we try. We need to disable the log so that future instances of this class
                 // will not attempt to do so indefinitely (which could wipe away useful debugging information before

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
@@ -144,7 +144,7 @@ class MemoryStateUpdater {
      * @param callback   A Consumer that will be invoked on EVERY {@link Operation} in the operations iterator, in the
      *                   order returned from the iterator, regardless of whether the operation was processed or not.
      * @throws ServiceHaltException    If a serious, non-recoverable state was detected, such as unable to create a
-     *      *                          CachedStreamSegmentAppendOperation.
+     *                                 CachedStreamSegmentAppendOperation.
      * @throws CacheFullException      If any operation in the given iterator contains data that needs to be added to the
      *                                 {@link ReadIndex} but it could not be done due to the cache being full and unable
      *                                 to evict anything to make room for more.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/MemoryStateUpdater.java
@@ -25,6 +25,7 @@ import io.pravega.segmentstore.server.ContainerMetadata;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.ReadIndex;
 import io.pravega.segmentstore.server.SegmentOperation;
+import io.pravega.segmentstore.server.ServiceHaltException;
 import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
@@ -142,13 +143,13 @@ class MemoryStateUpdater {
      * @param operations An Iterator iterating over the operations to process (in sequence).
      * @param callback   A Consumer that will be invoked on EVERY {@link Operation} in the operations iterator, in the
      *                   order returned from the iterator, regardless of whether the operation was processed or not.
-     * @throws DataCorruptionException If a serious, non-recoverable, data corruption was detected, such as trying to
-     *                                 append operations out of order.
+     * @throws ServiceHaltException    If a serious, non-recoverable state was detected, such as unable to create a
+     *      *                          CachedStreamSegmentAppendOperation.
      * @throws CacheFullException      If any operation in the given iterator contains data that needs to be added to the
      *                                 {@link ReadIndex} but it could not be done due to the cache being full and unable
      *                                 to evict anything to make room for more.
      */
-    void process(Iterator<Operation> operations, Consumer<Operation> callback) throws DataCorruptionException, CacheFullException {
+    void process(Iterator<Operation> operations, Consumer<Operation> callback) throws ServiceHaltException, CacheFullException {
         HashSet<Long> segmentIds = new HashSet<>();
         Operation op = null;
         try {
@@ -183,12 +184,12 @@ class MemoryStateUpdater {
      * Processes the given operation and applies it to the ReadIndex and InMemory OperationLog.
      *
      * @param operation The operation to process.
-     * @throws DataCorruptionException If a serious, non-recoverable, data corruption was detected, such as trying to
-     *                                 append operations out of order.
+     * @throws ServiceHaltException If a serious, non-recoverable state was detected, such as unable to create a
+     *                              CachedStreamSegmentAppendOperation.
      * @throws CacheFullException If the operation contains data that needs to be added to the {@link ReadIndex} but it
      * could not be done due to the cache being full and unable to evict anything to make room for more.
      */
-    void process(Operation operation) throws DataCorruptionException, CacheFullException {
+    void process(Operation operation) throws ServiceHaltException, CacheFullException {
         // Add entry to MemoryTransactionLog and ReadIndex/Cache. This callback is invoked from the OperationProcessor,
         // which always acks items in order of Sequence Number - so the entries should be ordered (but always check).
         if (operation instanceof StorageOperation) {
@@ -202,7 +203,7 @@ class MemoryStateUpdater {
                     if (Exceptions.mustRethrow(ex)) {
                         throw ex;
                     } else {
-                        throw new DataCorruptionException(String.format("Unable to create a CachedStreamSegmentAppendOperation from operation '%s'.", operation), ex);
+                        throw new ServiceHaltException(String.format("Unable to create a CachedStreamSegmentAppendOperation from operation '%s'.", operation), ex);
                     }
                 }
 
@@ -239,11 +240,11 @@ class MemoryStateUpdater {
      * @param operation The operation to register.
      * @throws CacheFullException If the operation could not be added to the {@link ReadIndex} due to the cache being
      * full and unable to evict anything to make room for more.
-     * @throws DataCorruptionException If any unexpected exception occurred that prevented the operation from being
+     * @throws ServiceHaltException If any unexpected exception occurred that prevented the operation from being
      * added to the {@link ReadIndex}. Unexpected exceptions are all exceptions other than those declared in this
      * method or that indicate we are shutting down or that the segment has been deleted.
      */
-    private void addToReadIndex(StorageOperation operation) throws DataCorruptionException, CacheFullException {
+    private void addToReadIndex(StorageOperation operation) throws ServiceHaltException, CacheFullException {
         try {
             if (operation instanceof StreamSegmentAppendOperation) {
                 // Record a StreamSegmentAppendOperation. Just in case, we also support this type of operation, but we need to
@@ -272,7 +273,7 @@ class MemoryStateUpdater {
             log.warn("Not adding operation '{}' to ReadIndex because the Cache is full.", operation);
             throw ex;
         } catch (Exception ex) {
-            throw new DataCorruptionException(String.format("Unable to add operation '%s' to ReadIndex.", operation), ex);
+            throw new ServiceHaltException(String.format("Unable to add operation '%s' to ReadIndex.", operation), ex);
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -26,9 +26,9 @@ import io.pravega.common.function.Callbacks;
 import io.pravega.common.util.BlockingDrainingQueue;
 import io.pravega.common.util.PriorityBlockingDrainingQueue;
 import io.pravega.segmentstore.server.CacheUtilizationProvider;
-import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.IllegalContainerStateException;
 import io.pravega.segmentstore.server.SegmentStoreMetrics;
+import io.pravega.segmentstore.server.ServiceHaltException;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.logs.operations.CompletableOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
@@ -443,7 +443,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
      * Determines whether the given Throwable is a fatal exception from which we cannot recover.
      */
     private static boolean isFatalException(Throwable ex) {
-        return ex instanceof DataCorruptionException
+        return ex instanceof ServiceHaltException
                 || ex instanceof DataLogWriterNotPrimaryException
                 || ex instanceof ObjectClosedException
                 || ex instanceof CacheFullException;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -443,7 +443,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
      * Determines whether the given Throwable is a fatal exception from which we cannot recover.
      */
     private static boolean isFatalException(Throwable ex) {
-        return ex instanceof ServiceHaltException
+        return ex instanceof ServiceHaltException       // Covers DataCorruptionException
                 || ex instanceof DataLogWriterNotPrimaryException
                 || ex instanceof ObjectClosedException
                 || ex instanceof CacheFullException;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/RecoveryProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/RecoveryProcessor.java
@@ -22,6 +22,7 @@ import io.pravega.segmentstore.contracts.ContainerException;
 import io.pravega.segmentstore.contracts.StreamSegmentException;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.SegmentStoreMetrics;
+import io.pravega.segmentstore.server.ServiceHaltException;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.logs.operations.CheckpointOperationBase;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
@@ -78,6 +79,7 @@ class RecoveryProcessor {
      *                   * DataLogWriterNotPrimaryException: If unable to acquire DurableDataLog ownership or the ownership
      *                   has been lost in the process.
      *                   * DataCorruptionException: If an unrecoverable corruption has been detected with the recovered data.
+     *                   * ServiceHaltException: If an unrecoverable state has been detected with the recovered data.
      *                   * SerializationException: If a DataFrame or Operation was unable to be deserialized.
      *                   * IOException: If a general IO exception occurred.
      */
@@ -177,7 +179,7 @@ class RecoveryProcessor {
         return recoveredItemCount;
     }
 
-    protected void recoverOperation(DataFrameRecord<Operation> dataFrameRecord, OperationMetadataUpdater metadataUpdater) throws DataCorruptionException {
+    protected void recoverOperation(DataFrameRecord<Operation> dataFrameRecord, OperationMetadataUpdater metadataUpdater) throws ServiceHaltException {
         // Update Metadata Sequence Number.
         Operation operation = dataFrameRecord.getItem();
         metadataUpdater.setOperationSequenceNumber(operation.getSequenceNumber());

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -32,6 +32,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.SegmentOperation;
+import io.pravega.segmentstore.server.ServiceHaltException;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.WriterFlushResult;
 import io.pravega.segmentstore.server.WriterSegmentProcessor;
@@ -324,13 +325,14 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
      * Adds the given SegmentOperation to the Aggregator.
      *
      * @param operation the Operation to add.
-     * @throws DataCorruptionException  If the validation of the given Operation indicates a possible data corruption in
-     *                                  the code (offset gaps, out-of-order operations, etc.)
+     * @throws ServiceHaltException     If the validation of the given Operation indicates a possible data corruption in
+     *                                  the code (offset gaps, out-of-order operations, etc.) or state in which the
+     *                                  operation has been already acknowledged.
      * @throws IllegalArgumentException If the validation of the given Operation indicates a possible non-corrupting bug
      *                                  in the code.
      */
     @Override
-    public void add(SegmentOperation operation) throws DataCorruptionException {
+    public void add(SegmentOperation operation) throws ServiceHaltException {
         ensureInitializedAndNotClosed();
         if (!(operation instanceof StorageOperation)) {
             // We only care about StorageOperations.
@@ -358,7 +360,7 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
         this.hasDeletePending.set(true);
     }
 
-    private void addStorageOperation(StorageOperation operation) throws DataCorruptionException {
+    private void addStorageOperation(StorageOperation operation) throws ServiceHaltException {
         checkValidStorageOperation(operation);
 
         // Add operation to list, but only if hasn't yet been persisted in Storage. It needs processing if either:
@@ -414,7 +416,7 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
      *
      * @param operation The operation to handle.
      */
-    private void acknowledgeAlreadyProcessedOperation(SegmentOperation operation) throws DataCorruptionException {
+    private void acknowledgeAlreadyProcessedOperation(SegmentOperation operation) throws ServiceHaltException {
         if (operation instanceof MergeSegmentOperation) {
             // Only MergeSegmentOperations need special handling. Others, such as StreamSegmentSealOperation, are not
             // needed since they're handled in the initialize() method. Ensure that the DataSource is aware of this
@@ -425,7 +427,7 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
             } catch (Throwable ex) {
                 // Something really weird must have happened if we ended up in here. To prevent any (further) damage, we need
                 // to stop the Segment Container right away.
-                throw new DataCorruptionException(String.format("Unable to acknowledge already processed operation '%s'.", operation), ex);
+                throw new ServiceHaltException(String.format("Unable to acknowledge already processed operation '%s'.", operation), ex);
             }
         }
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
@@ -309,6 +309,7 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
                     try {
                         aggregator.add(op);
                     } catch (ServiceHaltException ex) {
+                        // Covers DataCorruptionException
                         // Re-throw.
                         throw new CompletionException(ex);
                     } catch (Exception ex) {
@@ -471,7 +472,7 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
     private boolean isCriticalError(Throwable ex) {
         ex = Exceptions.unwrap(ex);
         return Exceptions.mustRethrow(ex)
-                || ex instanceof ServiceHaltException     // Service Halt - stop processing to prevent more damage.
+                || ex instanceof ServiceHaltException     // Service halt or Data corruption - stop processing to prevent more damage.
                 || ex instanceof StorageNotPrimaryException  // Fenced out - another instance took over.
                 || ex instanceof DataLogWriterNotPrimaryException;  // Fenced out at the DurableLog level.
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/StorageWriter.java
@@ -28,6 +28,7 @@ import io.pravega.common.concurrent.SequentialProcessor;
 import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.SegmentOperation;
 import io.pravega.segmentstore.server.SegmentStoreMetrics;
+import io.pravega.segmentstore.server.ServiceHaltException;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.Writer;
 import io.pravega.segmentstore.server.WriterFactory;
@@ -284,7 +285,7 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
             return processMetadataOperation((MetadataOperation) op);
         } else {
             // Unknown operation. Better throw an error rather than skipping over what could be important data.
-            return Futures.failedFuture(new DataCorruptionException(String.format("Unsupported operation %s.", op)));
+            return Futures.failedFuture(new ServiceHaltException(String.format("Unsupported operation %s.", op)));
         }
     }
 
@@ -307,13 +308,13 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
                 .thenAccept(aggregator -> {
                     try {
                         aggregator.add(op);
-                    } catch (DataCorruptionException ex) {
+                    } catch (ServiceHaltException ex) {
                         // Re-throw.
                         throw new CompletionException(ex);
                     } catch (Exception ex) {
                         // If we get any exception while processing this, then we will likely get it every time we attempt
                         // to do it again. Best if we bail out and attempt a recovery in this case.
-                        throw new CompletionException(new DataCorruptionException("Unable to process operation " + op, ex));
+                        throw new CompletionException(new ServiceHaltException("Unable to process operation " + op, ex));
                     }
                 });
     }
@@ -470,7 +471,7 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
     private boolean isCriticalError(Throwable ex) {
         ex = Exceptions.unwrap(ex);
         return Exceptions.mustRethrow(ex)
-                || ex instanceof DataCorruptionException     // Data corruption - stop processing to prevent more damage.
+                || ex instanceof ServiceHaltException     // Service Halt - stop processing to prevent more damage.
                 || ex instanceof StorageNotPrimaryException  // Fenced out - another instance took over.
                 || ex instanceof DataLogWriterNotPrimaryException;  // Fenced out at the DurableLog level.
     }
@@ -665,7 +666,7 @@ class StorageWriter extends AbstractThreadPoolService implements Writer {
         }
 
         @Override
-        public void add(SegmentOperation operation) throws DataCorruptionException {
+        public void add(SegmentOperation operation) throws ServiceHaltException {
             for (WriterSegmentProcessor wsp : this.processors) {
                 wsp.add(operation);
             }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/MemoryStateUpdaterTests.java
@@ -21,6 +21,7 @@ import io.pravega.segmentstore.server.DataCorruptionException;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.ReadIndex;
 import io.pravega.segmentstore.server.SegmentOperation;
+import io.pravega.segmentstore.server.ServiceHaltException;
 import io.pravega.segmentstore.server.UpdateableContainerMetadata;
 import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
@@ -206,7 +207,7 @@ public class MemoryStateUpdaterTests extends ThreadPooledTestSuite {
         verify(l1).notifyThrottleSourceChanged();
     }
 
-    private ArrayList<Operation> populate(MemoryStateUpdater updater, int segmentCount, int operationCountPerType) throws DataCorruptionException {
+    private ArrayList<Operation> populate(MemoryStateUpdater updater, int segmentCount, int operationCountPerType) throws ServiceHaltException {
         ArrayList<Operation> operations = new ArrayList<>();
         long offset = 0;
         for (int i = 0; i < segmentCount; i++) {


### PR DESCRIPTION
**Change log description**  
Replaced `DataCorruptionException` with `ServiceHaltException` in required places:

**Purpose of the change**  
Fixes #5846 

**What the code does**  
Created a new exception `ServiceHaltException` which inherits from `StreamingException`. Made `DataCorruptionException` extend from it. Replaced `DataCorruptionException` with `ServiceHaltException` in required places.

**How to verify it**  
Build shall pass.