### PR TITLE
Issue 6042: (KVT Beta2) Keeping track of the number of extended attributes per Segment

### DIFF
--- a/common_server/src/main/java/io/pravega/common/util/btree/BTreeIndex.java
+++ b/common_server/src/main/java/io/pravega/common/util/btree/BTreeIndex.java
@@ -876,7 +876,6 @@ public class BTreeIndex {
     private void setState(long length, long rootPageOffset, int rootPageLength) {
         this.state = new IndexState(length, rootPageOffset, rootPageLength);
         log.debug("{}: IndexState: {}, Stats: {}.", this.traceObjectId, this.state, this.statistics);
-        //System.out.println(String.format("%s: IndexState: %s, Stats: %s.", this.traceObjectId, this.state, this.statistics));
     }
 
     private long getFooterOffset(long indexLength) {

--- a/common_server/src/main/java/io/pravega/common/util/btree/BTreeIndex.java
+++ b/common_server/src/main/java/io/pravega/common/util/btree/BTreeIndex.java
@@ -22,8 +22,8 @@ import io.pravega.common.util.AsyncIterator;
 import io.pravega.common.util.BufferViewComparator;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.common.util.IllegalDataFormatException;
+import java.io.IOException;
 import java.time.Duration;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -31,8 +31,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -45,6 +45,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
@@ -120,7 +121,10 @@ public class BTreeIndex {
     private final ReadPage read;
     private final WritePages write;
     private final GetLength getLength;
-    private final AtomicReference<IndexState> state;
+    private volatile IndexState state;
+    private volatile boolean maintainStatistics;
+    @Getter
+    private volatile Statistics statistics;
     private final Executor executor;
     private final String traceObjectId;
 
@@ -131,28 +135,30 @@ public class BTreeIndex {
     /**
      * Creates a new instance of the BTreeIndex class.
      *
-     * @param maxPageSize Maximum page size. No BTreeIndex Page will exceed this value.
-     * @param keyLength   The length, in bytes, of the index Keys.
-     * @param valueLength The length, in bytes, of the index Values.
-     * @param readPage    A Function that reads the contents of a page from an external data source.
-     * @param writePages  A Function that writes contents of one or more contiguous pages to an external data source.
-     * @param getLength   A Function that returns the length of the index, in bytes, as stored in an external data source.
-     * @param executor    Executor for async operations.
-     * @param traceObjectId An identifier to add to all log entries.
+     * @param maxPageSize        Maximum page size. No BTreeIndex Page will exceed this value.
+     * @param keyLength          The length, in bytes, of the index Keys.
+     * @param valueLength        The length, in bytes, of the index Values.
+     * @param readPage           A Function that reads the contents of a page from an external data source.
+     * @param writePages         A Function that writes contents of one or more contiguous pages to an external data source.
+     * @param getLength          A Function that returns the length of the index, in bytes, as stored in an external data source.
+     * @param maintainStatistics If true, the BTreeIndex will maintain {@link Statistics} about its contents.
+     * @param executor           Executor for async operations.
+     * @param traceObjectId      An identifier to add to all log entries.
      */
     @Builder
     public BTreeIndex(int maxPageSize, int keyLength, int valueLength, @NonNull ReadPage readPage, @NonNull WritePages writePages,
-                      @NonNull GetLength getLength, @NonNull Executor executor, String traceObjectId) {
+                      @NonNull GetLength getLength, boolean maintainStatistics, @NonNull Executor executor, String traceObjectId) {
         this.read = readPage;
         this.write = writePages;
         this.getLength = getLength;
+        this.maintainStatistics = maintainStatistics;
         this.executor = executor;
         this.traceObjectId = traceObjectId;
 
         // BTreePage.Config validates the arguments so we don't need to.
         this.indexPageConfig = new BTreePage.Config(keyLength, INDEX_VALUE_LENGTH, maxPageSize, true);
         this.leafPageConfig = new BTreePage.Config(keyLength, valueLength, maxPageSize, false);
-        this.state = new AtomicReference<>();
+        this.state = null;
     }
 
     //endregion
@@ -165,7 +171,7 @@ public class BTreeIndex {
      * @return True if initialized, false otherwise.
      */
     public boolean isInitialized() {
-        return this.state.get() != null;
+        return this.state != null;
     }
 
     /**
@@ -174,7 +180,7 @@ public class BTreeIndex {
      * @return The Index Length.
      */
     public long getIndexLength() {
-        IndexState s = this.state.get();
+        IndexState s = this.state;
         return s == null ? -1 : s.length;
     }
 
@@ -197,13 +203,16 @@ public class BTreeIndex {
                     if (indexInfo.getIndexLength() <= FOOTER_LENGTH) {
                         // Empty index.
                         setState(indexInfo.getIndexLength(), PagePointer.NO_OFFSET, 0);
+                        this.statistics = this.maintainStatistics ? Statistics.EMPTY : null;
                         return CompletableFuture.completedFuture(null);
                     }
 
                     long footerOffset = indexInfo.getRootPointer() >= 0 ? indexInfo.getRootPointer() : getFooterOffset(indexInfo.getIndexLength());
                     return this.read
-                            .apply(footerOffset, FOOTER_LENGTH, timer.getRemaining())
-                            .thenAccept(footer -> initialize(footer, footerOffset, indexInfo.getIndexLength()));
+                            .apply(footerOffset, FOOTER_LENGTH, false, timer.getRemaining())
+                            .thenAcceptAsync(footer -> initialize(footer, footerOffset, indexInfo.getIndexLength()), this.executor)
+                            .thenCompose(v -> loadStatistics(timer.getRemaining()))
+                            .thenRun(() -> log.info("{}: Initialized. State = {}, Stats = {}.", this.traceObjectId, this.state, this.statistics));
                 });
     }
 
@@ -230,6 +239,40 @@ public class BTreeIndex {
         setState(indexLength, rootPageOffset, rootPageLength);
     }
 
+    private CompletableFuture<Void> loadStatistics(Duration timeout) {
+        if (!this.maintainStatistics) {
+            // Disabled.
+            return CompletableFuture.completedFuture(null);
+        }
+
+        val s = this.state;
+        if (s.rootPageOffset == PagePointer.NO_OFFSET) {
+            this.statistics = Statistics.EMPTY;
+            log.debug("{}: Resetting stats due to index empty.", this.traceObjectId);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        long statsOffset = s.rootPageOffset + s.rootPageLength;
+        int statsLength = (int) Math.min(s.length - FOOTER_LENGTH - statsOffset, Integer.MAX_VALUE);
+        if (statsLength <= 0) {
+            // The Maintain Stats option was set, however this particular index does not support stats (because it was
+            // originally build with stats disabled or before stats were added).
+            this.maintainStatistics = false;
+            this.statistics = null;
+            log.debug("{}: Not loading stats due to legacy index not supporting stats.", this.traceObjectId);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        return this.read.apply(statsOffset, statsLength, false, timeout)
+                .thenAccept(data -> {
+                    try {
+                        this.statistics = Statistics.SERIALIZER.deserialize(data);
+                    } catch (IOException ex) {
+                        throw new CompletionException(ex);
+                    }
+                });
+    }
+
     /**
      * Looks up the value of a single key.
      *
@@ -244,7 +287,7 @@ public class BTreeIndex {
         TimeoutTimer timer = new TimeoutTimer(timeout);
 
         // Lookup the page where the Key should exist (if at all).
-        PageCollection pageCollection = new PageCollection(this.state.get().length);
+        PageCollection pageCollection = new PageCollection(this.state.length);
         return locatePage(key, pageCollection, timer)
                 .thenApplyAsync(page -> page.getPage().searchExact(key), this.executor);
     }
@@ -269,7 +312,7 @@ public class BTreeIndex {
         // where provided to us.
         ensureInitialized();
         TimeoutTimer timer = new TimeoutTimer(timeout);
-        PageCollection pageCollection = new PageCollection(this.state.get().length);
+        PageCollection pageCollection = new PageCollection(this.state.length);
         val gets = keys.stream()
                 .map(key -> locatePage(key, pageCollection, timer)
                         .thenApplyAsync(page -> page.getPage().searchExact(key), this.executor))
@@ -294,8 +337,8 @@ public class BTreeIndex {
         // Process the Entries in sorted order (by key); this makes the operation more efficient as we can batch-update
         // entries belonging to the same page.
         val toUpdate = entries.stream()
-                              .sorted((e1, e2) -> KEY_COMPARATOR.compare(e1.getKey(), e2.getKey()))
-                              .iterator();
+                .sorted((e1, e2) -> KEY_COMPARATOR.compare(e1.getKey(), e2.getKey()))
+                .iterator();
         return applyUpdates(toUpdate, timer)
                 .thenComposeAsync(pageCollection -> loadSmallestOffsetPage(pageCollection, timer)
                                 .thenRun(() -> processModifiedPages(pageCollection))
@@ -319,7 +362,7 @@ public class BTreeIndex {
     public AsyncIterator<List<PageEntry>> iterator(@NonNull ByteArraySegment firstKey, boolean firstKeyInclusive,
                                                    @NonNull ByteArraySegment lastKey, boolean lastKeyInclusive, Duration fetchTimeout) {
         ensureInitialized();
-        return new EntryIterator(firstKey, firstKeyInclusive, lastKey, lastKeyInclusive, this::locatePage, this.state.get().length, fetchTimeout);
+        return new EntryIterator(firstKey, firstKeyInclusive, lastKey, lastKeyInclusive, this::locatePage, this.state.length, fetchTimeout);
     }
 
     //endregion
@@ -336,7 +379,7 @@ public class BTreeIndex {
      * @return A CompletableFuture that will contain a PageCollection with all touched pages.
      */
     private CompletableFuture<UpdateablePageCollection> applyUpdates(Iterator<PageEntry> updates, TimeoutTimer timer) {
-        UpdateablePageCollection pageCollection = new UpdateablePageCollection(this.state.get().length);
+        UpdateablePageCollection pageCollection = new UpdateablePageCollection(this.state.length);
         AtomicReference<PageWrapper> lastPage = new AtomicReference<>(null);
         val lastPageUpdates = new ArrayList<PageEntry>();
         return Futures.loop(
@@ -353,7 +396,7 @@ public class BTreeIndex {
                                     // This key goes to a different page than the one we were looking at.
                                     if (last != null) {
                                         // Commit the outstanding updates.
-                                        last.getPage().update(lastPageUpdates);
+                                        last.setEntryCountDelta(last.getPage().update(lastPageUpdates));
                                     }
 
                                     // Update the pointers.
@@ -366,13 +409,14 @@ public class BTreeIndex {
                             });
                 },
                 this.executor)
-                      .thenApplyAsync(v -> {
-                          // We need not forget to apply the last batch of updates from the last page.
-                          if (lastPage.get() != null) {
-                              lastPage.get().getPage().update(lastPageUpdates);
-                          }
-                          return pageCollection;
-                      }, this.executor);
+                .thenApplyAsync(v -> {
+                    // We need not forget to apply the last batch of updates from the last page.
+                    PageWrapper last = lastPage.get();
+                    if (last != null) {
+                        last.setEntryCountDelta(last.getPage().update(lastPageUpdates));
+                    }
+                    return pageCollection;
+                }, this.executor);
     }
 
     /**
@@ -579,8 +623,8 @@ public class BTreeIndex {
         } else {
             // Update parent page's child pointers for modified pages.
             val toUpdate = context.getUpdatedPagePointers().stream()
-                                  .map(pp -> new PageEntry(pp.getKey(), serializePointer(pp)))
-                                  .collect(Collectors.toList());
+                    .map(pp -> new PageEntry(pp.getKey(), serializePointer(pp)))
+                    .collect(Collectors.toList());
             parentPage.getPage().update(toUpdate);
         }
     }
@@ -601,9 +645,9 @@ public class BTreeIndex {
         // Sanity check that our pageCollection has a somewhat correct view of the data index state. It is OK for it to
         // think the index length is less than what it actually is (since a concurrent update may have increased it), but
         // it is not a good sign if it thinks it's longer than the actual length.
-        Preconditions.checkArgument(pageCollection.getIndexLength() <= this.state.get().length, "Unexpected PageCollection.IndexLength.");
+        Preconditions.checkArgument(pageCollection.getIndexLength() <= this.state.length, "Unexpected PageCollection.IndexLength.");
 
-        if (this.state.get().rootPageOffset == PagePointer.NO_OFFSET && pageCollection.getCount() == 0) {
+        if (this.state.rootPageOffset == PagePointer.NO_OFFSET && pageCollection.getCount() == 0) {
             // No data. Return an empty (leaf) page, which will serve as the root for now.
             return CompletableFuture.completedFuture(pageCollection.insert(PageWrapper.wrapNew(createEmptyLeafPage(), null, null)));
         }
@@ -624,7 +668,7 @@ public class BTreeIndex {
      */
     private CompletableFuture<PageWrapper> locatePage(Function<BTreePage, PagePointer> getChildPointer, Predicate<PageWrapper> found,
                                                       PageCollection pageCollection, TimeoutTimer timer) {
-        AtomicReference<PagePointer> pagePointer = new AtomicReference<>(new PagePointer(null, this.state.get().rootPageOffset, this.state.get().rootPageLength));
+        AtomicReference<PagePointer> pagePointer = new AtomicReference<>(new PagePointer(null, this.state.rootPageOffset, this.state.rootPageLength));
         CompletableFuture<PageWrapper> result = new CompletableFuture<>();
         AtomicReference<PageWrapper> parentPage = new AtomicReference<>(null);
         Futures.loop(
@@ -641,10 +685,10 @@ public class BTreeIndex {
                             }
                         }),
                 this.executor)
-               .exceptionally(ex -> {
-                   result.completeExceptionally(ex);
-                   return null;
-               });
+                .exceptionally(ex -> {
+                    result.completeExceptionally(ex);
+                    return null;
+                });
 
         return result;
     }
@@ -747,7 +791,7 @@ public class BTreeIndex {
      * @return A CompletableFuture with a ByteArraySegment representing the contents of the page.
      */
     private CompletableFuture<ByteArraySegment> readPage(long offset, int length, Duration timeout) {
-        return this.read.apply(offset, length, timeout);
+        return this.read.apply(offset, length, true, timeout);
     }
 
     /**
@@ -757,12 +801,13 @@ public class BTreeIndex {
      * @param timeout        Timeout for the operation.
      * @return A CompletableFuture with a Long representing the current length of the index in the external data source.
      */
+    @SneakyThrows(IOException.class)
     private CompletableFuture<Long> writePages(UpdateablePageCollection pageCollection, Duration timeout) {
-        IndexState state = this.state.get();
+        IndexState state = this.state;
         Preconditions.checkState(state != null, "Cannot write without fetching the state first.");
 
         // Collect the data to be written.
-        val pages = new ArrayList<Map.Entry<Long, ByteArraySegment>>();
+        val pages = new ArrayList<WritePage>();
         val oldOffsets = new ArrayList<Long>();
         long offset = state.length;
         PageWrapper lastPage = null;
@@ -772,20 +817,38 @@ public class BTreeIndex {
             }
 
             // Collect the page, as well as its previous offset.
-            pages.add(new AbstractMap.SimpleImmutableEntry<>(offset, p.getPage().getContents()));
+            pages.add(new WritePage(offset, p.getPage().getContents(), true));
             if (p.getPointer() != null && p.getPointer().getOffset() >= 0) {
                 oldOffsets.add(p.getPointer().getOffset());
+                if (this.maintainStatistics && p.getParent() == null) {
+                    // Stats are stored immediately after the root page; mark that as obsolete as well.
+                    oldOffsets.add(p.getPointer().getOffset() + p.getPointer().getLength());
+                }
             }
 
             offset = p.getOffset() + p.getPage().getLength();
             lastPage = p;
         }
 
-        // Write a footer with information about locating the root page.
         Preconditions.checkArgument(lastPage != null && lastPage.getParent() == null, "Last page to be written is not the root page");
         Preconditions.checkArgument(pageCollection.getIndexLength() == offset, "IndexLength mismatch.");
+
+        // Update and store statistics - if required.
+        Statistics newStats;
+        if (this.maintainStatistics) {
+            // Calculate and store stats here.
+            newStats = this.statistics.update(pageCollection.getEntryCountDelta(), pageCollection.getPageCountDelta());
+            val sp = new WritePage(offset, Statistics.SERIALIZER.serialize(newStats), false);
+            pages.add(sp);
+            offset += sp.getContents().getLength();
+        } else {
+            // Stats are not maintained.
+            newStats = null;
+        }
+
+        // Write a footer with information about locating the root page.
         final long footerOffset = offset;
-        pages.add(new AbstractMap.SimpleImmutableEntry<>(footerOffset, getFooter(lastPage.getOffset(), lastPage.getPage().getLength())));
+        pages.add(new WritePage(footerOffset, getFooter(lastPage.getOffset(), lastPage.getPage().getLength()), false));
 
         // Collect the old footer's offset, as it will be replaced by a more recent value.
         long oldFooterOffset = getFooterOffset(state.length);
@@ -803,6 +866,7 @@ public class BTreeIndex {
         assert rootMinOffset >= 0 : "root.MinOffset not set";
         return this.write.apply(pages, oldOffsets, rootMinOffset, timeout)
                 .thenApply(indexLength -> {
+                    this.statistics = newStats;
                     setState(indexLength, rootOffset, rootLength);
                     assert footerOffset == getFooterOffset(indexLength); // This should fail any unit tests.
                     return footerOffset;
@@ -810,9 +874,9 @@ public class BTreeIndex {
     }
 
     private void setState(long length, long rootPageOffset, int rootPageLength) {
-        IndexState s = new IndexState(length, rootPageOffset, rootPageLength);
-        this.state.set(s);
-        log.debug("{}: IndexState: {}.", this.traceObjectId, s);
+        this.state = new IndexState(length, rootPageOffset, rootPageLength);
+        log.debug("{}: IndexState: {}, Stats: {}.", this.traceObjectId, this.state, this.statistics);
+        //System.out.println(String.format("%s: IndexState: %s, Stats: %s.", this.traceObjectId, this.state, this.statistics));
     }
 
     private long getFooterOffset(long indexLength) {
@@ -916,13 +980,14 @@ public class BTreeIndex {
         /**
          * Reads a single Page from an external data source.
          *
-         * @param offset  The offset of the desired Page.
-         * @param length  The length of the desired Page.
-         * @param timeout Timeout for the operation.
+         * @param offset      The offset of the desired Page.
+         * @param length      The length of the desired Page.
+         * @param cacheResult If true, the result of this operation should be cached if possible.
+         * @param timeout     Timeout for the operation.
          * @return A CompletableFuture that, when completed, will contain a ByteArraySegment that represents the contents
          * of the desired Page.
          */
-        CompletableFuture<ByteArraySegment> apply(long offset, int length, Duration timeout);
+        CompletableFuture<ByteArraySegment> apply(long offset, int length, boolean cacheResult, Duration timeout);
     }
 
     /**
@@ -933,7 +998,7 @@ public class BTreeIndex {
         /**
          * Persists the contents of multiple, contiguous Pages to an external data source.
          *
-         * @param pageContents    An ordered List of Offset-ByteArraySegments pairs representing the contents of the
+         * @param pageContents    An ordered List of {@link WritePage} representing the contents of the
          *                        individual pages mapped to their assigned Offsets. The list is ordered by Offset (Keys).
          *                        All entries should be contiguous (an entry's offset is equal to the previous entry's
          *                        offset + the previous entry's length).
@@ -947,8 +1012,14 @@ public class BTreeIndex {
          * @return A CompletableFuture that, when completed, will contain the current length (in bytes) of the index in the
          * external data source.
          */
-        CompletableFuture<Long> apply(List<Map.Entry<Long, ByteArraySegment>> pageContents, Collection<Long> obsoleteOffsets,
-                                      long truncateOffset, Duration timeout);
+        CompletableFuture<Long> apply(List<WritePage> pageContents, Collection<Long> obsoleteOffsets, long truncateOffset, Duration timeout);
+    }
+
+    @Data
+    public static class WritePage {
+        private final long offset;
+        private final ByteArraySegment contents;
+        private final boolean cache;
     }
 
     //endregion

--- a/common_server/src/main/java/io/pravega/common/util/btree/BTreePage.java
+++ b/common_server/src/main/java/io/pravega/common/util/btree/BTreePage.java
@@ -375,20 +375,21 @@ class BTreePage {
      * * Will have all entries sorted by Key
      *
      * @param entries The Entries to insert or update. This List must be sorted by {@link PageEntry#getKey()}.
+     * @return A delta (negative, zero or positive) indicating the change in {@link #getCount()} as a result of this update.
      * @throws IllegalDataFormatException If any of the entries do not conform to the Key/Value size constraints.
      * @throws IllegalArgumentException   If the entries are not sorted by {@link PageEntry#getKey()}.
      */
-    void update(@NonNull List<PageEntry> entries) {
+    int update(@NonNull List<PageEntry> entries) {
         if (entries.isEmpty()) {
             // Nothing to do.
-            return;
+            return 0;
         }
 
         // Apply the in-place updates and collect the new entries to be added.
         val ci = applyUpdates(entries);
         if (ci.changes.isEmpty()) {
             // Nothing else to change. We've already updated the keys in-place.
-            return;
+            return 0;
         }
 
         val newPage = applyInsertsAndRemovals(ci);
@@ -399,7 +400,9 @@ class BTreePage {
         this.data = newPage.data;
         this.contents = newPage.contents;
         this.footer = newPage.footer;
+        val delta = newPage.count - this.count;
         this.count = newPage.count;
+        return delta;
     }
 
     /**

--- a/common_server/src/main/java/io/pravega/common/util/btree/PageEntry.java
+++ b/common_server/src/main/java/io/pravega/common/util/btree/PageEntry.java
@@ -16,6 +16,7 @@
 package io.pravega.common.util.btree;
 
 import io.pravega.common.util.ByteArraySegment;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ import lombok.RequiredArgsConstructor;
  * A Key-Value pair of ByteArraySegments that represent an entry in a B+Tree Page.
  */
 @Getter
+@EqualsAndHashCode
 @RequiredArgsConstructor
 public class PageEntry {
     /**

--- a/common_server/src/main/java/io/pravega/common/util/btree/PageWrapper.java
+++ b/common_server/src/main/java/io/pravega/common/util/btree/PageWrapper.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Wraps a BTreePage by adding additional metadata, such as parent information and offset.
@@ -39,6 +40,9 @@ class PageWrapper {
     private final AtomicLong offset;
     private final AtomicLong minOffset;
     private final AtomicBoolean needsFirstKeyUpdate;
+    @Getter
+    @Setter
+    private volatile int entryCountDelta;
 
     //endregion
 
@@ -52,6 +56,7 @@ class PageWrapper {
         this.offset = new AtomicLong(this.pointer == null ? PagePointer.NO_OFFSET : this.pointer.getOffset());
         this.minOffset = new AtomicLong(this.pointer == null ? PagePointer.NO_OFFSET : this.pointer.getMinOffset());
         this.needsFirstKeyUpdate = new AtomicBoolean(false);
+        this.entryCountDelta = 0;
     }
 
     /**
@@ -87,13 +92,6 @@ class PageWrapper {
      */
     BTreePage getPage() {
         return this.page.get();
-    }
-
-    /**
-     * Gets a value indicating whether the wrapped BTreePage is new or has been modified since it was loaded.
-     */
-    boolean isModified() {
-        return isNewPage() || getOffset() != (this.pointer == null ? PagePointer.NO_OFFSET : this.pointer.getOffset());
     }
 
     /**

--- a/common_server/src/main/java/io/pravega/common/util/btree/Statistics.java
+++ b/common_server/src/main/java/io/pravega/common/util/btree/Statistics.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.common.util.btree;
+
+import com.google.common.base.Preconditions;
+import io.pravega.common.ObjectBuilder;
+import io.pravega.common.io.serialization.RevisionDataInput;
+import io.pravega.common.io.serialization.RevisionDataOutput;
+import io.pravega.common.io.serialization.VersionedSerializer;
+import java.io.IOException;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * Statistics about a {@link BTreeIndex}.
+ */
+@Getter
+@Builder
+@EqualsAndHashCode
+public final class Statistics {
+    /**
+     * Empty Statistics.
+     */
+    static final Statistics EMPTY = new Statistics(0, 0);
+    static final Serializer SERIALIZER = new Serializer();
+    /**
+     * Number of Data Entries (only counting within Data Pages - does not include Index page pointers).
+     */
+    private final long entryCount;
+    /**
+     * Number of pages (Data + Entry).
+     */
+    private final long pageCount;
+
+    /**
+     * Creates a new {@link Statistics} object by applying the given deltas to the current {@link Statistics} object.
+     *
+     * @param entryCountDelta The delta to apply to {@link #getEntryCount()}.
+     * @param pageCountDelta  The delta to apply to {@link #getPageCount()}.
+     * @return A new {@link Statistics} object.
+     */
+    Statistics update(int entryCountDelta, int pageCountDelta) {
+        long newEntryCount = this.entryCount + entryCountDelta;
+        long newPageCount = this.pageCount + pageCountDelta;
+        Preconditions.checkArgument(newEntryCount >= 0,
+                "New Entry Count would be negative (EntryCount=%s, Delta=%s)", this.entryCount, entryCountDelta);
+        Preconditions.checkArgument(newPageCount >= 0,
+                "New Page Count would be negative (PageCount=%s, Delta=%s)", this.pageCount, pageCountDelta);
+        return new Statistics(newEntryCount, newPageCount);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("EntryCount = %s, PageCount = %s", this.entryCount, this.pageCount);
+    }
+
+    static class StatisticsBuilder implements ObjectBuilder<Statistics> {
+    }
+
+    static class Serializer extends VersionedSerializer.WithBuilder<Statistics, StatisticsBuilder> {
+        @Override
+        protected StatisticsBuilder newBuilder() {
+            return builder();
+        }
+
+        @Override
+        protected byte getWriteVersion() {
+            return 0;
+        }
+
+        @Override
+        protected void declareVersions() {
+            version(0).revision(0, this::write00, this::read00);
+        }
+
+        private void write00(Statistics s, RevisionDataOutput target) throws IOException {
+            target.writeCompactLong(s.entryCount);
+            target.writeCompactLong(s.pageCount);
+        }
+
+        private void read00(RevisionDataInput source, StatisticsBuilder b) throws IOException {
+            b.entryCount(source.readCompactLong());
+            b.pageCount(source.readCompactLong());
+        }
+    }
+}

--- a/common_server/src/test/java/io/pravega/common/util/btree/BTreePageTests.java
+++ b/common_server/src/test/java/io/pravega/common/util/btree/BTreePageTests.java
@@ -67,7 +67,8 @@ public class BTreePageTests {
 
             // Apply to the page.
             val updateValues = updateKeys.stream().collect(Collectors.toMap(key -> key, key -> ((long) entries.size() << 32) + key));
-            page.update(serialize(updateValues, true));
+            int delta = page.update(serialize(updateValues, true));
+            Assert.assertEquals("Unexpected number of entries reported as inserted.", half, delta);
 
             // Update our expected values.
             entries.putAll(updateValues);
@@ -105,7 +106,10 @@ public class BTreePageTests {
                 }
             }
 
-            page.update(toDelete(serialize(deleteKeys, true)));
+            val keys = serialize(deleteKeys, true);
+            val existingKeys = keys.stream().filter(k -> page.searchExact(k) != null).count();
+            int delta = page.update(toDelete(keys));
+            Assert.assertEquals("Unexpected number of entries reported as deleted.", -existingKeys, delta);
             deleteKeys.forEach(remainingEntries::remove);
 
             checkPage(page, remainingEntries);
@@ -135,6 +139,7 @@ public class BTreePageTests {
         val rnd = new Random(0);
         for (int iteration = 0; iteration < iterationCount; iteration++) {
             val changes = new HashMap<Integer, Long>();
+            int expectedDelta = 0;
 
             // Generate inserts. We want to make sure we don't insert existing values.
             for (int i = 0; i < insertsPerIteration; i++) {
@@ -144,10 +149,13 @@ public class BTreePageTests {
                 } while (expectedValues.containsKey(key) && changes.containsKey(key));
 
                 changes.put(key, (long) key + 1);
+                if (page.searchExact(serializeInt(key)) == null) {
+                    expectedDelta++;
+                }
             }
 
             // Generate updates.
-            val allKeys = new ArrayList<Integer>(expectedValues.keySet());
+            val allKeys = new ArrayList<>(expectedValues.keySet());
             for (int i = 0; i < updatesPerIteration; i++) {
                 if (allKeys.size() == 0) {
                     break;
@@ -169,6 +177,7 @@ public class BTreePageTests {
                 int key = allKeys.get(idx);
                 allKeys.remove(idx); // Remove at index.
                 changes.put(key, null);
+                expectedDelta--;
             }
 
             // Store changes.
@@ -181,7 +190,8 @@ public class BTreePageTests {
             });
 
             // Apply changes.
-            page.update(serialize(changes, true));
+            int delta = page.update(serialize(changes, true));
+            Assert.assertEquals("Unexpected number of entries reported as changed.", expectedDelta, delta);
             checkPage(page, expectedValues);
         }
 

--- a/common_server/src/test/java/io/pravega/common/util/btree/StatisticsTests.java
+++ b/common_server/src/test/java/io/pravega/common/util/btree/StatisticsTests.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.common.util.btree;
+
+import io.pravega.test.common.AssertExtensions;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link Statistics} class.
+ */
+public class StatisticsTests {
+
+    @Test
+    public void testUpdate() {
+        val s1 = Statistics.EMPTY;
+        Assert.assertEquals(0, s1.getEntryCount());
+        Assert.assertEquals(0, s1.getPageCount());
+
+        val s2 = s1.update(12, 19);
+        Assert.assertEquals(12, s2.getEntryCount());
+        Assert.assertEquals(19, s2.getPageCount());
+
+        val s3 = s2.update(-4, -9);
+        Assert.assertEquals(8, s3.getEntryCount());
+        Assert.assertEquals(10, s3.getPageCount());
+
+        val r = new AtomicReference<Statistics>();
+        AssertExtensions.assertThrows("", () -> r.set(s3.update(-10, 0)), ex -> ex instanceof IllegalArgumentException);
+        AssertExtensions.assertThrows("", () -> r.set(s3.update(0, -11)), ex -> ex instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void testSerializer() throws Exception {
+        val s1 = Statistics.builder().entryCount(10).pageCount(11).build();
+        val data = Statistics.SERIALIZER.serialize(s1);
+        val s2 = Statistics.SERIALIZER.deserialize(data);
+        Assert.assertEquals(s1, s2);
+    }
+}

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/AttributeIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/attributes/AttributeIndexTests.java
@@ -1281,13 +1281,13 @@ public class AttributeIndexTests extends ThreadPooledTestSuite {
         }
 
         @Override
-        CompletableFuture<ByteArraySegment> readPageFromStorage(SegmentHandle handle, long offset, int length, Duration timeout) {
+        CompletableFuture<ByteArraySegment> readPageFromStorage(SegmentHandle handle, long offset, int length, boolean shouldCache, Duration timeout) {
             val interceptor = this.readPageInterceptor;
             if (interceptor != null) {
                 return interceptor.apply(handle, offset, length)
-                        .thenCompose(v -> super.readPageFromStorage(handle, offset, length, timeout));
+                        .thenCompose(v -> super.readPageFromStorage(handle, offset, length, shouldCache, timeout));
             }
-            return super.readPageFromStorage(handle, offset, length, timeout);
+            return super.readPageFromStorage(handle, offset, length, shouldCache, timeout);
         }
     }
 

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -354,7 +354,8 @@ public class AssertExtensions {
         for (int i = 0; i < expected.size(); i++) {
             T expectedItem = expected.get(i);
             T actualItem = actual.get(i);
-            Assert.assertTrue(String.format("%s Elements at index %d differ. Expected '%s', found '%s'.", message, i, expectedItem, actualItem), tester.test(expectedItem, actualItem));
+            Assert.assertTrue(String.format("%s Elements at index %d differ. Expected '%s', found '%s'.", message, i, expectedItem, actualItem),
+                    (expectedItem == null && actualItem == null) || tester.test(expectedItem, actualItem));
         }
     }
 


### PR DESCRIPTION
**Change log description**  
Keeping track of the number of Extended Attributes per Segment (if enabled)

**Purpose of the change**  
Fixes #6042.

**What the code does**  
BTreeIndex has a new option named `maintainStatistics`. If enabled, it will keep track of the number of Entries and Pages (nodes) within it. This feature only works if the BTreeIndex has been originally created with this option (so upgrading existing indices will not work - nor is it required). 

The Statistics are stored immediately after the Root Page (and implicitly below the Index Footer/Root Pointer) every time the index persists an update. This is loaded in the `initialize` method (if it exists) and maintained in memory for quick reference.

This is not yet wired up into upstream code. When implemented in a subsequent PR, the `SegmentAttributeBTreeIndex` will expose the `BTreeIndex.getStatistics().getEntryCount()` as its own method, then in `StreamSegmentContainer.DirectSegmentWrapper`, we'll expose it for whomever needs it.

As of right now, this feature is disabled for all segments. When Fixed-Key-Length Table Segments are introduced (next PR), we'll enable it for those ones only.

**How to verify it**  
Existing unit tests updated to verify new functionality. New unit tests added to validate backward compatibility.
