### PR TITLE
Issue 5950: Use `testPodImage` system property within `setupTestPod.sh`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1023,6 +1023,7 @@ project('test:system') {
         environment "desiredBookkeeperCMVersion", System.getProperty("desiredBookkeeperCMVersion", "0.9.0")
         environment "tlsEnabled", System.getProperty("tlsEnabled", "false")
         environment "skipServiceInstallation", System.getProperty("skipServiceInstallation", "false")
+        environment "testPodImage", System.getProperty("testPodImage", "openjdk:8u181-jre-alpine")
 
         commandLine './kubernetes/setupTestPod.sh'
     }

--- a/test/system/kubernetes/setupTestPod.sh
+++ b/test/system/kubernetes/setupTestPod.sh
@@ -162,7 +162,7 @@ spec:
        claimName: task-pv-claim
   containers:
     - name: task-pv-container
-      image: openjdk:8u181-jre-alpine
+      image: $testPodImage
       command: ["/bin/sh"]
       args: ["-c", "sleep 60000"]
       volumeMounts:


### PR DESCRIPTION
Signed-off-by: Colin Hryniowski <colin.hryniowski@dell.com>

**Change log description**  

* Provides the already defined `testPodImage` system property as an environment variable to the `setupTestPod.sh` script.

**Purpose of the change**  
Fixes #5950 

**What the code does**  

* See above.

**How to verify it**  
(Optional: steps to verify that the changes are effective)
