### PR TITLE
Issue 6004: Change Retry predicate for Controller Events so they are always retried unless on specific exceptions

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
@@ -21,6 +21,7 @@ import io.pravega.common.concurrent.Futures;
 import io.pravega.common.tracing.RequestTag;
 import io.pravega.common.util.Retry;
 import io.pravega.controller.eventProcessor.impl.SerializedRequestHandler;
+import io.pravega.controller.store.stream.EpochTransitionOperationExceptions;
 import io.pravega.controller.store.stream.OperationContext;
 import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
@@ -66,8 +67,15 @@ import static io.pravega.controller.eventProcessor.impl.EventProcessorHelper.wit
 @Slf4j
 public abstract class AbstractRequestProcessor<T extends ControllerEvent> extends SerializedRequestHandler<T> 
         implements StreamRequestProcessor {
-    protected static final Predicate<Throwable> OPERATION_NOT_ALLOWED_PREDICATE = e -> Exceptions.unwrap(e) 
-            instanceof StoreException.OperationNotAllowedException;
+    protected static final Predicate<Throwable> OPERATION_NOT_ALLOWED_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException;
+    protected static final Predicate<Throwable> ILLEGAL_STATE_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.IllegalStateException;
+    protected static final Predicate<Throwable> DATA_NOT_FOUND_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException;
+    protected static final Predicate<Throwable> VM_ERROR_PREDICATE = e -> Exceptions.unwrap(e) instanceof java.lang.VirtualMachineError;
+    protected static final Predicate<Throwable> SEGMENT_NOT_FOUND_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.DataContainerNotFoundException;
+    protected static final Predicate<Throwable> EVENT_RETRY_PREDICATE = OPERATION_NOT_ALLOWED_PREDICATE.or(ILLEGAL_STATE_PREDICATE).or(DATA_NOT_FOUND_PREDICATE)
+                                                                            .or(SEGMENT_NOT_FOUND_PREDICATE).or(VM_ERROR_PREDICATE).negate();
+    protected static final Predicate<Throwable> SCALE_EVENT_RETRY_PREDICATE = EVENT_RETRY_PREDICATE
+                                                                                .or(e -> e instanceof EpochTransitionOperationExceptions.ConflictException).negate();
 
     protected final StreamMetadataStore streamMetadataStore;
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -87,7 +87,7 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
 
     @Override
     public CompletableFuture<Void> processCommitTxnRequest(CommitEvent event) {
-        return withCompletion(this, event, event.getScope(), event.getStream(), OPERATION_NOT_ALLOWED_PREDICATE);
+        return withCompletion(this, event, event.getScope(), event.getStream(), EVENT_RETRY_PREDICATE);
     }
 
     /**

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
@@ -16,7 +16,6 @@
 package io.pravega.controller.server.eventProcessor.requesthandlers;
 
 import io.pravega.common.tracing.TagLogger;
-import io.pravega.controller.store.stream.EpochTransitionOperationExceptions;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.shared.controller.event.AutoScaleEvent;
 import io.pravega.shared.controller.event.ControllerEvent;
@@ -80,7 +79,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
         log.info(scaleOpEvent.getRequestId(), "Processing scale request for stream {}/{}", scaleOpEvent.getScope(), 
                 scaleOpEvent.getStream());
         return withCompletion(scaleOperationTask, scaleOpEvent, scaleOpEvent.getScope(), scaleOpEvent.getStream(),
-                OPERATION_NOT_ALLOWED_PREDICATE.or(e -> e instanceof EpochTransitionOperationExceptions.ConflictException))
+                SCALE_EVENT_RETRY_PREDICATE)
                 .thenAccept(v -> {
                     log.info(scaleOpEvent.getRequestId(), "Processing scale request for stream {}/{} complete",
                             scaleOpEvent.getScope(), scaleOpEvent.getStream());
@@ -92,7 +91,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
         log.info(updateStreamEvent.getRequestId(), "Processing update request for stream {}/{}",  
                 updateStreamEvent.getScope(), updateStreamEvent.getStream());
         return withCompletion(updateStreamTask, updateStreamEvent, updateStreamEvent.getScope(), updateStreamEvent.getStream(),
-                OPERATION_NOT_ALLOWED_PREDICATE)
+                EVENT_RETRY_PREDICATE)
                 .thenAccept(v -> {
                     log.info(updateStreamEvent.getRequestId(), "Processing update request for stream {}/{} complete", 
                             updateStreamEvent.getScope(), updateStreamEvent.getStream());
@@ -104,7 +103,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
         log.info(truncateStreamEvent.getRequestId(), "Processing truncate request for stream {}/{}", 
                 truncateStreamEvent.getScope(), truncateStreamEvent.getStream());
         return withCompletion(truncateStreamTask, truncateStreamEvent, truncateStreamEvent.getScope(), truncateStreamEvent.getStream(),
-                OPERATION_NOT_ALLOWED_PREDICATE)
+                EVENT_RETRY_PREDICATE)
                 .thenAccept(v -> {
                     log.info(truncateStreamEvent.getRequestId(), "Processing truncate request for stream {}/{} complete", 
                             truncateStreamEvent.getScope(), truncateStreamEvent.getStream());
@@ -116,7 +115,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
         log.info(sealStreamEvent.getRequestId(), "Processing seal request for stream {}/{}", 
                 sealStreamEvent.getScope(), sealStreamEvent.getStream());
         return withCompletion(sealStreamTask, sealStreamEvent, sealStreamEvent.getScope(), sealStreamEvent.getStream(),
-                OPERATION_NOT_ALLOWED_PREDICATE)
+                EVENT_RETRY_PREDICATE)
                 .thenAccept(v -> {
                     log.info(sealStreamEvent.getRequestId(), "Processing seal request for stream {}/{} complete", 
                             sealStreamEvent.getScope(), sealStreamEvent.getStream());
@@ -128,7 +127,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
         log.info(deleteStreamEvent.getRequestId(), "Processing delete request for stream {}/{}", 
                 deleteStreamEvent.getScope(), deleteStreamEvent.getStream());
         return withCompletion(deleteStreamTask, deleteStreamEvent, deleteStreamEvent.getScope(), deleteStreamEvent.getStream(),
-                OPERATION_NOT_ALLOWED_PREDICATE)
+                EVENT_RETRY_PREDICATE)
                 .thenAccept(v -> {
                     log.info(deleteStreamEvent.getRequestId(), "Processing delete request for stream {}/{} complete", 
                             deleteStreamEvent.getScope(), deleteStreamEvent.getStream());


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
The Event Processor framework on Controller processes Controller Events. If any exception is thrown during event processing, the Event is retried, unless the Exception is _StoreException.OperationNotAllowedException_, in which case the event processing is not retried. 
This PR changes the Event Retry logic from _inclusive_ to _exclusive_, saying do not retry on **these** set of exceptions and retry on everything else.

**Purpose of the change**  
Fixes #6004 

**What the code does**  
Changed Retry predicate for Controller Event Processing to include exceptions on which we do not want the event to be Retried. On any other Exception or Error, the event will be retried.

**How to verify it**  
All Unit, Intergation and System Tests should pass.
