### PR TITLE
Issue #5955: Use codecov-action@v1 instead of @v1.0.15

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -332,7 +332,7 @@ jobs:
       - name: Untar reports
         run: ( ls */reports-*.tzst | xargs -n1 tar --use-compress-program zstd --keep-newer-files -xf )
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v1.0.15
+        uses: codecov/codecov-action@v1
 
   snapshot:
     name: Artifactory Snapshot


### PR DESCRIPTION
**Change log description**  
Uses latest v1 release of codecov-action to always pull in latest bug fixes. SHA commit hash detection bugs have been fixed since the previous version of codecov-action that we were pegged to.

**Purpose of the change**  
Fixes #5955

**What the code does**  
Uses v1 catchall of codecov-action instead of fixed v1.0.15.

**How to verify it**  
May allow failing PRs to succeed in processing their unit test coverage reports after upload to codecov, where final "CI Complete" build step fails to detect commit SHA during codecov upload.
