### PR TITLE
Issue 5989: SLTS - Log additional information in case of exceptions.

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
@@ -116,9 +116,9 @@ class ConcatOperation implements Callable<CompletableFuture<Void>> {
     }
 
     private Void handleException(Throwable e) {
-        log.debug("{} concat - exception op={}, target={}, source={}, offset={}.",
-                chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), targetHandle.getSegmentName(), sourceSegment, offset);
         val ex = Exceptions.unwrap(e);
+        log.error("{} concat - exception op={}, target={}, source={}, offset={}.",
+                chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), targetHandle.getSegmentName(), sourceSegment, offset, ex);
         if (ex instanceof StorageMetadataWritesFencedOutException) {
             throw new CompletionException(new StorageNotPrimaryException(targetHandle.getSegmentName(), ex));
         }
@@ -140,7 +140,7 @@ class ConcatOperation implements Callable<CompletableFuture<Void>> {
         SLTS_CONCAT_LATENCY.reportSuccessEvent(elapsed);
         SLTS_CONCAT_COUNT.inc();
         if (chunkedSegmentStorage.getConfig().getLateWarningThresholdInMillis() < elapsed.toMillis()) {
-            log.warn("{} concat - late op={}, target={}, source={}, offset={}, latency={}.",
+            log.warn("{} concat - finished late op={}, target={}, source={}, offset={}, latency={}.",
                     chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), targetHandle.getSegmentName(), sourceSegment, offset, elapsed.toMillis());
         } else {
             log.debug("{} concat - finished op={}, target={}, source={}, offset={}, latency={}.",

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ReadOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ReadOperation.java
@@ -111,8 +111,9 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
                                         return readData(txn);
                                     }, chunkedSegmentStorage.getExecutor())
                                     .exceptionally(ex -> {
-                                        log.debug("{} read - exception op={}, segment={}, offset={}, bytesRead={}.",
-                                                chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, totalBytesRead);
+                                        log.error("{} read - exception op={}, segment={}, offset={}, bytesRead={}.",
+                                                chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this),
+                                                handle.getSegmentName(), offset, totalBytesRead, ex);
                                         if (ex instanceof CompletionException) {
                                             throw (CompletionException) ex;
                                         }
@@ -142,7 +143,7 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
         }
 
         if (chunkedSegmentStorage.getConfig().getLateWarningThresholdInMillis() < elapsed.toMillis()) {
-            log.warn("{} read - late op={}, segment={}, offset={}, bytesRead={}, latency={}.",
+            log.warn("{} read - finished late op={}, segment={}, offset={}, bytesRead={}, latency={}.",
                     chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, totalBytesRead, elapsed.toMillis());
         } else {
             log.debug("{} read - finished op={}, segment={}, offset={}, bytesRead={}, latency={}.",

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
@@ -127,7 +127,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
             chunkedSegmentStorage.reportMetricsForSystemSegment(segmentMetadata);
         }
         if (chunkedSegmentStorage.getConfig().getLateWarningThresholdInMillis() < elapsed.toMillis()) {
-            log.warn("{} truncate - late op={}, segment={}, offset={}, latency={}.",
+            log.warn("{} truncate - finished late op={}, segment={}, offset={}, latency={}.",
                     chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, elapsed.toMillis());
         } else {
             log.debug("{} truncate - finished op={}, segment={}, offset={}, latency={}.",
@@ -138,8 +138,8 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
 
     private Void handleException(Void value, Throwable e) {
         if (null != e) {
-            log.debug("{} truncate - exception op={}, segment={}, offset={}.",
-                    chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset);
+            log.error("{} truncate - exception op={}, segment={}, offset={}.",
+                    chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, e);
             val ex = Exceptions.unwrap(e);
             if (ex instanceof StorageMetadataWritesFencedOutException) {
                 throw new CompletionException(new StorageNotPrimaryException(handle.getSegmentName(), ex));

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/WriteOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/WriteOperation.java
@@ -140,8 +140,8 @@ class WriteOperation implements Callable<CompletableFuture<Void>> {
     }
 
     private Object handleException(Throwable e) {
-        log.debug("{} write - exception op={}, segment={}, offset={}, length={}.",
-                chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, length);
+        log.error("{} write - exception op={}, segment={}, offset={}, length={}.",
+                chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, length, e);
         val ex = Exceptions.unwrap(e);
         if (ex instanceof StorageMetadataWritesFencedOutException) {
             throw new CompletionException(new StorageNotPrimaryException(handle.getSegmentName(), ex));
@@ -181,7 +181,7 @@ class WriteOperation implements Callable<CompletableFuture<Void>> {
             SLTS_WRITE_INSTANT_TPUT.reportSuccessValue(bytesPerSecond);
         }
         if (chunkedSegmentStorage.getConfig().getLateWarningThresholdInMillis() < elapsed.toMillis()) {
-            log.warn("{} write - late op={}, segment={}, offset={}, length={}, latency={}.",
+            log.warn("{} write - finished late op={}, segment={}, offset={}, length={}, latency={}.",
                     chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, length, elapsed.toMillis());
         } else {
             log.debug("{} write - finished op={}, segment={}, offset={}, length={}, latency={}.",


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  

- Log additional information about parameters to failed calls to SLTS in case of exceptions.
- Make debug log message uninform in case of late calls. ( `finished late`  instead of just `late` simplifies grep search for successful calls.)

**Purpose of the change**  
Fix #5989 

**What the code does**  
Adds new logs at ERROR or converts existing logs to ERRORs where appropriate.

**How to verify it**  
All tests must pass
