### PR TITLE
Issue5900: Modify Handling of Exceptions in Commit and Abort Transactions.

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -1,12 +1,12 @@
 /**
  * Copyright Pravega Authors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,10 +17,10 @@ package io.pravega.controller.server;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.tables.KeyValueTableConfiguration;
 import io.pravega.client.control.impl.ModelHelper;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.tables.KeyValueTableConfiguration;
 import io.pravega.common.Exceptions;
 import io.pravega.common.Timer;
 import io.pravega.common.cluster.Cluster;
@@ -29,8 +29,8 @@ import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.RetriesExhaustedException;
 import io.pravega.controller.metrics.StreamMetrics;
 import io.pravega.controller.metrics.TransactionMetrics;
-import io.pravega.controller.retryable.RetryableException;
 import io.pravega.controller.store.SegmentRecord;
+import io.pravega.controller.store.kvtable.KVTableMetadataStore;
 import io.pravega.controller.store.stream.BucketStore;
 import io.pravega.controller.store.stream.OperationContext;
 import io.pravega.controller.store.stream.ScaleMetadata;
@@ -39,33 +39,38 @@ import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.controller.store.stream.VersionedTransactionData;
 import io.pravega.controller.store.stream.records.StreamSegmentRecord;
-import io.pravega.controller.store.kvtable.KVTableMetadataStore;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateKeyValueTableStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateScopeStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.CreateStreamStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteKVTableStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteScopeStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteStreamStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.NodeUri;
 import io.pravega.controller.stream.api.grpc.v1.Controller.PingTxnStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfigResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ScaleResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.ScaleStatusResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SegmentId;
 import io.pravega.controller.stream.api.grpc.v1.Controller.SegmentRange;
+import io.pravega.controller.stream.api.grpc.v1.Controller.SubscribersResponse;
 import io.pravega.controller.stream.api.grpc.v1.Controller.TxnState;
 import io.pravega.controller.stream.api.grpc.v1.Controller.TxnStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateStreamStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteKVTableStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateSubscriberStatus;
-import io.pravega.controller.stream.api.grpc.v1.Controller.SubscribersResponse;
-import io.pravega.controller.stream.api.grpc.v1.Controller.CreateReaderGroupResponse;
-import io.pravega.controller.stream.api.grpc.v1.Controller.ReaderGroupConfigResponse;
-import io.pravega.controller.stream.api.grpc.v1.Controller.DeleteReaderGroupStatus;
 import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateReaderGroupResponse;
+import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateStreamStatus;
+import io.pravega.controller.stream.api.grpc.v1.Controller.UpdateSubscriberStatus;
+import io.pravega.controller.task.KeyValueTable.TableMetadataTasks;
 import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
-import io.pravega.controller.task.KeyValueTable.TableMetadataTasks;
 import io.pravega.shared.NameUtils;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -75,13 +80,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
-
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Stream controller RPC server implementation.
@@ -129,16 +128,19 @@ public class ControllerService {
         } catch (IllegalArgumentException | NullPointerException e) {
             log.warn("Create KeyValueTable failed due to invalid name {}", kvtName);
             return CompletableFuture.completedFuture(
-                    CreateKeyValueTableStatus.newBuilder().setStatus(CreateKeyValueTableStatus.Status.INVALID_TABLE_NAME).build());
+                    CreateKeyValueTableStatus.newBuilder().setStatus(
+                            CreateKeyValueTableStatus.Status.INVALID_TABLE_NAME).build());
         }
         return kvtMetadataTasks.createKeyValueTable(scope, kvtName, kvtConfig, createTimestamp)
                 .thenApplyAsync(status -> {
-                    reportCreateKVTableMetrics(scope, kvtName, kvtConfig.getPartitionCount(), status, timer.getElapsed());
+                    reportCreateKVTableMetrics(scope, kvtName, kvtConfig.getPartitionCount(), status,
+                            timer.getElapsed());
                     return CreateKeyValueTableStatus.newBuilder().setStatus(status).build();
                 }, executor);
     }
 
-    public CompletableFuture<List<SegmentRange>> getCurrentSegmentsKeyValueTable(final String scope, final String kvtName) {
+    public CompletableFuture<List<SegmentRange>> getCurrentSegmentsKeyValueTable(final String scope,
+                                                                                 final String kvtName) {
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Exceptions.checkNotNullOrEmpty(kvtName, "KeyValueTable");
 
@@ -155,7 +157,8 @@ public class ControllerService {
      * @param limit limit for number of KeyValueTables to return.
      * @return List of KeyValueTables in scope.
      */
