### PR TITLE
Issue 6118: (SegmentStore) Bugfix for StartOffset decremented by 1 upon segment remapping

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -486,9 +486,9 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         // Length must be at least StorageLength.
         metadata.setLength(Math.max(mapping.getLength(), metadata.getLength()));
 
-        // StartOffset must not exceed the last offset of the Segment.
+        // StartOffset must be a value in the interval [0, Length] (closed at both ends).
         if (metadata.getLength() > 0) {
-            metadata.setStartOffset(Math.min(mapping.getStartOffset(), metadata.getLength() - 1));
+            metadata.setStartOffset(Math.min(mapping.getStartOffset(), metadata.getLength()));
         }
 
         if (mapping.isSealed()) {


### PR DESCRIPTION
**Change log description**  
Fixed a bug where it was possible to subtract 1 from the StartOffset of the segment if the previous StartOffset was set to the Length of the segment.

**Purpose of the change**  
Fixes #6118.

**What the code does**  
Bug Fix. Removed the "subtract 1" from length when re-mapping a segment. See issue for details.

**How to verify it**  
Unit test updated with check.