### PR TITLE
Issue 2887: AutoScale stream if configuration changes the minNumberOfSegments

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/ScaleOperationTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/ScaleOperationTask.java
@@ -32,7 +32,6 @@ import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.shared.controller.event.ScaleOpEvent;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
@@ -69,8 +68,7 @@ public class ScaleOperationTask implements StreamTask<ScaleOpEvent> {
         log.info(request.getRequestId(), "starting scale request for {}/{} segments {} to new ranges {}",
                 request.getScope(), request.getStream(), request.getSegmentsToSeal(), request.getNewRanges());
 
-        runScale(request, request.isRunOnlyIfStarted(), context,
-                this.streamMetadataTasks.retrieveDelegationToken())
+        runScale(request, request.isRunOnlyIfStarted(), context)
                 .whenCompleteAsync((res, e) -> {
                     if (e != null) {
                         Throwable cause = Exceptions.unwrap(e);
@@ -78,7 +76,7 @@ public class ScaleOperationTask implements StreamTask<ScaleOpEvent> {
                             cause = cause.getCause();
                         }
                         if (cause instanceof EpochTransitionOperationExceptions.PreConditionFailureException) {
-                            log.warn(request.getRequestId(), "processing scale request for {}/{} segments {} failed {}",
+                            log.info(request.getRequestId(), "processing scale request for {}/{} segments {} failed {}",
                                     request.getScope(), request.getStream(), request.getSegmentsToSeal(), cause.getClass().getName());
                             result.complete(null);
                         } else {
@@ -103,7 +101,7 @@ public class ScaleOperationTask implements StreamTask<ScaleOpEvent> {
     }
 
     @VisibleForTesting
-    public CompletableFuture<Void> runScale(ScaleOpEvent scaleInput, boolean isManualScale, OperationContext context, String delegationToken) { // called upon event read from requeststream
+    public CompletableFuture<Void> runScale(ScaleOpEvent scaleInput, boolean isManualScale, OperationContext context) { // called upon event read from requeststream
         String scope = scaleInput.getScope();
         String stream = scaleInput.getStream();
         long requestId = scaleInput.getRequestId();
@@ -149,33 +147,24 @@ public class ScaleOperationTask implements StreamTask<ScaleOpEvent> {
                         
                         return future
                                 .thenCompose(versionedMetadata -> processScale(scope, stream, isManualScale, versionedMetadata, 
-                                        reference.get(), context, delegationToken, requestId));
+                                        reference.get(), context, requestId));
                     }));
     }
     
     private CompletableFuture<Void> processScale(String scope, String stream, boolean isManualScale,
                                                  VersionedMetadata<EpochTransitionRecord> metadata,
                                                  VersionedMetadata<State> state, OperationContext context,
-                                                 String delegationToken, long requestId) {
+                                                 long requestId) {
         return streamMetadataStore.updateVersionedState(scope, stream, State.SCALING, state, context, executor)
-                .thenCompose(updatedState -> streamMetadataStore.startScale(scope, stream, isManualScale, metadata, updatedState, context, executor)
-                        .thenCompose(record -> {
-                            List<Long> segmentIds = new ArrayList<>(record.getObject().getNewSegmentsWithRange().keySet());
-                            List<Long> segmentsToSeal = new ArrayList<>(record.getObject().getSegmentsToSeal());
-                            return streamMetadataTasks.notifyNewSegments(scope, stream, segmentIds, context, delegationToken, requestId)
-                                    .thenCompose(x -> streamMetadataStore.scaleCreateNewEpochs(scope, stream, record, context, executor))
-                                    .thenCompose(x -> streamMetadataTasks.notifySealedSegments(scope, stream, segmentsToSeal, delegationToken, requestId))
-                                    .thenCompose(x -> streamMetadataTasks.getSealedSegmentsSize(scope, stream, segmentsToSeal, delegationToken))
-                                    .thenCompose(map -> streamMetadataStore.scaleSegmentsSealed(scope, stream, map, record, context, executor))
-                                    .thenCompose(x -> streamMetadataStore.completeScale(scope, stream, record, context, executor))
-                                    .thenCompose(x -> streamMetadataStore.updateVersionedState(scope, stream, State.ACTIVE, updatedState, context, executor))
-                                    .thenAccept(y -> {
-                                        log.info(requestId, "scale processing for {}/{} epoch {} completed.", scope, stream, record.getObject().getActiveEpoch());
-                                    });
-                        }));
-
+              .thenCompose(updatedState -> streamMetadataStore.startScale(scope, stream, isManualScale, metadata, updatedState, context, executor)
+                        .thenCompose(record -> streamMetadataTasks.processScale(scope, stream, metadata, context, requestId, streamMetadataStore)
+                            .thenCompose(r ->  streamMetadataStore.updateVersionedState(scope, stream, State.ACTIVE, updatedState, context, executor))
+                            .thenAccept(y -> {
+                                log.info(requestId, "scale processing for {}/{} epoch {} completed.", scope, stream, 
+                                        record.getObject().getActiveEpoch());
+                            })));
     }
-
+    
     @Override
     public CompletableFuture<Boolean> hasTaskStarted(ScaleOpEvent event) {
         return streamMetadataStore.getState(event.getScope(), event.getStream(), true, null, executor)

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateStreamTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateStreamTask.java
@@ -16,6 +16,7 @@
 package io.pravega.controller.server.eventProcessor.requesthandlers;
 
 import com.google.common.base.Preconditions;
+import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.store.stream.BucketStore;
@@ -23,13 +24,25 @@ import io.pravega.controller.store.stream.OperationContext;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.controller.store.VersionedMetadata;
 import io.pravega.controller.store.stream.State;
+import io.pravega.controller.store.stream.records.EpochRecord;
+import io.pravega.controller.store.stream.records.EpochTransitionRecord;
 import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.shared.controller.event.UpdateStreamEvent;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import lombok.extern.slf4j.Slf4j;
+
+import static io.pravega.client.stream.ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS;
 
 /**
  * Request handler for performing scale operations received from requeststream.
@@ -84,11 +97,55 @@ public class UpdateStreamTask implements StreamTask<UpdateStreamEvent> {
                                                   VersionedMetadata<State> state, OperationContext context, long requestId) {
         StreamConfigurationRecord configProperty = record.getObject();
 
-        return Futures.toVoid(streamMetadataStore.updateVersionedState(scope, stream, State.UPDATING, state, context, executor)
+        return Futures.toVoid(
+                streamMetadataStore.getEpochTransition(scope, stream, context, executor)
+                .thenCompose(etr -> streamMetadataStore.updateVersionedState(scope, stream, State.UPDATING, state, context, executor)
                 .thenCompose(updated -> updateStreamForAutoStreamCut(scope, stream, configProperty, updated)
                         .thenCompose(x -> notifyPolicyUpdate(context, scope, stream, configProperty.getStreamConfiguration(), requestId))
+                        .thenCompose(x -> handleSegmentCount(scope, stream, configProperty, etr, context, executor, requestId))
                         .thenCompose(x -> streamMetadataStore.completeUpdateConfiguration(scope, stream, record, context, executor))
-                        .thenCompose(x -> streamMetadataStore.updateVersionedState(scope, stream, State.ACTIVE, updated, context, executor))));
+                        .thenCompose(x -> streamMetadataStore.updateVersionedState(scope, stream, State.ACTIVE, updated, context, executor)))));
+    }
+
+    private CompletableFuture<Void> handleSegmentCount(final String scope, final String stream, 
+                                                       final StreamConfigurationRecord config, 
+                                                       final VersionedMetadata<EpochTransitionRecord> etr, 
+                                                       final OperationContext context, 
+                                                       final ScheduledExecutorService executor, 
+                                                       final long requestId) {
+        return streamMetadataStore.getActiveEpoch(scope, stream, context, true, executor)
+                              .thenCompose(activeEpoch -> {
+                                  ScalingPolicy scalingPolicy = config.getStreamConfiguration().getScalingPolicy();
+                                  int minNumSegments = scalingPolicy.getMinNumSegments();
+
+                                  if ((scalingPolicy.getScaleType() == FIXED_NUM_SEGMENTS &&
+                                          activeEpoch.getSegments().size() != minNumSegments) ||
+                                          activeEpoch.getSegments().size() < minNumSegments) {
+                                      return processScale(scope, stream, minNumSegments, etr, activeEpoch, context, requestId);
+                                  } else {
+                                      return CompletableFuture.completedFuture(null);
+                                  }
+                              });
+    }
+
+    private CompletableFuture<Void> processScale(String scope, String stream, int numSegments,
+                                                 VersionedMetadata<EpochTransitionRecord> etr, EpochRecord activeEpoch,
+                                                 OperationContext context, long requestId) {
+        // First reset the existing epoch transition (any submitted but unattempted scale 
+        // request is discarded). Then submit a new scale to seal all segments in active epoch and create new segments
+        // with count = numSegments and range equally divided among them. 
+        final double keyRangeChunk = 1.0 / numSegments;
+        
+        List<Map.Entry<Double, Double>> newRange = IntStream.range(0, numSegments).boxed()
+                                                            .map(x -> new AbstractMap.SimpleEntry<>(x * keyRangeChunk, (x + 1) * keyRangeChunk))
+                                                            .collect(Collectors.toList());
+
+        return streamMetadataStore.resetEpochTransition(scope, stream, etr, context, executor)
+              .thenCompose(reset -> streamMetadataStore.submitScale(scope, stream, new ArrayList<>(activeEpoch.getSegmentIds()), newRange,
+                      System.currentTimeMillis(), reset, context, executor))
+              .thenCompose(updated -> streamMetadataTasks.processScale(scope, stream, updated, context, requestId, streamMetadataStore)
+              .thenAccept(r -> log.info("{} Stream scaled to epoch {} to update minimum number of segments to {}", requestId, 
+                      updated.getObject().getActiveEpoch(), numSegments)));
     }
 
     private CompletableFuture<Void> updateStreamForAutoStreamCut(String scope, String stream,

--- a/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/AbstractStreamMetadataStore.java
@@ -473,6 +473,15 @@ public abstract class AbstractStreamMetadataStore implements StreamMetadataStore
     }
 
     @Override
+    public CompletableFuture<VersionedMetadata<EpochTransitionRecord>> resetEpochTransition(final String scope,
+                                                 final String name,
+                                                 final VersionedMetadata<EpochTransitionRecord> record,
+                                                 final OperationContext context,
+                                                 final Executor executor) {
+        return Futures.completeOn(getStream(scope, name, context).resetEpochTransition(record), executor);
+    }
+
+    @Override
     public CompletableFuture<VersionedMetadata<EpochTransitionRecord>> startScale(final String scope,
                                                           final String name,
                                                           final boolean isManualScale,

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -1230,6 +1230,13 @@ public abstract class PersistentStreamBase implements Stream {
                 .thenApply(x -> new VersionedMetadata<>(x.getObject(), x.getVersion()));
     }
 
+    @Override
+    public CompletableFuture<VersionedMetadata<EpochTransitionRecord>> resetEpochTransition(VersionedMetadata<EpochTransitionRecord> record) {
+        Preconditions.checkNotNull(record);
+        return updateEpochTransitionNode(new VersionedMetadata<>(EpochTransitionRecord.EMPTY, record.getVersion()))
+                .thenApply(v -> new VersionedMetadata<>(EpochTransitionRecord.EMPTY, v));
+    }
+
     private CompletableFuture<Void> clearMarkers(final Set<Long> segments) {
         return Futures.toVoid(Futures.allOfWithResults(segments.stream().parallel()
                                                                .map(this::removeColdMarker).collect(Collectors.toList())));

--- a/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/Stream.java
@@ -284,6 +284,14 @@ interface Stream {
     CompletableFuture<VersionedMetadata<EpochTransitionRecord>> getEpochTransition();
 
     /**
+     * Reset the given epoch transition to EMPTY.
+     * 
+     * @param record  existing versioned record.
+     * @return A future which when completed would have reset the epoch transition to empty.                 
+     */
+    CompletableFuture<VersionedMetadata<EpochTransitionRecord>> resetEpochTransition(VersionedMetadata<EpochTransitionRecord> record);
+
+    /**
      * Called to start metadata updates to stream store with respect to new scale request. This method should only update
      * the epochTransition record to reflect current request. It should not initiate the scale workflow. 
      * This should be called for both auto scale and manual scale. 

--- a/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/StreamMetadataStore.java
@@ -723,6 +723,22 @@ public interface StreamMetadataStore extends AutoCloseable {
     CompletableFuture<VersionedMetadata<EpochTransitionRecord>> getEpochTransition(String scope, String stream,
                                                                                    OperationContext context,
                                                                                    ScheduledExecutorService executor);
+
+    /**
+     * ResetEpoch transition record back to EMPTY.
+     * 
+     * @param scope          stream scope
+     * @param name           stream name.
+     * @param record         versioned record
+     * @param context        operation context
+     * @param executor       callers executor
+     * @return A future which when completed indicates that epoch transition record has been reset and holds the updated
+     * versioned record.                 
+     */
+    CompletableFuture<VersionedMetadata<EpochTransitionRecord>> resetEpochTransition(final String scope, final String name,
+                                          final VersionedMetadata<EpochTransitionRecord> record,
+                                          final OperationContext context,
+                                          final Executor executor);
     
     /**
      * Called to start metadata updates to stream store with respect to new scale request. This method should only update

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -1905,6 +1905,20 @@ public class StreamMetadataTasks extends TaskBase {
                 Collectors.toMap(x -> x, x -> getSegmentOffset(scope, stream, x, this.retrieveDelegationToken()))));
     }
 
+    public CompletableFuture<Void> processScale(String scope, String stream, 
+                                                VersionedMetadata<EpochTransitionRecord> record, OperationContext context, 
+                                                long requestId, StreamMetadataStore store) {
+        List<Long> segmentIds = new ArrayList<>(record.getObject().getNewSegmentsWithRange().keySet());
+        List<Long> segmentsToSeal = new ArrayList<>(record.getObject().getSegmentsToSeal());
+        String delegationToken = retrieveDelegationToken();
+        return notifyNewSegments(scope, stream, segmentIds, context, delegationToken, requestId)
+                  .thenCompose(x -> store.scaleCreateNewEpochs(scope, stream, record, context, executor))
+                  .thenCompose(x -> notifySealedSegments(scope, stream, segmentsToSeal, delegationToken, requestId))
+                  .thenCompose(x -> getSealedSegmentsSize(scope, stream, segmentsToSeal, delegationToken))
+                  .thenCompose(map -> store.scaleSegmentsSealed(scope, stream, map, record, context, executor))
+                  .thenCompose(x -> store.completeScale(scope, stream, record, context, executor));
+    }
+
     @Override
     public TaskBase copyWithContext(Context context) {
         return new StreamMetadataTasks(streamMetadataStore,

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -488,7 +488,58 @@ public abstract class RequestHandlersTest {
         streamStore2.close();
     }
 
-    abstract int getVersionNumber(Version version); 
+    abstract int getVersionNumber(Version version);
+
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 300000)
+    public void concurrentUpdateScaleStream() throws Exception {
+        String stream = "update2";
+        StreamMetadataStore streamStore1 = getStore();
+        StreamMetadataStore streamStore1Spied = spy(getStore());
+        StreamConfiguration config = StreamConfiguration.builder().scalingPolicy(
+                ScalingPolicy.fixed(1)).build();
+        streamStore1.createStream(scope, stream, config, System.currentTimeMillis(), null, executor).join();
+        streamStore1.setState(scope, stream, State.ACTIVE, null, executor).join();
+
+        StreamMetadataStore streamStore2 = getStore();
+
+        UpdateStreamTask requestHandler1 = new UpdateStreamTask(streamMetadataTasks, streamStore1Spied, bucketStore, executor);
+        UpdateStreamTask requestHandler2 = new UpdateStreamTask(streamMetadataTasks, streamStore2, bucketStore, executor);
+
+        CompletableFuture<Void> wait = new CompletableFuture<>();
+        CompletableFuture<Void> signal = new CompletableFuture<>();
+        config = StreamConfiguration.builder().scalingPolicy(
+                ScalingPolicy.fixed(2)).build();
+
+        streamStore1.startUpdateConfiguration(scope, stream, config, null, executor).join();
+
+        UpdateStreamEvent event = new UpdateStreamEvent(scope, stream, System.currentTimeMillis());
+
+        // make this wait at reset epoch transition. this has already changed the state to updating. both executions are 
+        // performing the same update. 
+        doAnswer(x -> {
+            signal.complete(null);
+            wait.join();
+            return streamStore1.resetEpochTransition(x.getArgument(0), x.getArgument(1),
+                    x.getArgument(2), x.getArgument(3), x.getArgument(4));
+        }).when(streamStore1Spied).resetEpochTransition(anyString(), anyString(), any(), any(), any());
+
+        CompletableFuture<Void> future1 = CompletableFuture.completedFuture(null)
+                                                           .thenComposeAsync(v -> requestHandler1.execute(event), executor);
+        signal.join();
+        requestHandler2.execute(event).join();
+        wait.complete(null);
+
+        AssertExtensions.assertSuppliedFutureThrows("first update job should fail", () -> future1,
+                e -> Exceptions.unwrap(e) instanceof StoreException.WriteConflictException);
+
+        VersionedMetadata<StreamConfigurationRecord> versioned = streamStore1.getConfigurationRecord(scope, stream, null, executor).join();
+        assertFalse(versioned.getObject().isUpdating());
+        assertEquals(2, getVersionNumber(versioned.getVersion()));
+        assertEquals(State.ACTIVE, streamStore1.getState(scope, stream, true, null, executor).join());
+        streamStore1.close();
+        streamStore2.close();
+    }
 
     // concurrent truncate stream
     @SuppressWarnings("unchecked")

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -72,7 +72,6 @@ import io.pravega.controller.store.stream.records.EpochRecord;
 import io.pravega.controller.store.stream.records.EpochTransitionRecord;
 import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
 import io.pravega.controller.store.stream.records.StreamCutRecord;
-import io.pravega.controller.store.stream.records.StreamSegmentRecord;
 import io.pravega.controller.store.stream.records.StreamTruncationRecord;
 import io.pravega.controller.store.task.LockFailedException;
 import io.pravega.controller.store.task.TaskMetadataStore;

--- a/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/ControllerRestApiTest.java
@@ -225,8 +225,9 @@ public class ControllerRestApiTest {
                 queryParam("to", System.currentTimeMillis()).request().get();
         List<ScaleMetadata> scaleMetadataListResponse = response.readEntity(
                 new GenericType<List<ScaleMetadata>>() { });
-        assertEquals(1, scaleMetadataListResponse.size());
+        assertEquals(2, scaleMetadataListResponse.size());
         assertEquals(2, scaleMetadataListResponse.get(0).getSegments().size());
+        assertEquals(4, scaleMetadataListResponse.get(1).getSegments().size());
 
         // Test getStream
         resourceURl = new StringBuilder(restServerURI).append("/v1/scopes/" + scope1 + "/streams/" + stream1)

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/ControllerServiceTest.java
@@ -245,7 +245,7 @@ public class ControllerServiceTest {
                                                   final String streamName) throws InterruptedException,
                                                                            ExecutionException {
         CompletableFuture<Map<Segment, Long>> segments = controller.getSegmentsAtTime(new StreamImpl(scope, streamName), System.currentTimeMillis() - 36000);
-        assertFalse("FAILURE: Fetching positions at given time before stream creation failed", segments.get().size() != controller.getCurrentSegments(scope, streamName).get().getSegments().size());
+        assertFalse("FAILURE: Fetching positions at given time before stream creation failed", segments.get().size() == 1);
        
     }
 
@@ -293,6 +293,7 @@ public class ControllerServiceTest {
         assertTrue(controller.updateStream(scope, streamName, StreamConfiguration.builder()
                                           .scalingPolicy(ScalingPolicy.byEventRate(200, 2, 3))
                                           .build()).get());
+        assertEquals(3, controller.getCurrentSegments(scope, streamName).get().getSegments().size());
     }
 
     private static void updateScaleFactor(Controller controller, final String scope,

--- a/test/integration/src/test/java/io/pravega/test/integration/controller/server/StreamMetadataTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/controller/server/StreamMetadataTest.java
@@ -156,6 +156,8 @@ public class StreamMetadataTest {
                                                                .build();
         assertTrue(controller.updateStream(scope1, streamName1, config9).get());
 
+        // the number of segments in the stream should now be 3. 
+        
         // AS7:Update configuration of non-existent stream.
         final StreamConfiguration config = StreamConfiguration.builder()
                                                               .scalingPolicy(ScalingPolicy.fixed(2))
@@ -195,8 +197,10 @@ public class StreamMetadataTest {
 
         // PS5:Get position at time before stream creation
         segments = controller.getSegmentsAtTime(stream1, System.currentTimeMillis() - 36000);
+        assertEquals(segments.join().size(), 2);
+
         assertEquals(controller.getCurrentSegments(scope1, streamName1).get().getSegments().size(),
-                     segments.get().size());
+                     3);
 
         // PS6:Get positions at a time in future after stream creation
         segments = controller.getSegmentsAtTime(stream1, System.currentTimeMillis() + 3600);

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndUpdateTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndUpdateTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.test.integration.endtoendtest;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import io.pravega.client.ClientConfig;
+import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
+import io.pravega.client.connection.impl.ConnectionFactory;
+import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
+import io.pravega.client.security.auth.DelegationTokenProviderFactory;
+import io.pravega.client.segment.impl.NoSuchSegmentException;
+import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.segment.impl.SegmentMetadataClient;
+import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
+import io.pravega.client.segment.impl.SegmentMetadataClientFactoryImpl;
+import io.pravega.client.stream.Checkpoint;
+import io.pravega.client.stream.EventRead;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.EventWriterConfig;
+import io.pravega.client.stream.InvalidStreamException;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroup;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ReinitializationRequiredException;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Serializer;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.TruncatedDataException;
+import io.pravega.client.stream.impl.ClientFactoryImpl;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.StreamImpl;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
+import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.Futures;
+import io.pravega.controller.server.eventProcessor.LocalController;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import io.pravega.test.integration.PravegaResource;
+import io.pravega.test.integration.ReadWriteUtils;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static io.pravega.shared.NameUtils.computeSegmentId;
+import static io.pravega.test.common.AssertExtensions.assertFutureThrows;
+import static io.pravega.test.common.AssertExtensions.assertThrows;
+import static io.pravega.test.integration.ReadWriteUtils.readEvents;
+import static io.pravega.test.integration.ReadWriteUtils.writeEvents;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.*;
+
+@Slf4j
+public class EndToEndUpdateTest extends ThreadPooledTestSuite {
+
+    @ClassRule
+    public static final PravegaResource PRAVEGA = new PravegaResource();
+
+    @Override
+    protected int getThreadPoolSize() {
+        return 1;
+    }
+    
+    @Test(timeout = 30000)
+    public void testUpdateStream() throws InterruptedException, ExecutionException, TimeoutException,
+                                        TruncatedDataException, ReinitializationRequiredException {
+        String scope = "scope";
+        String streamName = "updateStream";
+
+        LocalController controller = (LocalController) PRAVEGA.getLocalController();
+        controller.createScope(scope).join();
+        controller.createStream(scope, streamName, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build()).join();
+
+        StreamConfiguration config = StreamConfiguration.builder()
+                                                        .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 2))
+                                                        .build();
+        controller.updateStream(scope, streamName, config).get();
+        
+        // verify that stream is updated and also scaled.
+        assertEquals(controller.getCurrentSegments(scope, streamName).join().getNumberOfSegments(), 2);
+
+        config = StreamConfiguration.builder()
+                                    .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 1))
+                                    .build();
+        controller.updateStream(scope, streamName, config).get();
+        
+        // verify that stream is not scaled as min num of segments is still satisfied
+        assertEquals(controller.getCurrentSegments(scope, streamName).join().getNumberOfSegments(), 2);
+
+        config = StreamConfiguration.builder()
+                                    .scalingPolicy(ScalingPolicy.byEventRate(10, 2, 3))
+                                    .build();
+        controller.updateStream(scope, streamName, config).get();
+        
+        // verify that stream is scaled to have 3 segments
+        assertEquals(controller.getCurrentSegments(scope, streamName).join().getNumberOfSegments(), 3);
+
+        config = StreamConfiguration.builder()
+                                    .scalingPolicy(ScalingPolicy.fixed(6))
+                                    .build();
+        controller.updateStream(scope, streamName, config).get();
+        
+        // verify that stream is scaled to have 6 segments
+        assertEquals(controller.getCurrentSegments(scope, streamName).join().getNumberOfSegments(), 6);
+
+        config = StreamConfiguration.builder()
+                                    .scalingPolicy(ScalingPolicy.fixed(5))
+                                    .build();
+        controller.updateStream(scope, streamName, config).get();
+        
+        // verify that stream is scaled to have 3 segments
+        assertEquals(controller.getCurrentSegments(scope, streamName).join().getNumberOfSegments(), 5);
+    }
+}

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndUpdateTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndUpdateTest.java
@@ -15,70 +15,21 @@
  */
 package io.pravega.test.integration.endtoendtest;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import io.pravega.client.ClientConfig;
-import io.pravega.client.EventStreamClientFactory;
-import io.pravega.client.admin.ReaderGroupManager;
-import io.pravega.client.admin.StreamManager;
-import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
-import io.pravega.client.connection.impl.ConnectionFactory;
-import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
-import io.pravega.client.security.auth.DelegationTokenProviderFactory;
-import io.pravega.client.segment.impl.NoSuchSegmentException;
-import io.pravega.client.segment.impl.Segment;
-import io.pravega.client.segment.impl.SegmentMetadataClient;
-import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
-import io.pravega.client.segment.impl.SegmentMetadataClientFactoryImpl;
-import io.pravega.client.stream.Checkpoint;
-import io.pravega.client.stream.EventRead;
-import io.pravega.client.stream.EventStreamReader;
-import io.pravega.client.stream.EventStreamWriter;
-import io.pravega.client.stream.EventWriterConfig;
-import io.pravega.client.stream.InvalidStreamException;
-import io.pravega.client.stream.ReaderConfig;
-import io.pravega.client.stream.ReaderGroup;
-import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReinitializationRequiredException;
 import io.pravega.client.stream.ScalingPolicy;
-import io.pravega.client.stream.Serializer;
-import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.TruncatedDataException;
-import io.pravega.client.stream.impl.ClientFactoryImpl;
-import io.pravega.client.stream.impl.JavaSerializer;
-import io.pravega.client.stream.impl.StreamImpl;
-import io.pravega.client.stream.impl.UTF8StringSerializer;
-import io.pravega.common.Exceptions;
-import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.server.eventProcessor.LocalController;
-import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import io.pravega.test.integration.PravegaResource;
-import io.pravega.test.integration.ReadWriteUtils;
-import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static io.pravega.shared.NameUtils.computeSegmentId;
-import static io.pravega.test.common.AssertExtensions.assertFutureThrows;
-import static io.pravega.test.common.AssertExtensions.assertThrows;
-import static io.pravega.test.integration.ReadWriteUtils.readEvents;
-import static io.pravega.test.integration.ReadWriteUtils.writeEvents;
-import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 @Slf4j
 public class EndToEndUpdateTest extends ThreadPooledTestSuite {


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Applies configuration change and enforces minimum number of segments. Scales stream if the stream has lesser number of segments (for auto scaling) and different number of segments (for fixed policy). 

**Purpose of the change**  
Fixes #2887 

**What the code does**  
Abstracts out scaling logic from ScaleOperationTask into StreamMetadataTask and uses that in UpdateStreamTask.
A stream can be scaled as part of update workflow if the active segments in the stream are different.

**How to verify it**  
Unit tests added
