### PR TITLE
SLTS - Cherry-pick #5964 into r0.9 branch

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -649,7 +649,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                 new AttributeUpdate(ATTRIBUTE_SLTS_LATEST_SNAPSHOT_EPOCH, AttributeUpdateType.Replace, checkpoint.getEpoch()));
         return this.metadataStore.getOrAssignSegmentId(NameUtils.getMetadataSegmentName(this.metadata.getContainerId()), timer.getRemaining(),
                 streamSegmentId -> updateAttributesForSegment(streamSegmentId, attributeUpdates, timer.getRemaining()))
-                .thenRunAsync(() -> log.debug("{}: Save SLTS snapshot. {}", this.traceObjectId, checkpoint));
+                .thenRun(() -> log.debug("{}: Save SLTS snapshot. {}", this.traceObjectId, checkpoint));
     }
 
     //region SegmentContainer Implementation

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/TableMetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/TableMetadataStore.java
@@ -88,10 +88,8 @@ class TableMetadataStore extends MetadataStore {
                 .map(e -> new AttributeUpdate(e.getKey(), AttributeUpdateType.None, e.getValue()))
                 .collect(Collectors.toList());
 
-        // Container Metadata Segment is a System Table Segment. It is Internal, but it is not Critical (i.e., does not
-        // prevent the good functioning of the Segment Store). It is OK if "modify" operations on this segment are
-        // throttled as that would not prevent the Segment Store from making forward progress.
-        val segmentType = SegmentType.builder().tableSegment().system().internal().build();
+        // Container Metadata Segment is a System Table Segment. It is System, Internal, and Critical.
+        val segmentType = SegmentType.builder().tableSegment().system().critical().internal().build();
         return submitAssignment(SegmentInfo.newSegment(this.metadataSegmentName, segmentType, attributeUpdates), true, timeout)
                 .thenAccept(segmentId -> {
                     this.initialized.set(true);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AttributeAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/AttributeAggregator.java
@@ -207,7 +207,7 @@ class AttributeAggregator implements WriterSegmentProcessor, AutoCloseable {
         CompletableFuture<Void> result = handleAttributeException(persistPendingAttributes(
                 this.state.getAttributes(), this.state.getLastSequenceNumber(), timer));
         if (this.state.hasSeal()) {
-            result = result.thenComposeAsync(v -> handleAttributeException(sealAttributes(timer)));
+            result = result.thenComposeAsync(v -> handleAttributeException(sealAttributes(timer)), this.executor);
         }
 
         return result.thenApply(v -> {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -191,11 +191,8 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         this.logPrefix = String.format("ChunkedSegmentStorage[%d]", containerId);
 
         // Now bootstrap
-        log.debug("{} STORAGE BOOT: Started.", logPrefix);
-        Timer t = new Timer();
         return this.systemJournal.bootstrap(epoch, snapshotInfoStore)
-                .thenRun(() -> garbageCollector.initialize())
-                .thenRun(() -> log.debug("{} STORAGE BOOT: Ended. Total time = {} ms.", logPrefix, t.getElapsedMillis()));
+                .thenRun(() -> garbageCollector.initialize());
     }
 
     @Override

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ReadOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ReadOperation.java
@@ -281,7 +281,7 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
                         } else {
                             SLTS_READ_INDEX_BLOCK_LOOKUP_LATENCY.reportSuccessEvent(indexLookupTimer.getElapsed());
                         }
-                    });
+                    }, chunkedSegmentStorage.getExecutor());
         } else {
            f = CompletableFuture.completedFuture(null);
         }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -12,6 +12,7 @@ package io.pravega.segmentstore.storage.chunklayer;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectBuilder;
+import io.pravega.common.Timer;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.concurrent.MultiKeySequentialProcessor;
 import io.pravega.common.io.serialization.RevisionDataInput;
