### PR TITLE
Issue 6094: Remove unnecessary Param tag causing javadoc warning

### DIFF
--- a/client/src/main/java/io/pravega/client/ClientConfig.java
+++ b/client/src/main/java/io/pravega/client/ClientConfig.java
@@ -85,9 +85,6 @@ public class ClientConfig implements Serializable {
 
     /**
      * Maximum number of connections per Segment store to be used by connection pooling.
-     *
-     * @param maxConnectionsPerSegmentStore Maximum number of connections per Segment Store for connection pooling.
-     * @return Maximum number of connections per Segment Store for connection pooling.
      */
     private final int maxConnectionsPerSegmentStore;
 


### PR DESCRIPTION
**Change log description**  
Remove @param and @return tag from a variable in ClientConfig.java

**Purpose of the change**  
Fixes #6094

**What the code does**  
Remove @param tag from an instance variable `maxConnectionsPerSegmentStore` which doesn't have a getter or setter. Delombok generates Javadoc with `@param` tag to this variable which gives a warning during execution of gradle task.

**How to verify it**  
running task `./gradlew :client:javadoc` gives a warning message:- 
`/pravega/client/build/delombok/io/pravega/client/ClientConfig.java:67: warning - Tag @param cannot be used in field documentation.  It can only be used in the following types of documentation: class/interface, constructor, method.
1 warning`
 
