### PR TITLE
Issue 6069: Max batch size not being honoured sometimes

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -2244,6 +2244,9 @@ public abstract class PersistentStreamBase implements Stream {
         return Futures.loop(() -> from.get() < txnIds.size() && transactionsMap.size() < limit, 
                 () -> getTransactionRecords(epoch, txnIds.subList(from.get(), till.get()), context).thenAccept(txns -> {
             for (int i = 0; i < txns.size(); i++) {
+                if (transactionsMap.size() >= limit) {
+                    break;
+                }
                 ActiveTxnRecord txnRecord = txns.get(i);
                 int index = from.get() + i;
                 UUID txnId = UUID.fromString(txnIds.get(index));

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -2256,9 +2256,6 @@ public abstract class PersistentStreamBase implements Stream {
                         if (txnRecord.getCommitOrder() == order) {
                             // if entry matches record's position then include it
                             transactionsMap.put(txnId, txnRecord);
-                            if (transactionsMap.size() >= limit) {
-                                break;
-                            }
                         } else {
                             log.debug(context.getRequestId(), "duplicate txn {} at position {}. removing {}",
                                     txnId, txnRecord.getCommitOrder(), order);

--- a/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java
@@ -2243,10 +2243,7 @@ public abstract class PersistentStreamBase implements Stream {
         AtomicInteger till = new AtomicInteger(Math.min(limit, txnIds.size()));
         return Futures.loop(() -> from.get() < txnIds.size() && transactionsMap.size() < limit, 
                 () -> getTransactionRecords(epoch, txnIds.subList(from.get(), till.get()), context).thenAccept(txns -> {
-            for (int i = 0; i < txns.size(); i++) {
-                if (transactionsMap.size() >= limit) {
-                    break;
-                }
+            for (int i = 0; i < txns.size() && transactionsMap.size() < limit; i++) {
                 ActiveTxnRecord txnRecord = txns.get(i);
                 int index = from.get() + i;
                 UUID txnId = UUID.fromString(txnIds.get(index));


### PR DESCRIPTION
Signed-off-by: Shivesh Ranjan <shivesh.ranjan@gmail.com>

**Change log description**  
Fixes the issue that was causing Max batch count for txn to exceed the max limit.

**Purpose of the change**  
Fixes #6069 

**What the code does**  
  the issue was that whenever we had collected 100 txns we thought we were breaking from the loop (but the loop had a switch case and the [break](https://github.com/pravega/pravega/blob/fe8a2a3dbfcef518b2749ab46cdcbf75a16bdae0/controller/src/main/java/io/pravega/controller/store/stream/PersistentStreamBase.java#L2260) actually applied to the switch case and not to the for loop. which meant that we could end up going up to 2 x limit -1 the batch count in case where we did not get limit items from first iteration and end up picking up to limit elements from second iteration. 

**How to verify it**  
Unit test added