### PR TITLE
Issue 6003:  Fix a flaky test in TcpClientConnection.

### DIFF
--- a/client/src/test/java/io/pravega/client/connection/impl/TcpClientConnectionTest.java
+++ b/client/src/test/java/io/pravega/client/connection/impl/TcpClientConnectionTest.java
@@ -142,8 +142,10 @@ public class TcpClientConnectionTest {
         TcpClientConnection.ConnectionReader reader = new TcpClientConnection.ConnectionReader("reader", tcpStream, rp, mock(FlowToBatchSizeTracker.class));
         // Trigger a read.
         reader.start();
+        tcpStream.lastByteLatch.release();
         // Wait until the ReplyProcessor callback is invoked.
         isCallbackInvokedLatch.await();
+
         // Verify if ConnectionReader.stop() is blocked until the ReplyProcessor callback finish its execution.
         assertBlocks(reader::stop, blockCallbackLatch::release);
         verify(rp, times(1)).process(any(WireCommands.SegmentIsSealed.class));


### PR DESCRIPTION
**Change log description**  
Fix flakiness in the TcpClientConnection test.

**Purpose of the change**  
Fixes #6003 

**What the code does**  
Fixes the flaky test by ensuring we invoke `ConnectionReader.stop() ` before the last byte is read from the Socket InputStream.

**How to verify it**  
The test should pass reliably.
