### PR TITLE
SLTS: cherry-pick 6045 to r0.9

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StorageReadManager.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StorageReadManager.java
@@ -195,7 +195,15 @@ public class StorageReadManager implements AutoCloseable {
     private CompletableFuture<SegmentHandle> getHandle() {
         synchronized (this.lock) {
             if (this.handle == null) {
-                this.handle = storage.openRead(this.segmentName);
+                this.handle = storage.openRead(this.segmentName)
+                        .whenComplete((h, ex) -> {
+                            if (ex != null) {
+                                synchronized (this.lock) {
+                                    log.debug("{}: storage.openRead failed for {}. Resetting handle. {}", this.traceObjectId, this.segmentName, ex);
+                                    this.handle = null;
+                                }
+                            }
+                        });
             }
 
             return this.handle;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StorageReadManagerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/reading/StorageReadManagerTests.java
@@ -106,20 +106,23 @@ public class StorageReadManagerTests extends ThreadPooledTestSuite {
         @Cleanup
         Storage storage = InMemoryStorageFactory.newStorage(executorService());
         storage.initialize(1);
-        byte[] segmentData = populateSegment(storage);
-        @Cleanup
-        StorageReadManager reader = new StorageReadManager(SEGMENT_METADATA, storage, executorService());
 
         // Segment does not exist.
         AssertExtensions.assertThrows(
                 "Request was not failed when StreamSegment does not exist.",
                 () -> {
-                    SegmentMetadata sm = new StreamSegmentMetadata("foo", 0, 0);
+                    SegmentMetadata sm = new StreamSegmentMetadata(SEGMENT_METADATA.getName(), 0, 0);
                     @Cleanup
                     StorageReadManager nonExistentReader = new StorageReadManager(sm, storage, executorService());
                     sendRequest(nonExistentReader, 0, 1).join();
                 },
                 ex -> ex instanceof StreamSegmentNotExistsException);
+
+        // Now create segment, it should exist and request should succeed.
+        byte[] segmentData = populateSegment(storage);
+        @Cleanup
+        StorageReadManager reader = new StorageReadManager(SEGMENT_METADATA, storage, executorService());
+        sendRequest(reader, 0, 1).join();
 
         // Invalid read offset.
         AssertExtensions.assertSuppliedFutureThrows(
@@ -132,6 +135,9 @@ public class StorageReadManagerTests extends ThreadPooledTestSuite {
                 "Request was not failed when bad offset + length was provided.",
                 () -> sendRequest(reader, segmentData.length - 1, 2),
                 ex -> ex instanceof ArrayIndexOutOfBoundsException);
+
+        // Make sure valid request succeeds after invalid one
+        sendRequest(reader, 0, 1).join();
     }
 
     private CompletableFuture<StorageReadManager.Result> sendRequest(StorageReadManager reader, long offset, int length) {


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

Co-authored-by: Andrei Paduroiu <andreipaduroiu@users.noreply.github.com>

**Change log description**  
Cherry pick #6048 to r0.9 branch

**Purpose of the change**  
Fixes #6050 

**What the code does**  
Cherry pick following change 

> Issue 6045: Storage - StorageReadManager does not correctly handle failures in Storage::openRead (#6048)
> 
> Correctly handle failures in Storage::openRead when initializing StorageReadManager by caching handle only when openRead call is successful
> 

**How to verify it**  
Build should pass
