### PR TITLE
Issue 5953: Missing "styler" property in java.gradle

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -113,11 +113,11 @@ plugins.withId('java') {
             while (outputCache.size() > 300) outputCache.remove()
         }
 
-	afterTest { descriptor, result ->
+	    afterTest { descriptor, result ->
             if (result.resultType == TestResult.ResultType.FAILURE && outputCache.size() > 0) {
                 println()
-		def red = new String((char) 27) + "[31m"
-		def black = new String((char) 27) + "[0m"
+		        def red = new String((char) 27) + "[31m"
+		        def black = new String((char) 27) + "[0m"
                 println("${red}${descriptor.getClassName()}.${descriptor.getDisplayName()} FAILED. Output (Last 300 lines):${black}")
                 outputCache.each { print(" > $it") }
             }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -113,10 +113,12 @@ plugins.withId('java') {
             while (outputCache.size() > 300) outputCache.remove()
         }
 
-        afterTest { descriptor, result ->
+	afterTest { descriptor, result ->
             if (result.resultType == TestResult.ResultType.FAILURE && outputCache.size() > 0) {
                 println()
-                println("${styler['red'](${descriptor.getClassName()}.${descriptor.getDisplayName()} + " FAILED" )} Output (Last 300 lines):")
+		def red = new String((char) 27) + "[31m"
+		def black = new String((char) 27) + "[0m"
+                println("${red}${descriptor.getClassName()}.${descriptor.getDisplayName()} FAILED. Output (Last 300 lines):${black}")
                 outputCache.each { print(" > $it") }
             }
         }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -113,11 +113,11 @@ plugins.withId('java') {
             while (outputCache.size() > 300) outputCache.remove()
         }
 
-	    afterTest { descriptor, result ->
+        afterTest { descriptor, result ->
             if (result.resultType == TestResult.ResultType.FAILURE && outputCache.size() > 0) {
                 println()
-		        def red = new String((char) 27) + "[31m"
-		        def black = new String((char) 27) + "[0m"
+                def red = new String((char) 27) + "[31m"
+                def black = new String((char) 27) + "[0m"
                 println("${red}${descriptor.getClassName()}.${descriptor.getDisplayName()} FAILED. Output (Last 300 lines):${black}")
                 outputCache.each { print(" > $it") }
             }


### PR DESCRIPTION
**Change log description**  
Explicitly use text colors in test build failure output.

**Purpose of the change**  
Fixes #5953.

**What the code does**  
Replaces the undefined variable `styler` by the actual text color expected in a failure output. Also, the text color is reset after the output for a failed build has been printed.

**How to verify it**  
Observed a failed build and the original error does not appear in Jenkins.

Signed-off-by: Raúl Gracia <raul.gracia@emc.com>