### PR TITLE
Issue 6063: Ensure getTxn API starts the Transaction Pinger.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterImpl.java
@@ -230,6 +230,7 @@ public class TransactionalEventStreamWriterImpl<Type> implements TransactionalEv
             SegmentTransactionImpl<Type> impl = new SegmentTransactionImpl<>(txId, out, serializer);
             transactions.put(s, impl);
         }
+        pinger.startPing(txId);
         return new TransactionImpl<Type>(writerId, txId, transactions, segments, controller, stream, pinger);
     }
 

--- a/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
@@ -47,7 +47,9 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
     @Rule
@@ -125,12 +127,17 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(bad);
 
         // Create a transactional event Writer
-        @Cleanup
         TransactionalEventStreamWriter<String> writer = new TransactionalEventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
                 config, executorService());
         writer.beginTxn();
+        writer.close();
 
-        Transaction<String> txn = writer.getTxn(txnId);
+        //Create a new transactional eventWriter
+        @Cleanup
+        TransactionalEventStreamWriter<String> writer1 = new TransactionalEventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
+                                                                                                  EventWriterConfig.builder().transactionTimeoutTime(10000).build(),
+                                                                                                  executorService());
+        Transaction<String> txn = writer1.getTxn(txnId);
         txn.writeEvent("Foo");
         assertTrue(bad.unacked.isEmpty());
         assertEquals(1, outputStream.unacked.size());
@@ -138,6 +145,8 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
         txn.flush();
         assertTrue(bad.unacked.isEmpty());
         assertTrue(outputStream.unacked.isEmpty());
+        // verify pings was invoked for the transaction with the specified transactionTimeout.
+        verify(controller, atLeastOnce()).pingTransaction(eq(stream), eq(txnId), eq(10000L));
     }
 
     @Test(expected = TxnFailedException.class)

--- a/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/TransactionalEventStreamWriterTest.java
@@ -135,7 +135,7 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
         //Create a new transactional eventWriter
         @Cleanup
         TransactionalEventStreamWriter<String> writer1 = new TransactionalEventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
-                                                                                                  EventWriterConfig.builder().transactionTimeoutTime(10000).build(),
+                                                                                                  config,
                                                                                                   executorService());
         Transaction<String> txn = writer1.getTxn(txnId);
         txn.writeEvent("Foo");
@@ -146,7 +146,7 @@ public class TransactionalEventStreamWriterTest extends ThreadPooledTestSuite {
         assertTrue(bad.unacked.isEmpty());
         assertTrue(outputStream.unacked.isEmpty());
         // verify pings was invoked for the transaction with the specified transactionTimeout.
-        verify(controller, atLeastOnce()).pingTransaction(eq(stream), eq(txnId), eq(10000L));
+        verify(controller, atLeastOnce()).pingTransaction(eq(stream), eq(txnId), eq(config.getTransactionTimeoutTime()));
     }
 
     @Test(expected = TxnFailedException.class)


### PR DESCRIPTION
**Change log description**  
Ensure getTxn API starts the Transaction Pinger.

**Purpose of the change**  
Fixes #6063 

**What the code does**  
Ensure getTxn API starts the Transaction Pinger.


**How to verify it**  
All the existing and modified tests should pass.
