### PR TITLE
Issue 5196: REST call for fetching readergroup properties does not work when TLS is enabled in the standalone

### DIFF
--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/SecureControllerCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/SecureControllerCommandsTest.java
@@ -141,14 +141,18 @@ public class SecureControllerCommandsTest {
         command.printResponseInfo(Response.status(Response.Status.INTERNAL_SERVER_ERROR).build());
     }
 
+    @Test
+    @SneakyThrows
+    public void testDescribeReaderGroupCommand() {
+        // Check that the system reader group can be listed.
+        String commandResult = TestUtils.executeCommand("controller describe-readergroup _system commitStreamReaders", cliConfig());
+        Assert.assertTrue(commandResult.contains("commitStreamReaders"));
+        Assert.assertNotNull(ControllerDescribeReaderGroupCommand.descriptor());
+    }
+
     // TODO: Test controller describe-stream command in the secure scenario (auth+TLS).
     // Cannot at this point due to the following issue:
     // Issue 3821: Create describeStream REST call in Controller
     // https://github.com/pravega/pravega/issues/3821
-
-    // TODO: Test controller describe-readergroup command in the secure scenario (auth+TLS).
-    // Cannot at this point due to the following issue:
-    // Issue 5196: REST call for fetching readergroup properties does not work when TLS is enabled in the standalone
-    // https://github.com/pravega/pravega/issues/5196
 }
 

--- a/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerServiceStarter.java
@@ -349,7 +349,8 @@ public class ControllerServiceStarter extends AbstractIdleService implements Aut
                         controllerService,
                         grpcServer.getAuthHandlerManager(),
                         serviceConfig.getRestServerConfig().get(),
-                        connectionFactory);
+                        connectionFactory,
+                        clientConfig);
                 restServer.startAsync();
                 log.info("Awaiting start of REST server");
                 restServer.awaitRunning();

--- a/controller/src/main/java/io/pravega/controller/server/rest/RESTServer.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/RESTServer.java
@@ -16,6 +16,7 @@
 package io.pravega.controller.server.rest;
 
 import com.google.common.util.concurrent.AbstractIdleService;
+import io.pravega.client.ClientConfig;
 import io.pravega.client.connection.impl.ConnectionFactory;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.security.JKSHelper;