@@ -120,7 +121,7 @@ public class SystemJournal {
     /**
      * Indicates whether new chunk is required.
      */
-    final private AtomicBoolean newChunkRequired = new AtomicBoolean();
+    final private AtomicBoolean newChunkRequired = new AtomicBoolean(true);
 
     /**
      * Last successful snapshot.
@@ -297,11 +298,13 @@ public class SystemJournal {
         this.snapshotInfoStore = Preconditions.checkNotNull(snapshotInfoStore, "snapshotInfoStore");
         Preconditions.checkState(!reentryGuard.getAndSet(true), "bootstrap called multiple times.");
 
+        log.debug("SystemJournal[{}] BOOT started.", containerId);
+        Timer t = new Timer();
+
         // Start a transaction
         val txn = metadataStore.beginTransaction(false, getSystemSegments());
 
         val state = new BootstrapState();
-        val snapshotSaved = new AtomicBoolean();
 
         // Step 1: Create metadata records for system segments from latest snapshot.
         return findLatestSnapshot()
@@ -325,16 +328,9 @@ public class SystemJournal {
                     return applyFinalTruncateOffsets(txn, state);
                 }, executor)
                 .thenComposeAsync(v -> {
-                    // Step 5: Validate and save a snapshot.
-                    return validateAndSaveSnapshot(txn, true, config.isSelfCheckEnabled())
-                            .thenComposeAsync(saved -> {
-                                if (saved) {
-                                    snapshotSaved.set(true);
-                                    return writeSnapshotInfo(lastSavedSystemSnapshotId.get());
-                                } else {
-                                    return CompletableFuture.completedFuture(null);
-                                }
-                            }, executor);
+                    // Step 5: Create a snapshot record and validate it. However do not save it yet.
+                    return createSystemSnapshotRecord(txn, true, config.isSelfCheckEnabled())
+                            .thenComposeAsync(systemSnapshotRecord -> checkInvariants(systemSnapshotRecord), executor);
                 }, executor)
                 .thenAcceptAsync(v -> {
                     // Step 6: Check invariants. These should never fail.
@@ -342,9 +338,6 @@ public class SystemJournal {
                         Preconditions.checkState(currentFileIndex.get() == 0, "currentFileIndex must be zero");
                         Preconditions.checkState(systemJournalOffset.get() == 0, "systemJournalOffset must be zero");
                         Preconditions.checkState(newChunkRequired.get(), "newChunkRequired must be true");
-                        if (snapshotSaved.get()) {
-                            Preconditions.checkState(lastSavedSystemSnapshot.get() != null, "lastSavedSystemSnapshot must be initialized");
-                        }
                     }
                 }, executor)
                 .thenComposeAsync(v -> {
@@ -353,10 +346,11 @@ public class SystemJournal {
                 }, executor)
                 .whenCompleteAsync((v, e) -> {
                     txn.close();
-                    log.info("SystemJournal[{}] BOOT complete - applied {} records in {} journals.",
+                    log.info("SystemJournal[{}] BOOT complete - applied {} records in {} journals. Total time = {} ms.",
                             containerId,
                             state.recordsProcessedCount.get(),
-                            state.filesProcessedCount.get());
+                            state.filesProcessedCount.get(),
+                            t.getElapsedMillis());
                 }, executor);
     }
 
@@ -367,7 +361,7 @@ public class SystemJournal {
         if (getConfig().isSelfCheckEnabled()) {
             val snapshotFileName = NameUtils.getSystemJournalSnapshotFileName(containerId, epoch, snapshotId);
             return chunkStorage.exists(snapshotFileName)
-                    .thenAcceptAsync(exists -> Preconditions.checkState(exists, "Snapshot file must exist"), executor);
+                    .thenAcceptAsync(exists -> Preconditions.checkState(exists, "Snapshot chunk must exist"), executor);
         }
         return CompletableFuture.completedFuture(null);
     }
@@ -421,7 +415,7 @@ public class SystemJournal {
                 () -> !done.get() && attempt.get() < config.getMaxJournalWriteAttempts(),
                 () -> writeToJournal(bytes)
                         .thenAcceptAsync(v -> {
-                            log.trace("SystemJournal[{}] Logging system log records - file={}, batch={}.",
+                            log.trace("SystemJournal[{}] Logging system log records - journal={}, batch={}.",
                                     containerId, currentHandle.get().getChunkName(), batch);
                             recordsSinceSnapshot.incrementAndGet();
                             done.set(true);
@@ -462,15 +456,26 @@ public class SystemJournal {
      * Generate a snapshot if required.
      */
     private CompletableFuture<Void> generateSnapshotIfRequired() {
-        // Generate a snapshot when threshold for either time or number batches is reached.
-        if (recordsSinceSnapshot.get() > config.getMaxJournalUpdatesPerSnapshot() ||
-                currentTimeSupplier.get() - lastSavedSnapshotTime.get() > config.getJournalSnapshotInfoUpdateFrequency().toMillis()) {
+        // Generate a snapshot if no snapshot was saved before or when threshold for either time or number batches is reached.
+        boolean shouldGenerate = true;
+        if (lastSavedSystemSnapshot.get() == null) {
+            log.debug("SystemJournal[{}] Generating first snapshot.", containerId);
+        } else if (recordsSinceSnapshot.get() > config.getMaxJournalUpdatesPerSnapshot()) {
+            log.debug("SystemJournal[{}] Generating snapshot based on update threshold. {} updates since last snapshot.", containerId, recordsSinceSnapshot.get());
+        } else if (currentTimeSupplier.get() - lastSavedSnapshotTime.get() > config.getJournalSnapshotInfoUpdateFrequency().toMillis()) {
+            log.debug("SystemJournal[{}] Generating snapshot based on time threshold. current time={} last saved ={}.",
+                    containerId, currentTimeSupplier.get(), lastSavedSnapshotTime.get());
+        } else {
+            shouldGenerate = false;
+        }
+        if (shouldGenerate) {
             // Write a snapshot.
             val txn = metadataStore.beginTransaction(true, getSystemSegments());
             return validateAndSaveSnapshot(txn, true, config.isSelfCheckEnabled())
                     .thenAcceptAsync(saved -> {
                         txn.close();
                         if (saved) {
+                            lastSavedSnapshotTime.set(currentTimeSupplier.get());
                             recordsSinceSnapshot.set(0);
                             // Always start a new journal after snapshot
                             newChunkRequired.set(true);
@@ -490,12 +495,22 @@ public class SystemJournal {
      */
     private CompletableFuture<Void> writeSnapshotInfoIfRequired() {
         // Save if we have generated newer snapshot since last time we saved.
-        if (lastSavedSystemSnapshot.get() != null && lastSavedSnapshotInfo.get() != null
-                && lastSavedSnapshotInfo.get().getSnapshotId() < lastSavedSystemSnapshotId.get()) {
-            return writeSnapshotInfo(lastSavedSystemSnapshotId.get());
-        } else {
-            return CompletableFuture.completedFuture(null);
+        if (lastSavedSystemSnapshot.get() != null) {
+            boolean shouldSave = true;
+            if (lastSavedSnapshotInfo.get() == null) {
+                log.debug("SystemJournal[{}] Saving first snapshot info new={}.", containerId, lastSavedSystemSnapshotId.get());
+            } else if (lastSavedSnapshotInfo.get().getSnapshotId() < lastSavedSystemSnapshotId.get()) {
+                log.debug("SystemJournal[{}] Saving new snapshot info new={} old={}.", containerId,
+                        lastSavedSystemSnapshotId.get(), lastSavedSnapshotInfo.get().getSnapshotId());
+            } else {
+                shouldSave = false;
+            }
+            if (shouldSave) {
+                return writeSnapshotInfo(lastSavedSystemSnapshotId.get());
+            }
         }
+
+        return CompletableFuture.completedFuture(null);
     }
 
     /**
@@ -512,7 +527,6 @@ public class SystemJournal {
                             .thenAcceptAsync(v1 -> {
                                 log.info("SystemJournal[{}] Snapshot info saved.{}", containerId, info);
                                 lastSavedSnapshotInfo.set(info);
-                                lastSavedSnapshotTime.set(currentTimeSupplier.get());
                             }, executor)
                             .exceptionally(e -> {
                                 log.error("Unable to persist snapshot info.{}", currentSnapshotIndex, e);
@@ -539,6 +553,7 @@ public class SystemJournal {
                                 // Step 4: Deserialize and return.
                                 .thenApplyAsync(contents -> readSnapshotRecord(snapshotInfo, contents), executor);
                     } else {
+                        log.info("SystemJournal[{}] No Snapshot info available. This is ok if this is new installation", containerId);
                         return CompletableFuture.completedFuture(null);
                     }
                 }, executor);
@@ -550,7 +565,7 @@ public class SystemJournal {
     private CompletableFuture<Void> checkSnapshotExists(String snapshotFileName) {
         if (getConfig().isSelfCheckEnabled()) {
             return chunkStorage.exists(snapshotFileName)
-                    .thenAcceptAsync(exists -> Preconditions.checkState(exists, "File pointed by SnapshotInfo must exist"), executor);
+                    .thenAcceptAsync(exists -> Preconditions.checkState(exists, "Chunk pointed by SnapshotInfo must exist"), executor);
         } else {
             return CompletableFuture.completedFuture(null);
         }
@@ -585,6 +600,8 @@ public class SystemJournal {
                                                                               BootstrapState state,
                                                                               SystemSnapshotRecord systemSnapshot) {
         if (null != systemSnapshot) {
+            log.debug("SystemJournal[{}] Applying snapshot that includes journals up to epoch={} journal index={}", containerId,
+                    systemSnapshot.epoch, systemSnapshot.fileIndex);
             log.trace("SystemJournal[{}] Processing system log snapshot {}.", containerId, systemSnapshot);
             // Initialize the segments and their chunks.
             for (SegmentSnapshotRecord segmentSnapshot : systemSnapshot.segmentSnapshotRecords) {
@@ -613,6 +630,7 @@ public class SystemJournal {
                 }
             }
         } else {
+            log.debug("SystemJournal[{}] No previous snapshot present.", containerId);
             // Initialize with default values.
             for (String systemSegment : systemSegments) {
                 SegmentMetadata segmentMetadata = SegmentMetadata.builder()
@@ -814,7 +832,8 @@ public class SystemJournal {
             epochToStartScanning.set(systemSnapshotRecord.epoch);
             fileIndexToRecover.set(systemSnapshotRecord.fileIndex + 1);
         }
-
+        log.debug("SystemJournal[{}] Applying journal operations. Starting at epoch={}  journal index={}", containerId,
+                epochToStartScanning.get(), fileIndexToRecover.get());
         // Linearly read and apply all the journal files after snapshot.
         val epochToRecover = new AtomicLong(epochToStartScanning.get());
         return Futures.loop(
@@ -836,6 +855,8 @@ public class SystemJournal {
                                             if (!exists) {
                                                 // File does not exist. We have reached end of our scanning.
                                                 isScanDone.set(true);
+                                                log.debug("SystemJournal[{}] Done applying journal operations for epoch={}. Last journal index={}",
+                                                        containerId, epochToRecover.get(), fileIndexToRecover.get());
                                                 return CompletableFuture.completedFuture(null);
                                             } else {
                                                 // Read contents.
@@ -864,6 +885,7 @@ public class SystemJournal {
                 () -> !isBatchDone.get(),
                 () -> {
                     try {
+                        log.debug("SystemJournal[{}] Processing journal {}.", containerId, systemLogName);
                         val batch = BATCH_SERIALIZER.deserialize(input);
 
                         return Futures.loop(
@@ -872,10 +894,10 @@ public class SystemJournal {
                                         .thenApply(r -> true),
                                 executor);
                     } catch (EOFException e) {
-                        log.debug("SystemJournal[{}] Done processing file {}.", containerId, systemLogName);
+                        log.debug("SystemJournal[{}] Done processing journal {}.", containerId, systemLogName);
                         isBatchDone.set(true);
                     } catch (Exception e) {
-                        log.error("SystemJournal[{}] Error file {}.", containerId, systemLogName, e);
+                        log.error("SystemJournal[{}] Error while processing journal {}.", containerId, systemLogName, e);
                         throw new CompletionException(e);
                     }
                     return CompletableFuture.completedFuture(null);
@@ -941,7 +963,11 @@ public class SystemJournal {
                                                     Preconditions.checkState(null != lastChunk, "lastChunk must not be null. Segment=%s", segmentMetadata);
                                                     lastChunk.setLength(length);
                                                     txn.update(lastChunk);
-                                                    segmentMetadata.setLength(segmentMetadata.getLastChunkStartOffset() + length);
+                                                    val newLength = segmentMetadata.getLastChunkStartOffset() + length;
+                                                    segmentMetadata.setLength(newLength);
+                                                    log.debug("SystemJournal[{}] Adjusting length of last chunk segment. segment={}, length={} chunk={}, chunk length={}",
+                                                            containerId, segmentMetadata.getName(), length, lastChunk.getName(), newLength);
+
                                                 }, executor);
                                     }, executor);
                         } else {
@@ -952,7 +978,7 @@ public class SystemJournal {
                             segmentMetadata.checkInvariants();
 
                             return segmentMetadata;
-                        });
+                        }, executor);
                     }, executor)
                     .thenAcceptAsync(segmentMetadata -> txn.update(segmentMetadata), executor);
             futures.add(f);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalOperationsTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalOperationsTests.java
@@ -17,6 +17,7 @@ import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
 import io.pravega.segmentstore.storage.mocks.InMemoryChunkStorage;
 import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
 import io.pravega.segmentstore.storage.mocks.InMemorySnapshotInfoStore;
+import io.pravega.shared.NameUtils;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import lombok.Builder;
 import lombok.Cleanup;
@@ -255,6 +256,140 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         instance4.validate();
         TestUtils.checkSegmentBounds(instance3.metadataStore, testSegmentName, 4, 10);
         TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance3.metadataStore, testSegmentName);
+    }
+
+    @Test
+    public void testWithSnapshots() throws Exception {
+        val testContext = new TestContext(CONTAINER_ID);
+        testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .maxJournalUpdatesPerSnapshot(3)
+                .selfCheckEnabled(true)
+                .build());
+
+        val testSegmentName = testContext.segmentNames[0];
+
+        @Cleanup
+        val instance =  new TestInstance(testContext, 1);
+        instance.bootstrap();
+        instance.validate();
+        checkJournalsNotExist(testContext, instance, 1, 1, 1);
+
+        // Add chunk.
+        instance.append(testSegmentName, "A", 0, 1);
+        checkJournalsExist(testContext, instance, 1, 1, 1);
+
+        // Add chunk.
+        instance.append(testSegmentName, "B", 1, 2);
+        checkJournalsExist(testContext, instance, 1, 1, 2);
+
+        // Add chunk.
+        instance.append(testSegmentName, "C", 3, 3);
+        checkJournalsExist(testContext, instance, 1, 1, 3);
+
+        // Add chunk.
+        instance.append(testSegmentName, "D", 6, 4);
+        checkJournalsExist(testContext, instance, 1, 1, 4);
+
+        // Add chunk.
+        instance.append(testSegmentName, "E", 10, 5);
+        checkJournalsExist(testContext, instance, 2, 2, 5);
+
+        // Add chunk.
+        instance.append(testSegmentName, "F", 15, 6);
+        checkJournalsExist(testContext, instance, 2, 2, 6);
+
+        // Bootstrap new instance.
+        @Cleanup
+        val instance2 =  new TestInstance(testContext, 2);
+        instance2.bootstrap();
+        instance2.validate();
+
+        // Validate.
+        TestUtils.checkSegmentBounds(instance2.metadataStore, testSegmentName, 0, 21);
+        TestUtils.checkSegmentLayout(instance2.metadataStore, testSegmentName, new long[] { 1, 2, 3, 4, 5, 6});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance2.metadataStore, testSegmentName);
+        val segmentMetadata = TestUtils.getSegmentMetadata(instance2.metadataStore, testSegmentName);
+        Assert.assertEquals("A", segmentMetadata.getFirstChunk());
+        Assert.assertEquals("F", segmentMetadata.getLastChunk());
+        Assert.assertEquals(0, segmentMetadata.getFirstChunkStartOffset());
+        Assert.assertEquals(15, segmentMetadata.getLastChunkStartOffset());
+    }
+
+    private void checkJournalsExist(TestContext testContext, TestInstance instance, long snapshotId, long journalIndex, long changeNumber) throws Exception {
+        Assert.assertTrue(testContext.chunkStorage.exists(NameUtils.getSystemJournalSnapshotFileName(CONTAINER_ID, instance.epoch, snapshotId)).get());
+        Assert.assertFalse(testContext.chunkStorage.exists(NameUtils.getSystemJournalSnapshotFileName(CONTAINER_ID, instance.epoch, snapshotId + 1)).get());
+        if (testContext.config.isAppendEnabled() && testContext.chunkStorage.supportsAppend()) {
+            Assert.assertTrue(testContext.chunkStorage.exists(NameUtils.getSystemJournalFileName(CONTAINER_ID, instance.epoch, journalIndex)).get());
+            Assert.assertFalse(testContext.chunkStorage.exists(NameUtils.getSystemJournalFileName(CONTAINER_ID, instance.epoch, journalIndex + 1)).get());
+        } else {
+            Assert.assertTrue(testContext.chunkStorage.exists(NameUtils.getSystemJournalFileName(CONTAINER_ID, instance.epoch, changeNumber)).get());
+            Assert.assertFalse(testContext.chunkStorage.exists(NameUtils.getSystemJournalFileName(CONTAINER_ID, instance.epoch, changeNumber + 1)).get());
+        }
+    }
+
+    private void checkJournalsNotExist(TestContext testContext, TestInstance instance, long snapshotId, long journalIndex, long changeNumber) throws Exception {
+        Assert.assertFalse(testContext.chunkStorage.exists(NameUtils.getSystemJournalSnapshotFileName(CONTAINER_ID, instance.epoch, snapshotId)).get());
+        if (testContext.config.isAppendEnabled() && testContext.chunkStorage.supportsAppend()) {
+            Assert.assertFalse(testContext.chunkStorage.exists(NameUtils.getSystemJournalFileName(CONTAINER_ID, instance.epoch, journalIndex)).get());
+        } else {
+            Assert.assertFalse(testContext.chunkStorage.exists(NameUtils.getSystemJournalFileName(CONTAINER_ID, instance.epoch, changeNumber)).get());
+        }
+    }
+
+    @Test
+    public void testWithSnapshotsAndTime() throws Exception {
+        val testContext = new TestContext(CONTAINER_ID);
+        testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .maxJournalUpdatesPerSnapshot(2)
+                .selfCheckEnabled(true)
+                .build());
+
+        val testSegmentName = testContext.segmentNames[0];
+
+        @Cleanup
+        val instance =  new TestInstance(testContext, 1);
+        instance.bootstrap();
+        instance.validate();
+        checkJournalsNotExist(testContext, instance, 1, 1, 1);
+        // Add chunk.
+        instance.append(testSegmentName, "A", 0, 1);
+        checkJournalsExist(testContext, instance, 1, 1, 1);
+        // Add chunk.
+        instance.append(testSegmentName, "B", 1, 2);
+        checkJournalsExist(testContext, instance, 1, 1, 2);
+
+        // Trigger Time and add chunk
+        testContext.addTime(testContext.config.getJournalSnapshotInfoUpdateFrequency().toMillis() + 1);
+        instance.append(testSegmentName, "C", 3, 3);
+        checkJournalsExist(testContext, instance, 2, 2, 3);
+
+        // Add chunk.
+        instance.append(testSegmentName, "D", 6, 4);
+        checkJournalsExist(testContext, instance, 2, 2, 4);
+
+        // Add chunk.
+        instance.append(testSegmentName, "E", 10, 5);
+        checkJournalsExist(testContext, instance, 2, 2, 5);
+
+        // Add chunk.
+        instance.append(testSegmentName, "F", 15, 6);
+        checkJournalsExist(testContext, instance, 3, 3, 6);
+
+        // Bootstrap new instance.
+        @Cleanup
+        val instance2 =  new TestInstance(testContext, 2);
+        instance2.bootstrap();
+        instance2.validate();
+
+        // Validate.
+        TestUtils.checkSegmentBounds(instance2.metadataStore, testSegmentName, 0, 21);
+        TestUtils.checkSegmentLayout(instance2.metadataStore, testSegmentName, new long[] { 1, 2, 3, 4, 5, 6});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance2.metadataStore, testSegmentName);
+        val segmentMetadata = TestUtils.getSegmentMetadata(instance2.metadataStore, testSegmentName);
+        Assert.assertEquals("A", segmentMetadata.getFirstChunk());
+        Assert.assertEquals("F", segmentMetadata.getLastChunk());
+        Assert.assertEquals(0, segmentMetadata.getFirstChunkStartOffset());
+        Assert.assertEquals(15, segmentMetadata.getLastChunkStartOffset());
     }
 
     /**
@@ -1095,7 +1230,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
             super.after();
         }
 
-        protected ChunkStorage getChunkStorage() throws Exception {
+        protected ChunkStorage createChunkStorage() throws Exception {
             val chunkStorage = new InMemoryChunkStorage(executorService());
             chunkStorage.setShouldSupportAppend(false);
             return chunkStorage;

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -592,7 +592,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         } catch (Exception e) {
             val ex = Exceptions.unwrap(e);
             Assert.assertTrue(Exceptions.unwrap(e) instanceof IllegalStateException
-                    && ex.getMessage().contains("File pointed by SnapshotInfo must exist"));
+                    && ex.getMessage().contains("Chunk pointed by SnapshotInfo must exist"));
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Cherry-pick #5964 into r0.9
- Issue 5963: SLTS - writeSnapshotInfo should not block in case of cache throttle. (#5964)

**Purpose of the change**  
Closes #5977

**What the code does**  
Cherry picks following change into r0.9 branch
- Issue 5963: SLTS - writeSnapshotInfo should not block in case of cache throttle. (#5964)

**How to verify it**  
Build should pass.
