### PR TITLE
Issue 5994: (SegmentStore) Auto-deleting LTS segments if marked as deleted in metadata

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -255,6 +255,26 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
         assert this.handle.get() == null : "non-null handle but state == " + this.state.get();
         long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "initialize");
 
+        if (this.metadata.isDeleted()) {
+            // Segment is dead on arrival. Delete it from Storage (if it exists) and do not bother to do anything else with it).
+            // This is a rather uncommon case, but it can happen in one of two cases: 1) the segment has been deleted
+            // immediately after creation or 2) after a container recovery.
+            log.info("{}: Segment '{}' is marked as Deleted in Metadata. Attempting Storage delete.",
+                    this.traceObjectId, this.metadata.getName());
+            return Futures.exceptionallyExpecting(
+                    this.storage.openWrite(this.metadata.getName())
+                            .thenComposeAsync(handle -> this.storage.delete(handle, timeout), this.executor),
+                    ex -> ex instanceof StreamSegmentNotExistsException, null) // It's OK if already deleted.
+                    .thenRun(() -> {
+                        updateMetadataPostDeletion(this.metadata);
+                        log.info("{}: Segment '{}' is marked as Deleted in Metadata and has been deleted from Storage. Ignoring all further operations on it.",
+                                this.traceObjectId, this.metadata.getName());
+                        setState(AggregatorState.Writing);
+                        LoggerHelpers.traceLeave(log, this.traceObjectId, "initialize", traceId);
+                    });
+        }
+
+        // Segment not deleted.
         return openWrite(this.metadata.getName(), this.handle, timeout)
                 .thenAcceptAsync(segmentInfo -> {
                     // Check & Update StorageLength in metadata.


### PR DESCRIPTION
**Change log description**  
If SegmentMetadata.isDeleted() returns true while SegmentAggregator.initialize() is called, then the segment is deleted from LTS and the SegmentAggregator should ignore any further operations on it.

**Purpose of the change**  
Fixes #5994.

**What the code does**  
See description.

**How to verify it**  
Existing unit tests already covered this partially. New unit tests added to verify this explicitly.