@@ -53,7 +54,7 @@ public class RESTServer extends AbstractIdleService {
 
     public RESTServer(LocalController localController, ControllerService controllerService,
                       AuthHandlerManager pravegaAuthManager, RESTServerConfig restServerConfig,
-                      ConnectionFactory connectionFactory) {
+                      ConnectionFactory connectionFactory, ClientConfig clientConfig) {
         this.objectId = "RESTServer";
         this.restServerConfig = restServerConfig;
         final String serverURI = "http://" + restServerConfig.getHost();
@@ -62,7 +63,7 @@ public class RESTServer extends AbstractIdleService {
         final Set<Object> resourceObjs = new HashSet<>();
         resourceObjs.add(new PingImpl());
         resourceObjs.add(new StreamMetadataResourceImpl(localController, controllerService, pravegaAuthManager,
-                connectionFactory));
+                connectionFactory, clientConfig));
 
         final ControllerApplication controllerApplication = new ControllerApplication(resourceObjs);
         this.resourceConfig = ResourceConfig.forApplication(controllerApplication);

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -86,13 +86,15 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
     private final ConnectionFactory connectionFactory;
     private final AuthorizationResource authorizationResource = new AuthorizationResourceImpl();
     private final Random requestIdGenerator = new Random();
+    private final ClientConfig clientConfig;
 
     public StreamMetadataResourceImpl(LocalController localController, ControllerService controllerService, 
-                                      AuthHandlerManager pravegaAuthManager, ConnectionFactory connectionFactory) {
+                                      AuthHandlerManager pravegaAuthManager, ConnectionFactory connectionFactory, ClientConfig clientConfig) {
         this.localController = localController;
         this.controllerService = controllerService;
         this.restAuthHelper = new RESTAuthHelper(pravegaAuthManager);
         this.connectionFactory = connectionFactory;
+        this.clientConfig = clientConfig;
     }
 
     /**
@@ -330,7 +332,7 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
             return;
         }
 
-        ClientFactoryImpl clientFactory = new ClientFactoryImpl(scopeName, this.localController, ClientConfig.builder().build());
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl(scopeName, this.localController, this.clientConfig);
         ReaderGroupManager readerGroupManager = new ReaderGroupManagerImpl(scopeName, this.localController, clientFactory);
         ReaderGroupProperty readerGroupProperty = new ReaderGroupProperty();
         readerGroupProperty.setScopeName(scopeName);

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -15,6 +15,7 @@
  */
 package io.pravega.controller.server.rest.resources;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.pravega.auth.AuthException;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.ReaderGroupManager;
@@ -334,10 +335,21 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
 
         ClientFactoryImpl clientFactory = new ClientFactoryImpl(scopeName, this.localController, this.clientConfig);
         ReaderGroupManager readerGroupManager = new ReaderGroupManagerImpl(scopeName, this.localController, clientFactory);
+        processGetReaderGroup(scopeName, readerGroupName, requestId, readerGroupManager).thenAccept(response -> {
+            asyncResponse.resume(response);
+            readerGroupManager.close();
+            clientFactory.close();
+            LoggerHelpers.traceLeave(log, "getReaderGroup", traceId);
+        });
+    }
+
+    @VisibleForTesting
+    public CompletableFuture<Response> processGetReaderGroup(String scopeName, String readerGroupName,
+                                                             long requestId, ReaderGroupManager readerGroupManager) {
         ReaderGroupProperty readerGroupProperty = new ReaderGroupProperty();
         readerGroupProperty.setScopeName(scopeName);
         readerGroupProperty.setReaderGroupName(readerGroupName);
-        CompletableFuture.supplyAsync(() -> {
+        return CompletableFuture.supplyAsync(() -> {
             ReaderGroup readerGroup = readerGroupManager.getReaderGroup(readerGroupName);
             readerGroupProperty.setOnlineReaderIds(
                     new ArrayList<>(readerGroup.getOnlineReaders()));
@@ -351,11 +363,6 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
             } else {
                 return Response.status(Status.INTERNAL_SERVER_ERROR).build();
             }
-        }).thenAccept(response -> {
-            asyncResponse.resume(response);
-            readerGroupManager.close();
-            clientFactory.close();
-            LoggerHelpers.traceLeave(log, "getReaderGroup", traceId);
         });
     }
 

--- a/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
@@ -127,6 +127,13 @@ public class FailingSecureStreamMetaDataTests extends StreamMetaDataTests {
     }
 
     @Override
+    public void testGetReaderGroup() {
+        final String resourceURI = getURI() + "v1/scopes/scope1/readergroups/readergroup1";
+        Response response = addAuthHeaders(client.target(resourceURI).request()).buildGet().invoke();
+        assertEquals("List Reader Groups response code", expectedResult, response.getStatus());
+    }
+
+    @Override
     @Test
     public void testDeleteStream() throws Exception {
         final String resourceURI = getURI() + "v1/scopes/scope1/streams/stream1";

--- a/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
@@ -63,7 +63,7 @@ public abstract class PingTest {
         serverConfig = getServerConfig();
         connectionFactory = new SocketConnectionFactoryImpl(ClientConfig.builder().build());
         restServer = new RESTServer(null, mockControllerService, null, serverConfig,
-                connectionFactory);
+                connectionFactory, ClientConfig.builder().build());
         restServer.startAsync();
         restServer.awaitRunning();
         client = createJerseyClient();

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
@@ -194,7 +194,7 @@ public class StreamMetaDataAuthFocusedTests {
                                                                   .controllerURI(URI.create("tcp://localhost"))
                                                                   .build());
         restServer = new RESTServer(controller, mockControllerService, authManager, serverConfig,
-                connectionFactory, ClientConfig.builder().controllerURI(URI.create("tcp://localhost")).build());
+                connectionFactory, ClientConfig.builder().build());
         restServer.startAsync();
         restServer.awaitRunning();
         client = ClientBuilder.newClient();

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataAuthFocusedTests.java
@@ -194,7 +194,7 @@ public class StreamMetaDataAuthFocusedTests {
                                                                   .controllerURI(URI.create("tcp://localhost"))
                                                                   .build());
         restServer = new RESTServer(controller, mockControllerService, authManager, serverConfig,
-                connectionFactory);
+                connectionFactory, ClientConfig.builder().controllerURI(URI.create("tcp://localhost")).build());
         restServer.startAsync();
         restServer.awaitRunning();
         client = ClientBuilder.newClient();

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -85,6 +85,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 
 /**
  * Tests for Stream metadata REST APIs.
@@ -1006,6 +1008,20 @@ public class StreamMetaDataTests {
         final ReaderGroupsList readerGroupsList = response.readEntity(ReaderGroupsList.class);
         assertEquals("List count", 50000, readerGroupsList.getReaderGroups().size());
         response.close();
+    }
+
+    @Test
+    public void testGetReaderGroups() {
+        final String resourceURI = getURI() + "v1/scopes/scope1/readergroups/readergroup1";
+
+        when(mockControllerService.getExecutor()).thenReturn(connectionFactory.getInternalExecutor());
+        when(mockControllerService.getCurrentSegments(anyString(), anyString(), anyLong()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+
+        // Verify that a ReaderGroupNotFoundException is generated as the segments are null.
+        Response response = addAuthHeaders(client.target(resourceURI).request()).buildGet().invoke();
+        assertEquals("List Reader Groups response code", 404, response.getStatus());
+        verify(mockControllerService, times(1)).getCurrentSegments(anyString(), anyString(), anyLong());
     }
 
     private static void testExpectedVsActualObject(final StreamProperty expected, final StreamProperty actual) {

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -196,7 +196,7 @@ public class StreamMetaDataTests {
                                                                         .controllerURI(URI.create("tcp://localhost"))
                                                                         .build());
         restServer = new RESTServer(controller, mockControllerService, authManager, serverConfig,
-                connectionFactory, ClientConfig.builder().controllerURI(URI.create("tcp://localhost")).build());
+                connectionFactory, ClientConfig.builder().build());
         restServer.startAsync();
         restServer.awaitRunning();
         client = ClientBuilder.newClient();

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -196,7 +196,7 @@ public class StreamMetaDataTests {
                                                                         .controllerURI(URI.create("tcp://localhost"))
                                                                         .build());
         restServer = new RESTServer(controller, mockControllerService, authManager, serverConfig,
-                connectionFactory);
+                connectionFactory, ClientConfig.builder().controllerURI(URI.create("tcp://localhost")).build());
         restServer.startAsync();
         restServer.awaitRunning();
         client = ClientBuilder.newClient();

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -17,20 +17,11 @@ package io.pravega.controller.rest.v1;
 
 import com.google.common.collect.ImmutableMap;
 import io.pravega.client.ClientConfig;
-import io.pravega.client.admin.ReaderGroupManager;
-import io.pravega.client.admin.impl.ReaderGroupManagerImpl;
 import io.pravega.client.connection.impl.ConnectionFactory;
 import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
-import io.pravega.client.state.StateSynchronizer;
-import io.pravega.client.state.SynchronizerConfig;
-import io.pravega.client.stream.ReaderGroup;
-import io.pravega.client.stream.ReaderGroupNotFoundException;
 import io.pravega.client.stream.RetentionPolicy;
 import io.pravega.client.stream.ScalingPolicy;
-import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.StreamConfiguration;
-import io.pravega.client.stream.impl.ClientFactoryImpl;
-import io.pravega.client.stream.impl.ReaderGroupState;
 import io.pravega.controller.server.ControllerService;
 import io.pravega.controller.server.eventProcessor.LocalController;
 import io.pravega.controller.server.rest.RESTServer;
@@ -48,7 +39,6 @@ import io.pravega.controller.server.rest.generated.model.StreamState;
 import io.pravega.controller.server.rest.generated.model.StreamsList;
 import io.pravega.controller.server.rest.generated.model.UpdateStreamRequest;
 import io.pravega.controller.server.rest.impl.RESTServerConfigImpl;
-import io.pravega.controller.server.rest.resources.StreamMetadataResourceImpl;
 import io.pravega.controller.server.security.auth.handler.AuthHandlerManager;
 import io.pravega.controller.store.stream.ScaleMetadata;
 import io.pravega.controller.store.stream.Segment;
@@ -66,10 +56,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -1018,41 +1006,6 @@ public class StreamMetaDataTests {
         final ReaderGroupsList readerGroupsList = response.readEntity(ReaderGroupsList.class);
         assertEquals("List count", 50000, readerGroupsList.getReaderGroups().size());
         response.close();
-    }
-
-    @Test
-    public void testGetReaderGroup() {
-        String scope = "scope";
-        String readerGroupName = "readerGroup";
-
-        LocalController controller = new LocalController(mockControllerService, false, "");
-        StreamMetadataResourceImpl streamMetadataResource = new StreamMetadataResourceImpl(controller, this.mockControllerService,
-                authManager, connectionFactory, ClientConfig.builder().build());
-        when(mockControllerService.getExecutor()).thenReturn(connectionFactory.getInternalExecutor());
-
-        StateSynchronizer<ReaderGroupState> synchronizer = mock(StateSynchronizer.class);
-
-        ClientFactoryImpl clientFactory = mock(ClientFactoryImpl.class);
-        when(clientFactory.createStateSynchronizer(anyString(), any(Serializer.class), any(Serializer.class),
-                any(SynchronizerConfig.class))).thenReturn(synchronizer);
-
-        ReaderGroup readerGroup = mock(ReaderGroup.class);
-        Set<String> readers = new HashSet<>(Arrays.asList("reader1", "reader2"));
-        Set<String> streamNames = new HashSet<>(Arrays.asList("stream1", "stream2"));
-        when(readerGroup.getOnlineReaders()).thenReturn(readers);
-        when(readerGroup.getStreamNames()).thenReturn(streamNames);
-
-        ReaderGroupManager readerGroupManager = mock(ReaderGroupManagerImpl.class);
-        when(readerGroupManager.getReaderGroup(readerGroupName)).thenReturn(readerGroup);
-
-        // Test for getReaderGroup success.
-        Response response = streamMetadataResource.processGetReaderGroup(scope, readerGroupName, 0, readerGroupManager).join();
-        assertEquals("Get Reader Group response code", 200, response.getStatus());
-
-        // Test for getReaderGroup failure.
-        when(readerGroupManager.getReaderGroup(readerGroupName)).thenThrow(new ReaderGroupNotFoundException("rg not found."));
-        Response failedResponse = streamMetadataResource.processGetReaderGroup(scope, readerGroupName, 0, readerGroupManager).join();
-        assertEquals("Get Reader Group response code", 404, failedResponse.getStatus());
     }
 
     private static void testExpectedVsActualObject(final StreamProperty expected, final StreamProperty actual) {

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -1011,7 +1011,7 @@ public class StreamMetaDataTests {
     }
 
     @Test
-    public void testGetReaderGroups() {
+    public void testGetReaderGroup() {
         final String resourceURI = getURI() + "v1/scopes/scope1/readergroups/readergroup1";
 
         when(mockControllerService.getExecutor()).thenReturn(connectionFactory.getInternalExecutor());

--- a/test/integration/src/test/java/io/pravega/test/integration/SecureControllerRestApiTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/SecureControllerRestApiTest.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.test.integration;
+
+import io.pravega.client.ClientConfig;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.admin.StreamManager;
+import io.pravega.client.admin.impl.StreamManagerImpl;
+import io.pravega.client.connection.impl.ConnectionPool;
+import io.pravega.client.connection.impl.ConnectionPoolImpl;
+import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
+import io.pravega.client.control.impl.Controller;
+import io.pravega.client.control.impl.ControllerImpl;
+import io.pravega.client.control.impl.ControllerImplConfig;
+import io.pravega.client.stream.ReaderConfig;
+import io.pravega.client.stream.ReaderGroupConfig;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.ClientFactoryImpl;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.controller.server.rest.generated.api.JacksonJsonProvider;
+import io.pravega.controller.server.rest.generated.model.ReaderGroupProperty;
+import io.pravega.controller.server.rest.generated.model.ReaderGroupsList;
+import io.pravega.controller.server.rest.generated.model.ReaderGroupsListReaderGroups;
+import io.pravega.shared.security.auth.DefaultCredentials;
+import io.pravega.test.common.InlineExecutor;
+import io.pravega.test.common.SecurityConfigDefaults;
+import io.pravega.test.integration.demo.ClusterWrapper;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.RandomStringUtils;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.net.URI;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.concurrent.TimeUnit;
+
+import static io.pravega.common.util.CertificateUtils.createTrustStore;
+import static io.pravega.test.integration.utils.TestUtils.pathToConfig;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Slf4j
+public class SecureControllerRestApiTest {
+
+    private static final String TRUSTSTORE_PATH = pathToConfig() + SecurityConfigDefaults.TLS_CA_CERT_FILE_NAME;
+    private static final ClusterWrapper CLUSTER = ClusterWrapper.builder()
+            .authEnabled(true)
+            .tlsEnabled(true)
+            .tlsServerCertificatePath(pathToConfig() + SecurityConfigDefaults.TLS_SERVER_CERT_FILE_NAME)
+            .tlsServerKeyPath(pathToConfig() + SecurityConfigDefaults.TLS_SERVER_PRIVATE_KEY_FILE_NAME)
+            .tlsHostVerificationEnabled(false)
+            .tlsServerKeystorePath(pathToConfig() + SecurityConfigDefaults.TLS_SERVER_KEYSTORE_NAME)
+            .tlsServerKeystorePasswordPath(pathToConfig() + SecurityConfigDefaults.TLS_PASSWORD_FILE_NAME)
+            .controllerRestEnabled(true)
+            .build();
+
+    @Rule
+    public final Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
+
+    private final Client client;
+    private WebTarget webTarget;
+    private String restServerURI;
+    private String resourceURl;
+
+    public SecureControllerRestApiTest() {
+        org.glassfish.jersey.client.ClientConfig clientConfig = new org.glassfish.jersey.client.ClientConfig();
+        clientConfig.register(JacksonJsonProvider.class);
+        clientConfig.property("sun.net.http.allowRestrictedHeaders", "true");
+
+        ClientBuilder builder = ClientBuilder.newBuilder().withConfig(clientConfig);
+
+        SSLContext tlsContext;
+        try {
+            KeyStore ks = createTrustStore(TRUSTSTORE_PATH);
+            TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            tmf.init(ks);
+            tlsContext = SSLContext.getInstance("TLS");
+            tlsContext.init(null, tmf.getTrustManagers(), null);
+            builder.sslContext(tlsContext);
+        } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException | KeyManagementException e) {
+            String message = String.format("Encountered exception while trying to use the given truststore: %s", TRUSTSTORE_PATH);
+            log.error(message, e);
+        }
+        client = builder.build();
+        HttpAuthenticationFeature auth = HttpAuthenticationFeature.basic(SecurityConfigDefaults.AUTH_ADMIN_USERNAME,
+                SecurityConfigDefaults.AUTH_ADMIN_PASSWORD);
+        client.register(auth);
+    }
+
+    @BeforeClass
+    public static void setupClass() throws Exception {
+        CLUSTER.start();
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        CLUSTER.close();
+    }
+
+    @After
+    public void tearDown() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    public void secureReaderGroupRestApiTest() throws Exception {
+
+        Invocation.Builder builder;
+        Response response;
+
+        restServerURI = CLUSTER.controllerRestUri();
+        log.info("REST Server URI: {}", restServerURI);
+
+        // TEST REST server status, ping test
+        resourceURl = new StringBuilder(restServerURI).append("/ping").toString();
+        webTarget = client.target(resourceURl);
+        builder = webTarget.request();
+        response = builder.get();
+        assertEquals("Ping test", OK.getStatusCode(), response.getStatus());
+        log.info("REST Server is running. Ping successful.");
+
+        // Test reader groups APIs.
+        // Prepare the streams and readers using the admin client.
+        final String testScope = RandomStringUtils.randomAlphanumeric(10);
+        final String testStream1 = RandomStringUtils.randomAlphanumeric(10);
+        final String testStream2 = RandomStringUtils.randomAlphanumeric(10);
+        URI controllerUri = new URI(CLUSTER.controllerUri());
+        @Cleanup("shutdown")
+        InlineExecutor inlineExecutor = new InlineExecutor();
+        ClientConfig clientConfig = ClientConfig.builder()
+                .controllerURI(controllerUri)
+                .credentials(new DefaultCredentials(SecurityConfigDefaults.AUTH_ADMIN_PASSWORD,
+                        SecurityConfigDefaults.AUTH_ADMIN_USERNAME))
+                .trustStore(TRUSTSTORE_PATH)
+                .validateHostName(false)
+                .build();
+        try (ConnectionPool cp = new ConnectionPoolImpl(clientConfig, new SocketConnectionFactoryImpl(clientConfig));
+             StreamManager streamManager = new StreamManagerImpl(createController(controllerUri, inlineExecutor), cp)) {
+            log.info("Creating scope: {}", testScope);
+            streamManager.createScope(testScope);
+
+            log.info("Creating stream: {}", testStream1);
+            StreamConfiguration streamConf1 = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
+            streamManager.createStream(testScope, testStream1, streamConf1);
+
+            log.info("Creating stream: {}", testStream2);
+            StreamConfiguration streamConf2 = StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build();
+            streamManager.createStream(testScope, testStream2, streamConf2);
+        }
+
+        final String readerGroupName1 = RandomStringUtils.randomAlphanumeric(10);
+        final String readerGroupName2 = RandomStringUtils.randomAlphanumeric(10);
+        final String reader1 = RandomStringUtils.randomAlphanumeric(10);
+        final String reader2 = RandomStringUtils.randomAlphanumeric(10);
+        try (ClientFactoryImpl clientFactory = new ClientFactoryImpl(testScope, createController(controllerUri, inlineExecutor), clientConfig);
+             ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(testScope,
+                     ClientConfig.builder()
+                             .controllerURI(controllerUri)
+                             .credentials(new DefaultCredentials(SecurityConfigDefaults.AUTH_ADMIN_PASSWORD,
+                                     SecurityConfigDefaults.AUTH_ADMIN_USERNAME))
+                             .trustStore(TRUSTSTORE_PATH)
+                             .validateHostName(false)
+                             .build())) {
+            readerGroupManager.createReaderGroup(readerGroupName1, ReaderGroupConfig.builder()
+                    .stream(Stream.of(testScope, testStream1))
+                    .stream(Stream.of(testScope, testStream2))
+                    .build());
+            readerGroupManager.createReaderGroup(readerGroupName2, ReaderGroupConfig.builder()
+                    .stream(Stream.of(testScope, testStream1))
+                    .stream(Stream.of(testScope, testStream2))
+                    .build());
+            clientFactory.createReader(reader1, readerGroupName1, new JavaSerializer<Long>(),
+                    ReaderConfig.builder().build());
+            clientFactory.createReader(reader2, readerGroupName1, new JavaSerializer<Long>(),
+                    ReaderConfig.builder().build());
+        }
+
+        // Test fetching readergroups.
+        resourceURl = new StringBuilder(restServerURI).append("/v1/scopes/" + testScope + "/readergroups").toString();
+        response = client.target(resourceURl).request().get();
+        assertEquals("Get readergroups status", OK.getStatusCode(), response.getStatus());
+        ReaderGroupsList readerGroupsList = response.readEntity(ReaderGroupsList.class);
+        assertEquals("Get readergroups size", 2, readerGroupsList.getReaderGroups().size());
+        assertTrue(readerGroupsList.getReaderGroups().contains(
+                new ReaderGroupsListReaderGroups().readerGroupName(readerGroupName1)));
+        assertTrue(readerGroupsList.getReaderGroups().contains(
+                new ReaderGroupsListReaderGroups().readerGroupName(readerGroupName2)));
+        log.info("Get readergroups successful");
+
+        // Test fetching readergroup info.
+        resourceURl = new StringBuilder(restServerURI).append("/v1/scopes/" + testScope + "/readergroups/"
+                + readerGroupName1).toString();
+        response = client.target(resourceURl).request().get();
+        assertEquals("Get readergroup properties status", OK.getStatusCode(), response.getStatus());
+        ReaderGroupProperty readerGroupProperty = response.readEntity(ReaderGroupProperty.class);
+        assertEquals("Get readergroup name", readerGroupName1, readerGroupProperty.getReaderGroupName());
+        assertEquals("Get readergroup scope name", testScope, readerGroupProperty.getScopeName());
+        assertEquals("Get readergroup streams size", 2, readerGroupProperty.getStreamList().size());
+        assertTrue(readerGroupProperty.getStreamList().contains(Stream.of(testScope, testStream1).getScopedName()));
+        assertTrue(readerGroupProperty.getStreamList().contains(Stream.of(testScope, testStream2).getScopedName()));
+        assertEquals("Get readergroup onlinereaders size", 2, readerGroupProperty.getOnlineReaderIds().size());
+        assertTrue(readerGroupProperty.getOnlineReaderIds().contains(reader1));
+        assertTrue(readerGroupProperty.getOnlineReaderIds().contains(reader2));
+
+        // Test readergroup or scope not found.
+        resourceURl = new StringBuilder(restServerURI).append("/v1/scopes/" + testScope + "/readergroups/" +
+                "unknownreadergroup").toString();
+        response = client.target(resourceURl).request().get();
+        assertEquals("Get readergroup properties status", NOT_FOUND.getStatusCode(), response.getStatus());
+        resourceURl = new StringBuilder(restServerURI).append("/v1/scopes/" + "unknownscope" + "/readergroups/" +
+                readerGroupName1).toString();
+        response = client.target(resourceURl).request().get();
+        assertEquals("Get readergroup properties status", NOT_FOUND.getStatusCode(), response.getStatus());
+        log.info("Get readergroup properties successful");
+
+        log.info("Test restApiTests passed successfully!");
+    }
+
+    private Controller createController(URI controllerUri, InlineExecutor executor) {
+        ClientConfig clientConfig = ClientConfig.builder()
+                .controllerURI(controllerUri)
+                .credentials(new DefaultCredentials(SecurityConfigDefaults.AUTH_ADMIN_PASSWORD,
+                        SecurityConfigDefaults.AUTH_ADMIN_USERNAME))
+                .trustStore(TRUSTSTORE_PATH)
+                .validateHostName(false)
+                .build();
+        return new ControllerImpl(ControllerImplConfig.builder()
+                .clientConfig(clientConfig)
+                .retryAttempts(1).build(), executor);
+    }
+}


### PR DESCRIPTION
**Change log description**  
The fix allows for readergroup properties to be queried through the REST API when TLS is enabled.

**Purpose of the change**  
Fixes #5196 

**What the code does**
- The class `StreamMetadataResourceImpl` now has a new field for `ClientConfig` which is to be passed through its constructor.
- When generating a `ClientFactory` in order to get the readergroup properties, the above `ClientConfig` is passed. 

**How to verify it**  
All tests should pass and build should succeed.
