### PR TITLE
Issue 6041: Default value of storage.metadata.rollover.size.bytes.max is too big. Change it to 128MB

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -144,8 +144,8 @@ pravegaservice.dataLog.impl.name=BOOKKEEPER
 
 # The maximum size of a single Segment Chunk in Storage for metadata segments.
 # Valid values: non-negative long less than 4611686018427387904.
-# Default value: 4611686018427387903
-# storage.metadata.rollover.size.bytes.max=4611686018427387903
+# Default value: 134217728 (128 MB)
+# storage.metadata.rollover.size.bytes.max=134217728
 
 # Whether the append functionality is enabled.
 # Valid values: true, false

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
@@ -43,7 +43,7 @@ public class ChunkedSegmentStorageConfig {
     public static final Property<Boolean> APPENDS_ENABLED = Property.named("appends.enable", true);
     public static final Property<Boolean> LAZY_COMMIT_ENABLED = Property.named("commit.lazy.enable", true);
     public static final Property<Boolean> INLINE_DEFRAG_ENABLED = Property.named("defrag.inline.enable", true);
-    public static final Property<Long> DEFAULT_ROLLOVER_SIZE = Property.named("metadata.rollover.size.bytes.max", SegmentRollingPolicy.MAX_CHUNK_LENGTH);
+    public static final Property<Long> DEFAULT_ROLLOVER_SIZE = Property.named("metadata.rollover.size.bytes.max", 128 * 1024 * 1024L);
     public static final Property<Integer> SELF_CHECK_LATE_WARNING_THRESHOLD = Property.named("self.check.late", 100);
     public static final Property<Integer> GARBAGE_COLLECTION_DELAY = Property.named("garbage.collection.delay.seconds", 60);
     public static final Property<Integer> GARBAGE_COLLECTION_MAX_CONCURRENCY = Property.named("garbage.collection.concurrency.max", 10);
@@ -65,7 +65,7 @@ public class ChunkedSegmentStorageConfig {
     public static final ChunkedSegmentStorageConfig DEFAULT_CONFIG = ChunkedSegmentStorageConfig.instanceBuilder()
             .minSizeLimitForConcat(0L)
             .maxSizeLimitForConcat(Long.MAX_VALUE)
-            .defaultRollingPolicy(SegmentRollingPolicy.NO_ROLLING)
+            .storageMetadataRollingPolicy(new SegmentRollingPolicy(128 * 1024 * 1024L))
             .maxBufferSizeForChunkDataTransfer(1024 * 1024)
             .maxIndexedSegments(1024)
             .maxIndexedChunksPerSegment(1024)
@@ -105,11 +105,11 @@ public class ChunkedSegmentStorageConfig {
     final private long maxSizeLimitForConcat;
 
     /**
-     * A SegmentRollingPolicy to apply to every StreamSegment that does not have its own policy defined.
+     * A SegmentRollingPolicy to apply to storage metadata segments.
      */
     @Getter
     @NonNull
-    final private SegmentRollingPolicy defaultRollingPolicy;
+    final private SegmentRollingPolicy storageMetadataRollingPolicy;
 
     /**
      * Maximum size for the buffer used while copying of data from one chunk to other.
@@ -255,8 +255,7 @@ public class ChunkedSegmentStorageConfig {
         this.maxIndexedSegments = properties.getInt(MAX_INDEXED_SEGMENTS);
         this.maxIndexedChunksPerSegment = properties.getInt(MAX_INDEXED_CHUNKS_PER_SEGMENTS);
         this.maxIndexedChunks = properties.getInt(MAX_INDEXED_CHUNKS);
-        long defaultMaxLength = properties.getLong(DEFAULT_ROLLOVER_SIZE);
-        this.defaultRollingPolicy = new SegmentRollingPolicy(defaultMaxLength);
+        this.storageMetadataRollingPolicy = new SegmentRollingPolicy(properties.getLong(DEFAULT_ROLLOVER_SIZE));
         this.lateWarningThresholdInMillis = properties.getInt(SELF_CHECK_LATE_WARNING_THRESHOLD);
         this.garbageCollectionDelay = Duration.ofSeconds(properties.getInt(GARBAGE_COLLECTION_DELAY));
         this.garbageCollectionMaxConcurrency = properties.getInt(GARBAGE_COLLECTION_MAX_CONCURRENCY);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -642,7 +642,7 @@ public class SystemJournal {
                 SegmentMetadata segmentMetadata = SegmentMetadata.builder()
                         .name(systemSegment)
                         .ownerEpoch(epoch)
-                        .maxRollinglength(config.getDefaultRollingPolicy().getMaxLength())
+                        .maxRollinglength(config.getStorageMetadataRollingPolicy().getMaxLength())
                         .build();
                 segmentMetadata.setActive(true)
                         .setOwnershipChanged(true)

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
@@ -59,7 +59,7 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertEquals(config.getMaxIndexedSegments(), 4);
         Assert.assertEquals(config.getMaxIndexedChunks(), 5);
         Assert.assertEquals(config.getMaxIndexedChunksPerSegment(), 6);
-        Assert.assertEquals(config.getDefaultRollingPolicy().getMaxLength(), 7);
+        Assert.assertEquals(config.getStorageMetadataRollingPolicy().getMaxLength(), 7);
         Assert.assertEquals(config.getLateWarningThresholdInMillis(), 8);
         Assert.assertEquals(config.getGarbageCollectionDelay().toSeconds(), 9);
         Assert.assertEquals(config.getGarbageCollectionMaxQueueSize(), 10);
@@ -90,7 +90,7 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertEquals(config.getMaxIndexedSegments(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxIndexedSegments());
         Assert.assertEquals(config.getMaxIndexedChunks(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxIndexedChunks());
         Assert.assertEquals(config.getMaxIndexedChunksPerSegment(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxIndexedChunksPerSegment());
-        Assert.assertEquals(config.getDefaultRollingPolicy().getMaxLength(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getDefaultRollingPolicy().getMaxLength());
+        Assert.assertEquals(config.getStorageMetadataRollingPolicy().getMaxLength(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getStorageMetadataRollingPolicy().getMaxLength());
         Assert.assertEquals(config.getLateWarningThresholdInMillis(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getLateWarningThresholdInMillis());
         Assert.assertEquals(config.getGarbageCollectionDelay(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getGarbageCollectionDelay());
         Assert.assertEquals(config.getGarbageCollectionMaxConcurrency(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getGarbageCollectionMaxConcurrency());

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageMockTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageMockTests.java
@@ -73,7 +73,7 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
         String concatSegmentName = "concat";
 
         SegmentRollingPolicy policy = new SegmentRollingPolicy(2); // Force rollover after every 2 byte.
-        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().defaultRollingPolicy(policy).build();
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().storageMetadataRollingPolicy(policy).build();
 
         @Cleanup
         BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
@@ -218,7 +218,7 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
         String testSegmentName = "test";
         String concatSegmentName = "concat";
         SegmentRollingPolicy policy = new SegmentRollingPolicy(2); // Force rollover after every 2 byte.
-        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().defaultRollingPolicy(policy).build();
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().storageMetadataRollingPolicy(policy).build();
         @Cleanup
         BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
         spyMetadataStore.setMaxEntriesInTxnBuffer(0);
@@ -308,7 +308,7 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
     public void testIOExceptionDuringWrite() throws Exception {
         String testSegmentName = "test";
         SegmentRollingPolicy policy = new SegmentRollingPolicy(2); // Force rollover after every 2 byte.
-        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().defaultRollingPolicy(policy).build();
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().storageMetadataRollingPolicy(policy).build();
 
         @Cleanup
         BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
@@ -377,7 +377,7 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
         String testSegmentName = "test";
         SegmentRollingPolicy policy = new SegmentRollingPolicy(2); // Force rollover after every 2 byte.
         val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
-                .defaultRollingPolicy(policy)
+                .storageMetadataRollingPolicy(policy)
                 .garbageCollectionDelay(Duration.ZERO)
                 .build();
         @Cleanup

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -148,7 +148,6 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
         val chunkStorage = createChunkStorage();
         @Cleanup
         val metadataStore = createMetadataStore();
-        val policy = SegmentRollingPolicy.NO_ROLLING;
         val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG;
         @Cleanup
         val chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, chunkStorage, metadataStore, executorService(), config);
@@ -159,14 +158,12 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
 
         Assert.assertNotNull(chunkedSegmentStorage.getMetadataStore());
         Assert.assertEquals(chunkStorage, chunkedSegmentStorage.getChunkStorage());
-        Assert.assertEquals(policy, chunkedSegmentStorage.getConfig().getDefaultRollingPolicy());
         Assert.assertEquals(1, chunkedSegmentStorage.getEpoch());
 
         Assert.assertEquals(metadataStore, chunkedSegmentStorage.getMetadataStore());
         Assert.assertEquals(chunkStorage, chunkedSegmentStorage.getChunkStorage());
-        Assert.assertEquals(policy, chunkedSegmentStorage.getConfig().getDefaultRollingPolicy());
         Assert.assertNotNull(chunkedSegmentStorage.getSystemJournal());
-        Assert.assertEquals(chunkedSegmentStorage.getSystemJournal().getConfig().getDefaultRollingPolicy(), policy);
+        Assert.assertEquals(chunkedSegmentStorage.getSystemJournal().getConfig().getStorageMetadataRollingPolicy(), chunkedSegmentStorage.getConfig().getStorageMetadataRollingPolicy());
         Assert.assertEquals(1, chunkedSegmentStorage.getEpoch());
         Assert.assertEquals(CONTAINER_ID, chunkedSegmentStorage.getContainerId());
         Assert.assertEquals(0, chunkedSegmentStorage.getConfig().getMinSizeLimitForConcat());

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -78,7 +78,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
     private ChunkedSegmentStorageConfig.ChunkedSegmentStorageConfigBuilder getDefaultConfigBuilder(SegmentRollingPolicy policy) {
         return ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .selfCheckEnabled(true)
-                .defaultRollingPolicy(policy);
+                .storageMetadataRollingPolicy(policy);
     }
 
     protected String[] getSystemSegments(String systemSegmentName) {
@@ -108,7 +108,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
 
         //Assert.assertEquals(epoch, journal.getEpoch());
         Assert.assertEquals(containerId, journal.getContainerId());
-        Assert.assertEquals(policy.getMaxLength(), journal.getConfig().getDefaultRollingPolicy().getMaxLength());
+        Assert.assertEquals(policy.getMaxLength(), journal.getConfig().getStorageMetadataRollingPolicy().getMaxLength());
         //Assert.assertEquals(epoch, journal.getEpoch());
         Assert.assertEquals(0, journal.getCurrentFileIndex().get());
 


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Issue 6041: Default value of storage.metadata.rollover.size.bytes.max is too big. Change it to 128MB

**Purpose of the change**  
Fixes #6041

**What the code does**  
Default value of storage.metadata.rollover.size.bytes.max is too big. Change it to 128MB
Rename the variable to a more meaningful name and update the comment.

**How to verify it**  
Build should pass.
