### PR TITLE
Issue 5996: Cherry-pick #5994 to r0.9

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/SegmentAggregator.java
@@ -249,6 +249,26 @@ class SegmentAggregator implements WriterSegmentProcessor, AutoCloseable {
         assert this.handle.get() == null : "non-null handle but state == " + this.state.get();
         long traceId = LoggerHelpers.traceEnterWithContext(log, this.traceObjectId, "initialize");
 
+        if (this.metadata.isDeleted()) {
+            // Segment is dead on arrival. Delete it from Storage (if it exists) and do not bother to do anything else with it).
+            // This is a rather uncommon case, but it can happen in one of two cases: 1) the segment has been deleted
+            // immediately after creation or 2) after a container recovery.
+            log.info("{}: Segment '{}' is marked as Deleted in Metadata. Attempting Storage delete.",
+                    this.traceObjectId, this.metadata.getName());
+            return Futures.exceptionallyExpecting(
+                    this.storage.openWrite(this.metadata.getName())
+                            .thenComposeAsync(handle -> this.storage.delete(handle, timeout), this.executor),
+                    ex -> ex instanceof StreamSegmentNotExistsException, null) // It's OK if already deleted.
+                    .thenRun(() -> {
+                        updateMetadataPostDeletion(this.metadata);
+                        log.info("{}: Segment '{}' is marked as Deleted in Metadata and has been deleted from Storage. Ignoring all further operations on it.",
+                                this.traceObjectId, this.metadata.getName());
+                        setState(AggregatorState.Writing);
+                        LoggerHelpers.traceLeave(log, this.traceObjectId, "initialize", traceId);
+                    });
+        }
+
+        // Segment not deleted.
         return openWrite(this.metadata.getName(), this.handle, timeout)
                 .thenAcceptAsync(segmentInfo -> {
                     // Check & Update StorageLength in metadata.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/SegmentAggregatorTests.java
@@ -110,7 +110,7 @@ public class SegmentAggregatorTests extends ThreadPooledTestSuite {
      * Tests the initialize() method.
      */
     @Test
-    public void testInitialize() {
+    public void testInitialize() throws Exception {
         @Cleanup
         TestContext context = new TestContext(DEFAULT_CONFIG);
 
@@ -125,6 +125,28 @@ public class SegmentAggregatorTests extends ThreadPooledTestSuite {
         context.transactionAggregators[3].initialize(TIMEOUT).join();
         Assert.assertTrue("isDeleted() flag not set on metadata for deleted segment.", sm3.isDeleted());
         Assert.assertTrue("isDeletedInStorage() flag not set on metadata for deleted segment.", sm3.isDeletedInStorage());
+
+        // Check behavior for already-deleted segments (in Metadata) that are also deleted from Storage.
+        val sm4  = (UpdateableSegmentMetadata) context.transactionAggregators[4].getMetadata();
+        sm4.markDeleted(); // We do not mark it as deleted in Storage.
+        val ag4 = context.transactionAggregators[4];
+        ag4.initialize(TIMEOUT).join();
+        Assert.assertTrue("Expected SegmentMetadata.isDeletedInStorage to be set to true post init.", sm4.isDeletedInStorage());
+        sm4.markSealed();
+        ag4.add(generateSealAndUpdateMetadata(sm4.getId(), context));
+        Assert.assertFalse("SegmentAggregator should have ignored new operation for deleted segment.", ag4.mustFlush());
+
+        // Check behavior for already-deleted segments (in Metadata) that are still present in Storage.
+        val sm5  = (UpdateableSegmentMetadata) context.transactionAggregators[5].getMetadata();
+        context.storage.create(sm5.getName(), TIMEOUT).join();
+        sm5.markDeleted(); // We do not mark it as deleted in Storage.
+        val ag5 = context.transactionAggregators[5];
+        ag5.initialize(TIMEOUT).join();
+        Assert.assertTrue("Expected SegmentMetadata.isDeletedInStorage to be set to true post init.", sm5.isDeletedInStorage());
+        Assert.assertFalse("Expected Segment to have been deleted from Storage.", context.storage.exists(sm5.getName(), TIMEOUT).join());
+        sm5.markSealed();
+        ag5.add(generateSealAndUpdateMetadata(sm5.getId(), context));
+        Assert.assertFalse("SegmentAggregator should have ignored new operation for deleted segment.", ag5.mustFlush());
 
         // Check behavior for already-sealed segments (in storage, but not in metadata)
         context.storage.create(context.transactionAggregators[1].getMetadata().getName(), TIMEOUT).join();


### PR DESCRIPTION
**Change log description**  
Issue 5996: Cherry-pick #5994 to r0.9
- Issue 5994: (SegmentStore) Auto-deleting LTS segments if marked as deleted in metadata 

**Purpose of the change**  
Fixes #5996.

**What the code does**  
Cherry-pick.

**How to verify it**  
Cherry-pick.
