### PR TITLE
Issue 6045: Storage - StorageReadManager does not correctly handle failures in Storage::openRead

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StorageReadManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StorageReadManager.java
@@ -201,7 +201,12 @@ public class StorageReadManager implements AutoCloseable {
     private CompletableFuture<SegmentHandle> getHandle() {
         synchronized (this.lock) {
             if (this.handle == null) {
-                this.handle = storage.openRead(this.segmentName);
+                return storage.openRead(this.segmentName)
+                        .thenApply(h -> {
+                            // only cache when successful.
+                            this.handle =  CompletableFuture.completedFuture(h);
+                            return h;
+                        });
             }
 
             return this.handle;


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Correctly handle failures in Storage::openRead when initializing StorageReadManager by caching handle only when openRead call is successful.
**Purpose of the change**  
Fixes #6045 

**What the code does**  
Cache handle only when openRead call is successful.

Failures in openRead are rare and may include mostly transient but also non-transient errors.  The best course of action here is to not cache exception state.

**How to verify it**  
Existing unit test has been modified for given scenario. 
