### PR TITLE
Issue 6030: (SegmentStore) Ignoring missing ledgers that were previously marked as Empty.

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Ledgers.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Ledgers.java
@@ -240,9 +240,8 @@ public final class Ledgers {
             try {
                 handle = openFence(ledgerMetadata.getLedgerId(), bookKeeper, config);
             } catch (DurableDataLogException ex) {
-                boolean notExists = ex.getCause() instanceof BKException.BKNoSuchLedgerExistsException
-                        || ex.getCause() instanceof BKException.BKNoSuchLedgerExistsOnMetadataServerException;
-                if (notExists && ledgerMetadata.getStatus() == LedgerMetadata.Status.Empty) {
+                val c = ex.getCause();
+                if (ledgerMetadata.getStatus() == LedgerMetadata.Status.Empty && (c instanceof BKException.BKNoSuchLedgerExistsOnMetadataServerException || c instanceof BKException.BKNoSuchLedgerExistsException)) {
                     log.warn("{}: Unable to open-fence EMPTY ledger {}. Skipping.", traceObjectId, ledgerMetadata, ex);
                     continue;
                 }

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Ledgers.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/Ledgers.java
@@ -30,8 +30,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
-import lombok.val;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BKException.BKNotEnoughBookiesException;
 import org.apache.bookkeeper.client.BKException.BKUnexpectedConditionException;
@@ -236,7 +236,19 @@ public final class Ledgers {
         val iterator = ledgers.listIterator(ledgers.size());
         while (iterator.hasPrevious() && (nonEmptyCount < MIN_FENCE_LEDGER_COUNT)) {
             LedgerMetadata ledgerMetadata = iterator.previous();
-            ReadHandle handle = openFence(ledgerMetadata.getLedgerId(), bookKeeper, config);
+            ReadHandle handle;
+            try {
+                handle = openFence(ledgerMetadata.getLedgerId(), bookKeeper, config);
+            } catch (DurableDataLogException ex) {
+                boolean notExists = ex.getCause() instanceof BKException.BKNoSuchLedgerExistsException
+                        || ex.getCause() instanceof BKException.BKNoSuchLedgerExistsOnMetadataServerException;
+                if (notExists && ledgerMetadata.getStatus() == LedgerMetadata.Status.Empty) {
+                    log.warn("{}: Unable to open-fence EMPTY ledger {}. Skipping.", traceObjectId, ledgerMetadata, ex);
+                    continue;
+                }
+                throw ex;
+            }
+
             if (handle.getLastAddConfirmed() != NO_ENTRY_ID) {
                 // Non-empty.
                 nonEmptyCount++;


### PR DESCRIPTION
**Change log description**  
During the BookKeeperLog initialization phase, we are now ignoring ledgers that we cannot open-fence due to them missing but have been previously identified as being Empty.

**Purpose of the change**  
Fixes #6030.

**What the code does**  
If a ledger has been marked as Empty, it means that we absolutely know it has no data. As such, during recovery we will auto-delete it. However, if we crash at one point in this process, it may be possible for the ledger to actually be deleted but we didn't have a chance to update the metadata accordingly. A subsequent recovery would attempt to re-open-fence this ledger and fail because it doesn't exist.

This change handles missing ledger exceptions during open-fencing and, if that ledger has been marked as empty previously, it is safe to skip it and move on. If the ledger, however, is not marked as Empty, then we will re-throw the exception.

**How to verify it**  
New unit test added.
