### PR TITLE
Issue 6117: Transactions get aborted due to lease expiry on failure or slowness of pingTxn API

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -80,7 +80,7 @@ public class EventWriterConfig implements Serializable {
      * of the lease renewal period. The 1,000 is hardcoded and has been chosen arbitrarily
      * to be a large enough value.
      *
-     * The maximum allowed lease time by default is 120s, see:
+     * The maximum allowed lease time by default is 300s, see:
      *
      * {@link io.pravega.controller.util.Config.PROPERTY_TXN_MAX_LEASE}
      *
@@ -105,7 +105,7 @@ public class EventWriterConfig implements Serializable {
         private int maxBackoffMillis = 20000;
         private int retryAttempts = 10;
         private int backoffMultiple = 10;
-        private long transactionTimeoutTime = 90 * 1000 - 1;
+        private long transactionTimeoutTime = 270 * 1000 - 1;
         private boolean automaticallyNoteTime = false; 
         // connection pooling for event writers is disabled by default.
         private boolean enableConnectionPooling = false;

--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -80,7 +80,7 @@ public class EventWriterConfig implements Serializable {
      * of the lease renewal period. The 1,000 is hardcoded and has been chosen arbitrarily
      * to be a large enough value.
      *
-     * The maximum allowed lease time by default is 300s, see:
+     * The maximum allowed lease time by default is 600s, see:
      *
      * {@link io.pravega.controller.util.Config.PROPERTY_TXN_MAX_LEASE}
      *
@@ -105,7 +105,7 @@ public class EventWriterConfig implements Serializable {
         private int maxBackoffMillis = 20000;
         private int retryAttempts = 10;
         private int backoffMultiple = 10;
-        private long transactionTimeoutTime = 270 * 1000 - 1;
+        private long transactionTimeoutTime = 600 * 1000 - 1;
         private boolean automaticallyNoteTime = false; 
         // connection pooling for event writers is disabled by default.
         private boolean enableConnectionPooling = false;

--- a/client/src/test/java/io/pravega/client/stream/impl/PingerTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/PingerTest.java
@@ -124,7 +124,7 @@ public class PingerTest {
         pinger.startPing(txnID);
 
         verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), anyLong(),
-                                                       longThat(l -> l > 0 && l <= 10000), eq(TimeUnit.MILLISECONDS));
+                                                       longThat(l -> l > 0 && l <= 50000), eq(TimeUnit.MILLISECONDS));
         verify(controller, times(1)).pingTransaction(eq(stream), eq(txnID), eq(config.getTransactionTimeoutTime()));
     }
 
@@ -138,7 +138,7 @@ public class PingerTest {
         pinger.startPing(txnID1);
         pinger.startPing(txnID2);
         verify(executor, times(1)).scheduleAtFixedRate(any(Runnable.class), anyLong(),
-                                                       longThat(l -> l > 0 && l <= 10000), eq(TimeUnit.MILLISECONDS));
+                                                       longThat(l -> l > 0 && l <= 50000), eq(TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -174,7 +174,7 @@ public final class Config {
             "transaction.lease.count.min", 10000, "transaction.minLeaseValue");
 
     public static final Property<Long> PROPERTY_TXN_MAX_LEASE = Property.named(
-            "transaction.lease.count.max", 120000L, "transaction.maxLeaseValue");
+            "transaction.lease.count.max", 300000L, "transaction.maxLeaseValue");
 
     public static final Property<Integer> PROPERTY_TXN_MAX_EXECUTION_TIMEBOUND_DAYS = Property.named(
             "transaction.execution.timeBound.days", 1);

--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -174,7 +174,7 @@ public final class Config {
             "transaction.lease.count.min", 10000, "transaction.minLeaseValue");
 
     public static final Property<Long> PROPERTY_TXN_MAX_LEASE = Property.named(
-            "transaction.lease.count.max", 300000L, "transaction.maxLeaseValue");
+            "transaction.lease.count.max", 600000L, "transaction.maxLeaseValue");
 
     public static final Property<Integer> PROPERTY_TXN_MAX_EXECUTION_TIMEBOUND_DAYS = Property.named(
             "transaction.execution.timeBound.days", 1);

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndTxnWithTest.java
@@ -183,8 +183,8 @@ public class EndToEndTxnWithTest extends ThreadPooledTestSuite {
                 },
                 e -> Exceptions.unwrap(e) instanceof IllegalArgumentException);
 
-        EventWriterConfig highTimeoutConfig = EventWriterConfig.builder().transactionTimeoutTime(200 * 1000).build();
-        AssertExtensions.assertThrows("lease value too large, max value is 120000",
+        EventWriterConfig highTimeoutConfig = EventWriterConfig.builder().transactionTimeoutTime(700 * 1000).build();
+        AssertExtensions.assertThrows("lease value too large, max value is 600000",
                 () -> createTxn(clientFactory, highTimeoutConfig, streamName),
                 e -> e instanceof IllegalArgumentException);
     }


### PR DESCRIPTION
**Change log description**  
Default timeout at controller config.java increased to 300s from 120s and pingtxn increased to 270s from 90s to recover from the failure due to slowness or failed pingTxn API

**Purpose of the change**  
Fixes #6117

**What the code does**  
Increases the default timeout of transaction from 2 to 5 minutes and pingtxn from 90S to 270s