-    public CompletableFuture<Pair<List<String>, String>> listKeyValueTables(final String scope, final String token, final int limit) {
+    public CompletableFuture<Pair<List<String>, String>> listKeyValueTables(final String scope, final String token,
+                                                                            final int limit) {
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         return kvtMetadataStore.listKeyValueTables(scope, token, limit, executor);
     }
@@ -173,8 +176,8 @@ public class ControllerService {
     }
 
     public CompletableFuture<CreateReaderGroupResponse> createReaderGroup(String scope, String rgName,
-                                                                            final ReaderGroupConfig rgConfig,
-                                                                            final long createTimestamp) {
+                                                                          final ReaderGroupConfig rgConfig,
+                                                                          final long createTimestamp) {
         Preconditions.checkNotNull(scope, "ReaderGroup scope is null");
         Preconditions.checkNotNull(rgName, "ReaderGroup name is null");
         Preconditions.checkNotNull(rgConfig, "ReaderGroup config is null");
@@ -185,7 +188,8 @@ public class ControllerService {
         } catch (IllegalArgumentException | NullPointerException e) {
             log.error("Create ReaderGroup failed due to invalid name {}", rgName);
             return CompletableFuture.completedFuture(
-                    CreateReaderGroupResponse.newBuilder().setStatus(CreateReaderGroupResponse.Status.INVALID_RG_NAME).build());
+                    CreateReaderGroupResponse.newBuilder().setStatus(
+                            CreateReaderGroupResponse.Status.INVALID_RG_NAME).build());
         }
         return streamMetadataTasks.createReaderGroup(scope, rgName, rgConfig, createTimestamp)
                 .thenApplyAsync(response -> {
@@ -195,15 +199,15 @@ public class ControllerService {
     }
 
     public CompletableFuture<UpdateReaderGroupResponse> updateReaderGroup(String scope, String rgName,
-                                                                        final ReaderGroupConfig rgConfig) {
+                                                                          final ReaderGroupConfig rgConfig) {
         Preconditions.checkNotNull(scope, "ReaderGroup scope is null");
         Preconditions.checkNotNull(rgName, "ReaderGroup name is null");
         Preconditions.checkNotNull(rgConfig, "ReaderGroup config is null");
         Timer timer = new Timer();
         return streamMetadataTasks.updateReaderGroup(scope, rgName, rgConfig, null)
                 .thenApplyAsync(response -> {
-                            reportUpdateReaderGroupMetrics(scope, rgName, response.getStatus(), timer.getElapsed());
-                            return response;
+                    reportUpdateReaderGroupMetrics(scope, rgName, response.getStatus(), timer.getElapsed());
+                    return response;
                 }, executor);
     }
 
@@ -213,7 +217,8 @@ public class ControllerService {
         return streamMetadataTasks.getReaderGroupConfig(scope, rgName, null);
     }
 
-    public CompletableFuture<DeleteReaderGroupStatus> deleteReaderGroup(String scope, String rgName, String readerGroupId) {
+    public CompletableFuture<DeleteReaderGroupStatus> deleteReaderGroup(String scope, String rgName,
+                                                                        String readerGroupId) {
         Preconditions.checkNotNull(scope, "ReaderGroup scope is null");
         Preconditions.checkNotNull(rgName, "ReaderGroup name is null");
         Preconditions.checkNotNull(readerGroupId, "ReaderGroup Id is null");
@@ -243,15 +248,17 @@ public class ControllerService {
         Preconditions.checkNotNull(readerGroupId, "readerGroupId is null");
         Preconditions.checkNotNull(truncationStreamCut, "Truncation StreamCut is null");
         Timer timer = new Timer();
-        return streamMetadataTasks.updateSubscriberStreamCut(scope, stream, subscriber, readerGroupId, generation, truncationStreamCut, null)
-                            .thenApplyAsync(status -> {
-                                reportUpdateTruncationSCMetrics(scope, stream, status, timer.getElapsed());
-                                return UpdateSubscriberStatus.newBuilder().setStatus(status).build();
-                            }, executor);
+        return streamMetadataTasks.updateSubscriberStreamCut(scope, stream, subscriber, readerGroupId, generation,
+                truncationStreamCut, null)
+                .thenApplyAsync(status -> {
+                    reportUpdateTruncationSCMetrics(scope, stream, status, timer.getElapsed());
+                    return UpdateSubscriberStatus.newBuilder().setStatus(status).build();
+                }, executor);
     }
 
-    public CompletableFuture<CreateStreamStatus> createStream(String scope, String stream, final StreamConfiguration streamConfig,
-            final long createTimestamp) {
+    public CompletableFuture<CreateStreamStatus> createStream(String scope, String stream,
+                                                              final StreamConfiguration streamConfig,
+                                                              final long createTimestamp) {
         Preconditions.checkNotNull(streamConfig, "streamConfig");
         Preconditions.checkArgument(createTimestamp >= 0);
         Timer timer = new Timer();
@@ -265,31 +272,34 @@ public class ControllerService {
 
         return Futures.exceptionallyExpecting(streamStore.getState(scope, stream, true, null, executor),
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException, State.UNKNOWN)
-                      .thenCompose(state -> {
-                          if (state.equals(State.UNKNOWN) || state.equals(State.CREATING)) {
-                              return streamMetadataTasks.createStreamRetryOnLockFailure(scope,
-                                      stream,
-                                      streamConfig,
-                                      createTimestamp, 10).thenApplyAsync(status -> {
-                                  reportCreateStreamMetrics(scope, stream, streamConfig.getScalingPolicy().getMinNumSegments(), status,
-                                          timer.getElapsed());
-                                  return CreateStreamStatus.newBuilder().setStatus(status).build();
-                              }, executor);
-                          } else {
-                              return CompletableFuture.completedFuture(
-                                      CreateStreamStatus.newBuilder().setStatus(CreateStreamStatus.Status.STREAM_EXISTS).build());
-                          }
-                      });
+                .thenCompose(state -> {
+                    if (state.equals(State.UNKNOWN) || state.equals(State.CREATING)) {
+                        return streamMetadataTasks.createStreamRetryOnLockFailure(scope,
+                                stream,
+                                streamConfig,
+                                createTimestamp, 10).thenApplyAsync(status -> {
+                            reportCreateStreamMetrics(scope, stream,
+                                    streamConfig.getScalingPolicy().getMinNumSegments(), status,
+                                    timer.getElapsed());
+                            return CreateStreamStatus.newBuilder().setStatus(status).build();
+                        }, executor);
+                    } else {
+                        return CompletableFuture.completedFuture(
+                                CreateStreamStatus.newBuilder().setStatus(
+                                        CreateStreamStatus.Status.STREAM_EXISTS).build());
+                    }
+                });
     }
 
-    public CompletableFuture<UpdateStreamStatus> updateStream(String scope, String stream, final StreamConfiguration streamConfig) {
+    public CompletableFuture<UpdateStreamStatus> updateStream(String scope, String stream,
+                                                              final StreamConfiguration streamConfig) {
         Preconditions.checkNotNull(streamConfig, "streamConfig");
         Timer timer = new Timer();
         return streamMetadataTasks.updateStream(scope, stream, streamConfig, null)
-                  .thenApplyAsync(status -> {
-                      reportUpdateStreamMetrics(scope, stream, status, timer.getElapsed());
-                      return UpdateStreamStatus.newBuilder().setStatus(status).build();
-                  }, executor);
+                .thenApplyAsync(status -> {
+                    reportUpdateStreamMetrics(scope, stream, status, timer.getElapsed());
+                    return UpdateStreamStatus.newBuilder().setStatus(status).build();
+                }, executor);
     }
 
     public CompletableFuture<UpdateStreamStatus> truncateStream(final String scope, final String stream,
@@ -346,7 +356,7 @@ public class ControllerService {
         Exceptions.checkArgument(epoch >= 0, "epoch", "Epoch cannot be less than 0");
         OperationContext context = streamStore.createContext(scope, stream);
         return streamStore.getEpoch(scope, stream, epoch, context, executor)
-                          .thenApplyAsync(epochRecord -> getSegmentRanges(epochRecord.getSegments(), scope, stream), executor);
+                .thenApplyAsync(epochRecord -> getSegmentRanges(epochRecord.getSegments(), scope, stream), executor);
     }
 
     public CompletableFuture<Map<SegmentId, Long>> getSegmentsAtHead(final String scope, final String stream) {
@@ -357,8 +367,9 @@ public class ControllerService {
         // Divide current segments in segmentFutures into at most count positions.
         return streamStore.getSegmentsAtHead(scope, stream, null, executor).thenApply(segments -> {
             return segments.entrySet().stream()
-                           .collect(Collectors.toMap(entry -> ModelHelper.createSegmentId(scope, stream, entry.getKey().segmentId()),
-                                   Map.Entry::getValue));
+                    .collect(Collectors.toMap(
+                            entry -> ModelHelper.createSegmentId(scope, stream, entry.getKey().segmentId()),
+                            Map.Entry::getValue));
         });
     }
 
@@ -374,9 +385,9 @@ public class ControllerService {
                 .thenApply(successors -> successors.entrySet().stream()
                         .collect(Collectors.toMap(
                                 entry -> ModelHelper.createSegmentRange(segment.getStreamInfo().getScope(),
-                                                segment.getStreamInfo().getStream(), entry.getKey().segmentId(),
-                                                entry.getKey().getKeyStart(),
-                                                entry.getKey().getKeyEnd()),
+                                        segment.getStreamInfo().getStream(), entry.getKey().segmentId(),
+                                        entry.getKey().getKeyStart(),
+                                        entry.getKey().getKeyEnd()),
                                 Map.Entry::getValue)));
     }
 
@@ -406,11 +417,11 @@ public class ControllerService {
         Preconditions.checkNotNull(newKeyRanges, "newKeyRanges");
 
         return streamMetadataTasks.manualScale(scope,
-                                         stream,
-                                         segmentsToSeal,
-                                         new ArrayList<>(ModelHelper.encode(newKeyRanges)),
-                                         scaleTimestamp,
-                                         null);
+                stream,
+                segmentsToSeal,
+                new ArrayList<>(ModelHelper.encode(newKeyRanges)),
+                scaleTimestamp,
+                null);
     }
 
     public CompletableFuture<ScaleStatusResponse> checkScale(final String scope, final String stream, final int epoch) {
@@ -421,7 +432,8 @@ public class ControllerService {
         return streamMetadataTasks.checkScale(scope, stream, epoch, null);
     }
 
-    public CompletableFuture<List<ScaleMetadata>> getScaleRecords(final String scope, final String stream, final long from, final long to) {
+    public CompletableFuture<List<ScaleMetadata>> getScaleRecords(final String scope, final String stream,
+                                                                  final long from, final long to) {
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Exceptions.checkNotNullOrEmpty(stream, "stream");
         return streamStore.getScaleMetadata(scope, stream, from, to, null, executor);
@@ -456,8 +468,8 @@ public class ControllerService {
     }
 
     public CompletableFuture<Boolean> isStreamCutValid(final String scope,
-                                                     final String stream,
-                                                     final Map<Long, Long> streamCut) {
+                                                       final String stream,
+                                                       final Map<Long, Long> streamCut) {
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Exceptions.checkNotNullOrEmpty(stream, "stream");
         return streamStore.isStreamCutValid(scope, stream, streamCut, null, executor);
@@ -484,7 +496,8 @@ public class ControllerService {
                 });
     }
 
-    private List<SegmentRange> getSegmentRanges(List<? extends SegmentRecord> activeSegments, String scope, String stream) {
+    private List<SegmentRange> getSegmentRanges(List<? extends SegmentRecord> activeSegments, String scope,
+                                                String stream) {
         List<SegmentRange> listOfSegment = activeSegments
                 .stream()
                 .map(segment -> convert(scope, stream, segment))
@@ -505,14 +518,14 @@ public class ControllerService {
                         log.error("Transaction commit failed for txn {} on stream {}. Cause: {}", txId.toString(),
                                 NameUtils.getScopedStreamName(scope, stream), ex);
                         Throwable unwrap = getRealException(ex);
-                        if (unwrap instanceof RetryableException) {
+                        if (unwrap instanceof StoreException.DataNotFoundException || unwrap instanceof StoreException.IllegalStateException || unwrap instanceof StoreException.UnknownException) {
                             // if its a retryable exception (it could be either write conflict or store exception)
                             // let it be thrown and translated to appropriate error code so that the client
                             // retries upon failure.
-                            throw new CompletionException(unwrap);
+                            TransactionMetrics.getInstance().commitTransactionFailed(scope, stream, txId.toString());
+                            return TxnStatus.newBuilder().setStatus(TxnStatus.Status.FAILURE).build();
                         }
-                        TransactionMetrics.getInstance().commitTransactionFailed(scope, stream, txId.toString());
-                        return TxnStatus.newBuilder().setStatus(TxnStatus.Status.FAILURE).build();
+                        throw new CompletionException(unwrap);
                     } else {
                         TransactionMetrics.getInstance().committingTransaction(timer.getElapsed());
                         return TxnStatus.newBuilder().setStatus(TxnStatus.Status.SUCCESS).build();
@@ -539,14 +552,14 @@ public class ControllerService {
                         log.error("Transaction abort failed for txn {} on Stream {}", txId.toString(),
                                 NameUtils.getScopedStreamName(scope, stream), ex);
                         Throwable unwrap = getRealException(ex);
-                        if (unwrap instanceof RetryableException) {
+                        if (unwrap instanceof StoreException.DataNotFoundException || unwrap instanceof StoreException.IllegalStateException || unwrap instanceof StoreException.UnknownException) {
                             // if its a retryable exception (it could be either write conflict or store exception)
                             // let it be thrown and translated to appropriate error code so that the client
                             // retries upon failure.
-                            throw new CompletionException(unwrap);
+                            TransactionMetrics.getInstance().abortTransactionFailed(scope, stream, txId.toString());
+                            return TxnStatus.newBuilder().setStatus(TxnStatus.Status.FAILURE).build();
                         }
-                        TransactionMetrics.getInstance().abortTransactionFailed(scope, stream, txId.toString());
-                        return TxnStatus.newBuilder().setStatus(TxnStatus.Status.FAILURE).build();
+                        throw new CompletionException(unwrap);
                     } else {
                         TransactionMetrics.getInstance().abortingTransaction(timer.getElapsed());
                         return TxnStatus.newBuilder().setStatus(TxnStatus.Status.SUCCESS).build();
@@ -566,12 +579,13 @@ public class ControllerService {
     }
 
     public CompletableFuture<TxnState> checkTransactionStatus(final String scope, final String stream,
-            final UUID txnId) {
+                                                              final UUID txnId) {
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         Exceptions.checkNotNullOrEmpty(stream, "stream");
         Preconditions.checkNotNull(txnId, "txnId");
         return streamStore.transactionStatus(scope, stream, txnId, null, executor)
-                .thenApplyAsync(res -> TxnState.newBuilder().setState(TxnState.State.valueOf(res.name())).build(), executor);
+                .thenApplyAsync(res -> TxnState.newBuilder().setState(TxnState.State.valueOf(res.name())).build(),
+                        executor);
     }
 
     /**
@@ -624,7 +638,8 @@ public class ControllerService {
      * @param limit limit for number of streams to return.
      * @return List of streams in scope.
      */
-    public CompletableFuture<Pair<List<String>, String>> listStreams(final String scope, final String token, final int limit) {
+    public CompletableFuture<Pair<List<String>, String>> listStreams(final String scope, final String token,
+                                                                     final int limit) {
         Exceptions.checkNotNullOrEmpty(scope, "scope");
         return streamStore.listStream(scope, token, limit, executor);
     }
@@ -661,8 +676,9 @@ public class ControllerService {
     }
 
     // Metrics reporting region
-    private void reportCreateKVTableMetrics(String scope, String kvtName, int initialSegments, CreateKeyValueTableStatus.Status status,
-                                           Duration latency) {
+    private void reportCreateKVTableMetrics(String scope, String kvtName, int initialSegments,
+                                            CreateKeyValueTableStatus.Status status,
+                                            Duration latency) {
         if (status.equals(CreateKeyValueTableStatus.Status.SUCCESS)) {
             StreamMetrics.getInstance().createKeyValueTable(scope, kvtName, initialSegments, latency);
         } else if (status.equals(CreateKeyValueTableStatus.Status.FAILURE)) {
@@ -670,7 +686,8 @@ public class ControllerService {
         }
     }
 
-    private void reportDeleteKVTableMetrics(String scope, String kvtName, DeleteKVTableStatus.Status status, Duration latency) {
+    private void reportDeleteKVTableMetrics(String scope, String kvtName, DeleteKVTableStatus.Status status,
+                                            Duration latency) {
         if (status.equals(DeleteKVTableStatus.Status.SUCCESS)) {
             StreamMetrics.getInstance().deleteKeyValueTable(scope, kvtName, latency);
         } else if (status.equals(DeleteKVTableStatus.Status.FAILURE)) {
@@ -678,7 +695,8 @@ public class ControllerService {
         }
     }
 
-    private void reportCreateStreamMetrics(String scope, String streamName, int initialSegments, CreateStreamStatus.Status status,
+    private void reportCreateStreamMetrics(String scope, String streamName, int initialSegments,
+                                           CreateStreamStatus.Status status,
                                            Duration latency) {
         if (status.equals(CreateStreamStatus.Status.SUCCESS)) {
             StreamMetrics.getInstance().createStream(scope, streamName, initialSegments, latency);
@@ -696,7 +714,8 @@ public class ControllerService {
         return status;
     }
 
-    private void reportUpdateStreamMetrics(String scope, String streamName, UpdateStreamStatus.Status status, Duration latency) {
+    private void reportUpdateStreamMetrics(String scope, String streamName, UpdateStreamStatus.Status status,
+                                           Duration latency) {
         if (status.equals(UpdateStreamStatus.Status.SUCCESS)) {
             StreamMetrics.getInstance().updateStream(scope, streamName, latency);
         } else if (status.equals(UpdateStreamStatus.Status.FAILURE)) {
@@ -704,7 +723,8 @@ public class ControllerService {
         }
     }
 
-    private void reportCreateReaderGroupMetrics(String scope, String rgName, CreateReaderGroupResponse.Status status, Duration latency) {
+    private void reportCreateReaderGroupMetrics(String scope, String rgName, CreateReaderGroupResponse.Status status,
+                                                Duration latency) {
         if (status.equals(CreateReaderGroupResponse.Status.SUCCESS)) {
             StreamMetrics.getInstance().createReaderGroup(scope, rgName, latency);
         } else if (status.equals(CreateReaderGroupResponse.Status.FAILURE)) {
@@ -712,7 +732,8 @@ public class ControllerService {
         }
     }
 
-    private void reportUpdateReaderGroupMetrics(String scope, String streamName, UpdateReaderGroupResponse.Status status, Duration latency) {
+    private void reportUpdateReaderGroupMetrics(String scope, String streamName,
+                                                UpdateReaderGroupResponse.Status status, Duration latency) {
         if (status.equals(UpdateReaderGroupResponse.Status.SUCCESS)) {
             StreamMetrics.getInstance().updateReaderGroup(scope, streamName, latency);
         } else if (status.equals(UpdateReaderGroupResponse.Status.FAILURE)) {
@@ -720,7 +741,8 @@ public class ControllerService {
         }
     }
 
-    private void reportDeleteReaderGroupMetrics(String scope, String streamName, DeleteReaderGroupStatus.Status status, Duration latency) {
+    private void reportDeleteReaderGroupMetrics(String scope, String streamName, DeleteReaderGroupStatus.Status status,
+                                                Duration latency) {
         if (status.equals(DeleteReaderGroupStatus.Status.SUCCESS)) {
             StreamMetrics.getInstance().deleteReaderGroup(scope, streamName, latency);
         } else if (status.equals(DeleteReaderGroupStatus.Status.FAILURE)) {
@@ -728,7 +750,8 @@ public class ControllerService {
         }
     }
 
-    private void reportUpdateTruncationSCMetrics(String scope, String streamName, UpdateSubscriberStatus.Status status, Duration latency) {
+    private void reportUpdateTruncationSCMetrics(String scope, String streamName, UpdateSubscriberStatus.Status status,
+                                                 Duration latency) {
         if (status.equals(UpdateSubscriberStatus.Status.SUCCESS)) {
             StreamMetrics.getInstance().updateTruncationSC(scope, streamName, latency);
         } else if (status.equals(UpdateSubscriberStatus.Status.FAILURE)) {
@@ -736,7 +759,8 @@ public class ControllerService {
         }
     }
 
-    private void reportTruncateStreamMetrics(String scope, String streamName, UpdateStreamStatus.Status status, Duration latency) {
+    private void reportTruncateStreamMetrics(String scope, String streamName, UpdateStreamStatus.Status status,
+                                             Duration latency) {
         if (status.equals(UpdateStreamStatus.Status.SUCCESS)) {
             StreamMetrics.getInstance().truncateStream(scope, streamName, latency);
         } else if (status.equals(UpdateStreamStatus.Status.FAILURE)) {
@@ -744,7 +768,8 @@ public class ControllerService {
         }
     }
 
-    private void reportSealStreamMetrics(String scope, String streamName, UpdateStreamStatus.Status status, Duration latency) {
+    private void reportSealStreamMetrics(String scope, String streamName, UpdateStreamStatus.Status status,
+                                         Duration latency) {
         if (status.equals(UpdateStreamStatus.Status.SUCCESS)) {
             StreamMetrics.getInstance().sealStream(scope, streamName, latency);
         } else if (status.equals(UpdateStreamStatus.Status.FAILURE)) {
@@ -752,7 +777,8 @@ public class ControllerService {
         }
     }
 
-    private void reportDeleteStreamMetrics(String scope, String streamName, DeleteStreamStatus.Status status, Duration latency) {
+    private void reportDeleteStreamMetrics(String scope, String streamName, DeleteStreamStatus.Status status,
+                                           Duration latency) {
         if (status.equals(DeleteStreamStatus.Status.SUCCESS)) {
             StreamMetrics.getInstance().deleteStream(scope, streamName, latency);
         } else if (status.equals(DeleteStreamStatus.Status.FAILURE)) {
@@ -769,26 +795,29 @@ public class ControllerService {
         return status;
     }
 
-    public CompletableFuture<Controller.TimestampResponse> noteTimestampFromWriter(String scope, String stream, String writerId, long timestamp, Map<Long, Long> streamCut) {
+    public CompletableFuture<Controller.TimestampResponse> noteTimestampFromWriter(String scope, String stream,
+                                                                                   String writerId, long timestamp,
+                                                                                   Map<Long, Long> streamCut) {
         return bucketStore.addStreamToBucketStore(BucketStore.ServiceType.WatermarkingService, scope, stream, executor)
-                          .thenCompose(v -> streamStore.noteWriterMark(scope, stream, writerId, timestamp, streamCut, null, executor))
+                .thenCompose(
+                        v -> streamStore.noteWriterMark(scope, stream, writerId, timestamp, streamCut, null, executor))
                 .thenApply(r -> {
-                        Controller.TimestampResponse.Builder response = Controller.TimestampResponse.newBuilder();
-                        switch (r) {
-                            case SUCCESS:
-                                response.setResult(Controller.TimestampResponse.Status.SUCCESS);
-                                break;
-                            case INVALID_TIME:
-                                response.setResult(Controller.TimestampResponse.Status.INVALID_TIME);
-                                break;
-                            case INVALID_POSITION:
-                                response.setResult(Controller.TimestampResponse.Status.INVALID_POSITION);
-                                break;
-                            default:
-                                response.setResult(Controller.TimestampResponse.Status.INTERNAL_ERROR);
-                                break;
-                        }
-                        return response.build();
+                    Controller.TimestampResponse.Builder response = Controller.TimestampResponse.newBuilder();
+                    switch (r) {
+                        case SUCCESS:
+                            response.setResult(Controller.TimestampResponse.Status.SUCCESS);
+                            break;
+                        case INVALID_TIME:
+                            response.setResult(Controller.TimestampResponse.Status.INVALID_TIME);
+                            break;
+                        case INVALID_POSITION:
+                            response.setResult(Controller.TimestampResponse.Status.INVALID_POSITION);
+                            break;
+                        default:
+                            response.setResult(Controller.TimestampResponse.Status.INTERNAL_ERROR);
+                            break;
+                    }
+                    return response.build();
                 });
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -504,10 +504,7 @@ public class ControllerService {
                         log.error("Transaction commit failed for txn {} on stream {}. Cause: {}", txId.toString(),
                                 NameUtils.getScopedStreamName(scope, stream), ex);
                         Throwable unwrap = getRealException(ex);
-                        if (unwrap instanceof StoreException.DataNotFoundException || unwrap instanceof StoreException.IllegalStateException || unwrap instanceof StoreException.UnknownException) {
-                            // if its a retryable exception (it could be either write conflict or store exception)
-                            // let it be thrown and translated to appropriate error code so that the client
-                            // retries upon failure.
+                        if (unwrap instanceof StoreException.DataNotFoundException || unwrap instanceof StoreException.IllegalStateException) {
                             TransactionMetrics.getInstance().commitTransactionFailed(scope, stream, txId.toString());
                             return TxnStatus.newBuilder().setStatus(TxnStatus.Status.FAILURE).build();
                         }
@@ -538,10 +535,7 @@ public class ControllerService {
                         log.error("Transaction abort failed for txn {} on Stream {}", txId.toString(),
                                 NameUtils.getScopedStreamName(scope, stream), ex);
                         Throwable unwrap = getRealException(ex);
-                        if (unwrap instanceof StoreException.DataNotFoundException || unwrap instanceof StoreException.IllegalStateException || unwrap instanceof StoreException.UnknownException) {
-                            // if its a retryable exception (it could be either write conflict or store exception)
-                            // let it be thrown and translated to appropriate error code so that the client
-                            // retries upon failure.
+                        if (unwrap instanceof StoreException.DataNotFoundException || unwrap instanceof StoreException.IllegalStateException) {
                             TransactionMetrics.getInstance().abortTransactionFailed(scope, stream, txId.toString());
                             return TxnStatus.newBuilder().setStatus(TxnStatus.Status.FAILURE).build();
                         }

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
@@ -257,17 +257,19 @@ public class ControllerServiceTest {
                 .when(streamStore).sealTransaction(eq(SCOPE), eq(stream1), eq(txnId), anyBoolean(), any(), anyString(), anyLong(),
                 any(), any());
 
-        Controller.TxnStatus status = consumer.commitTransaction(SCOPE, stream1, txnId, "", 0L).join();
-        assertEquals(status.getStatus(), Controller.TxnStatus.Status.FAILURE);
+        AssertExtensions.assertFutureThrows("Unknown exception should have been thrown",
+                consumer.commitTransaction(SCOPE, stream1, txnId, "", 0L),
+                e -> Exceptions.unwrap(e) instanceof StoreException.UnknownException);
 
-        status = consumer.abortTransaction(SCOPE, stream1, txnId).join();
-        assertEquals(status.getStatus(), Controller.TxnStatus.Status.FAILURE);
+        AssertExtensions.assertFutureThrows("Unknown exception should have been thrown",
+                consumer.abortTransaction(SCOPE, stream1, txnId),
+                e -> Exceptions.unwrap(e) instanceof StoreException.UnknownException);
 
         doThrow(StoreException.create(StoreException.Type.DATA_NOT_FOUND, "Data Not Found"))
                 .when(streamStore).sealTransaction(eq(SCOPE), eq(stream1), eq(txnId), anyBoolean(), any(), anyString(), anyLong(),
                 any(), any());
 
-        status = consumer.commitTransaction(SCOPE, stream1, txnId, "", 0L).join();
+        Controller.TxnStatus status = consumer.commitTransaction(SCOPE, stream1, txnId, "", 0L).join();
         assertEquals(status.getStatus(), Controller.TxnStatus.Status.FAILURE);
 
         status = consumer.abortTransaction(SCOPE, stream1, txnId).join();

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
@@ -262,6 +262,26 @@ public class ControllerServiceTest {
 
         status = consumer.abortTransaction(SCOPE, stream1, txnId).join();
         assertEquals(status.getStatus(), Controller.TxnStatus.Status.FAILURE);
+
+        doThrow(StoreException.create(StoreException.Type.DATA_NOT_FOUND, "Data Not Found"))
+                .when(streamStore).sealTransaction(eq(SCOPE), eq(stream1), eq(txnId), anyBoolean(), any(), anyString(), anyLong(),
+                any(), any());
+
+        status = consumer.commitTransaction(SCOPE, stream1, txnId, "", 0L).join();
+        assertEquals(status.getStatus(), Controller.TxnStatus.Status.FAILURE);
+
+        status = consumer.abortTransaction(SCOPE, stream1, txnId).join();
+        assertEquals(status.getStatus(), Controller.TxnStatus.Status.FAILURE);
+
+        doThrow(StoreException.create(StoreException.Type.ILLEGAL_STATE, "Data Not Found"))
+                .when(streamStore).sealTransaction(eq(SCOPE), eq(stream1), eq(txnId), anyBoolean(), any(), anyString(), anyLong(),
+                any(), any());
+
+        status = consumer.commitTransaction(SCOPE, stream1, txnId, "", 0L).join();
+        assertEquals(status.getStatus(), Controller.TxnStatus.Status.FAILURE);
+
+        status = consumer.abortTransaction(SCOPE, stream1, txnId).join();
+        assertEquals(status.getStatus(), Controller.TxnStatus.Status.FAILURE);
         reset(streamStore);
     }
     


### PR DESCRIPTION
**Change log description**  
Exception handling for commit and abort transaction is changed.  Only specific errors are thrown and the default way of handling exceptions is to fail the transaction so that the client can get retry.

**Purpose of the change**  
Fixes #5900 

**What the code does**  
For exceptions encountered during commit and abort transaction, they are checked against DataNotFound , IllegalState and  UnknownExceptions. For these the exception is thrown. For all other exceptions,  the transaction is failed for the client to retry.

**How to verify it**  
Build Pravega. Run the unit tests. Directly relevant ones are server/ControllerServiceTest.java and v1/ControllerServerTest.java.
