### PR TITLE
Issue 5999: (SegmentStore) Increasing priority of WriterTableProcessor indexer operations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,6 +15,7 @@
 #
 codecov:
   require_ci_to_pass: yes
+  max_report_age: off
   notify:
     wait_for_ci: yes
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainer.java
@@ -96,8 +96,8 @@ public interface SegmentContainer extends StreamSegmentStore, Container {
      * @param streamSegmentName The name of the Segment to get for.
      * @param desiredPriority   The desired {@link OperationPriority}. If null, the priority will be calculated in
      *                          accordance with the rules defined internally in the Segment Container. Note that even if
-     *                          provided, the Segment Container may choose to not alter this priority if the type of
-     *                          operation or Segment Type demands a higher priority.
+     *                          provided, the Segment Container may choose a higher priority (but not lower) if the Segment
+     *                          Type or Operation Type demand a higher one.
      * @param timeout           Timeout for the operation.
      * @return A CompletableFuture that, when completed normally, will contain the desired result. If the operation
      * failed, the future will be failed with the causing exception.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainer.java
@@ -20,9 +20,11 @@ import com.google.common.annotations.VisibleForTesting;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.server.logs.MetadataUpdateException;
+import io.pravega.segmentstore.server.logs.operations.OperationPriority;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 
 /**
  * Defines a Container for StreamSegments.
@@ -79,7 +81,29 @@ public interface SegmentContainer extends StreamSegmentStore, Container {
      * @return A CompletableFuture that, when completed normally, will contain the desired result. If the operation
      * failed, the future will be failed with the causing exception.
      */
-    CompletableFuture<DirectSegmentAccess> forSegment(String streamSegmentName, Duration timeout);
+    default CompletableFuture<DirectSegmentAccess> forSegment(String streamSegmentName, Duration timeout) {
+        return forSegment(streamSegmentName, null, timeout);
+    }
+
+    /**
+     * See {@link #forSegment(String, Duration)}.
+     *
+     * The difference from that one is that this one creates a {@link DirectSegmentAccess} where all modify operations
+     * ({@link DirectSegmentAccess#append}, {@link DirectSegmentAccess#updateAttributes}, {@link DirectSegmentAccess#seal}
+     * and {@link DirectSegmentAccess#truncate}} will be attempted with the requested {@code desiredPriority} instead
+     * of the default one.
+     *
+     * @param streamSegmentName The name of the Segment to get for.
+     * @param desiredPriority   The desired {@link OperationPriority}. If null, the priority will be calculated in
+     *                          accordance with the rules defined internally in the Segment Container. Note that even if
+     *                          provided, the Segment Container may choose to not alter this priority if the type of
+     *                          operation or Segment Type demands a higher priority.
+     * @param timeout           Timeout for the operation.
+     * @return A CompletableFuture that, when completed normally, will contain the desired result. If the operation
+     * failed, the future will be failed with the causing exception.
+     */
+    CompletableFuture<DirectSegmentAccess> forSegment(String streamSegmentName, @Nullable OperationPriority desiredPriority,
+                                                      Duration timeout);
 
     /**
      * Gets a registered {@link SegmentContainerExtension} of the given type.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ReadOnlySegmentContainer.java
@@ -33,6 +33,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.server.DirectSegmentAccess;
 import io.pravega.segmentstore.server.SegmentContainer;
 import io.pravega.segmentstore.server.SegmentContainerExtension;
+import io.pravega.segmentstore.server.logs.operations.OperationPriority;
 import io.pravega.segmentstore.server.reading.StreamSegmentStorageReader;
 import io.pravega.segmentstore.storage.ReadOnlyStorage;
 import io.pravega.segmentstore.storage.StorageFactory;
@@ -44,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -210,7 +212,7 @@ class ReadOnlySegmentContainer extends AbstractIdleService implements SegmentCon
     }
 
     @Override
-    public CompletableFuture<DirectSegmentAccess> forSegment(String streamSegmentName, Duration timeout) {
+    public CompletableFuture<DirectSegmentAccess> forSegment(String streamSegmentName, @Nullable OperationPriority priority, Duration timeout) {
         return unsupported("forSegment");
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/Throttler.java
@@ -90,7 +90,7 @@ class Throttler implements ThrottleSourceListener, AutoCloseable {
         if (currentDelay != null && isInterruptible(currentDelay.source)) {
             // We were actively throttling due to a reason that is eligible for re-throttling. Terminate the current
             // throttle cycle, which should force the throttler to re-evaluate the situation.
-            log.debug("{}: Cache Cleanup complete while actively throttling ({}).", this.traceObjectId, currentDelay);
+            log.debug("{}: Throttling interrupted while actively throttling ({}).", this.traceObjectId, currentDelay);
             currentDelay.delayFuture.completeExceptionally(new ThrottlingInterruptedException());
         }
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CachedStreamSegmentAppendOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/CachedStreamSegmentAppendOperation.java
@@ -54,6 +54,7 @@ public class CachedStreamSegmentAppendOperation extends StorageOperation impleme
         }
 
         this.attributeUpdates = baseOperation.getAttributeUpdates();
+        setDesiredPriority(baseOperation.getDesiredPriority());
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/Operation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/Operation.java
@@ -20,7 +20,9 @@ import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectBuilder;
 import io.pravega.common.io.serialization.VersionedSerializer;
 import io.pravega.segmentstore.contracts.SequencedElement;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 /**
  * Base class for a Log Operation.
@@ -30,6 +32,12 @@ public abstract class Operation implements SequencedElement {
 
     public static final long NO_SEQUENCE_NUMBER = Long.MIN_VALUE;
     private long sequenceNumber;
+    /**
+     * Requested priority. This field is not serialized.
+     */
+    @Getter
+    @Setter
+    private OperationPriority desiredPriority;
 
     //endregion
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/store/StreamSegmentContainerRegistryTests.java
@@ -34,6 +34,7 @@ import io.pravega.segmentstore.server.SegmentContainer;
 import io.pravega.segmentstore.server.SegmentContainerFactory;
 import io.pravega.segmentstore.server.SegmentContainerExtension;
 import io.pravega.segmentstore.server.ServiceListeners;
+import io.pravega.segmentstore.server.logs.operations.OperationPriority;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.ThreadPooledTestSuite;
@@ -404,7 +405,7 @@ public class StreamSegmentContainerRegistryTests extends ThreadPooledTestSuite {
         }
 
         @Override
-        public CompletableFuture<DirectSegmentAccess> forSegment(String streamSegmentName, Duration timeout) {
+        public CompletableFuture<DirectSegmentAccess> forSegment(String streamSegmentName, OperationPriority priority, Duration timeout) {
             return null;
         }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableContext.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableContext.java
@@ -33,6 +33,7 @@ import io.pravega.segmentstore.server.SegmentContainer;
 import io.pravega.segmentstore.server.SegmentContainerExtension;
 import io.pravega.segmentstore.server.UpdateableSegmentMetadata;
 import io.pravega.segmentstore.server.containers.StreamSegmentMetadata;
+import io.pravega.segmentstore.server.logs.operations.OperationPriority;
 import io.pravega.segmentstore.storage.cache.CacheStorage;
 import io.pravega.segmentstore.storage.cache.DirectMemoryCache;
 import java.time.Duration;
@@ -152,7 +153,7 @@ public class TableContext implements AutoCloseable {
         }
 
         @Override
-        public CompletableFuture<DirectSegmentAccess> forSegment(String segmentName, Duration timeout) {
+        public CompletableFuture<DirectSegmentAccess> forSegment(String segmentName, OperationPriority priority, Duration timeout) {
             Exceptions.checkNotClosed(this.closed.get(), this);
             SegmentMock segment = this.segment.get();
             if (segment == null) {


### PR DESCRIPTION
**Change log description**  
All WriterTableProcessor updates now have OperationPriority.Critical, which should help them bypass throttling and help avoid a deadlock (writer blocked by throttling, but throttling because writer can't process operations).

**Purpose of the change**  
Fixes #5999.

**What the code does**  
Added an overload to SegmentContainer.forSegment to specify a desired priority for all operations via that wrapper. That only applies to that instance. Changed ContainerTableExtensionImpl to request this with a Critical priority for WriterTableProcessor alone (not for any other operations it may execute, such as put or remove).

**How to verify it**  
Tests must pass.
