### PR TITLE
Issue 6128: Ensure RevisionedStreamClient logs the fact that no new updates are present to read post a revision.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/AsyncSegmentInputStreamImpl.java
@@ -94,7 +94,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
             log.info("Received noSuchSegment {}", noSuchSegment);
             CompletableFuture<SegmentRead> future = grabFuture(noSuchSegment.getSegment(), noSuchSegment.getOffset());
             if (future != null) {
-                future.completeExceptionally(new SegmentTruncatedException("Segment no longer exists."));
+                future.completeExceptionally(new SegmentTruncatedException(String.format("Segment %s no longer exists.", noSuchSegment.getSegment())));
             }
         }
         
@@ -103,7 +103,7 @@ class AsyncSegmentInputStreamImpl extends AsyncSegmentInputStream {
             log.info("Received segmentIsTruncated {}", segmentIsTruncated);
             CompletableFuture<SegmentRead> future = grabFuture(segmentIsTruncated.getSegment(), segmentIsTruncated.getOffset());
             if (future != null) {
-                future.completeExceptionally(new SegmentTruncatedException());
+                future.completeExceptionally(new SegmentTruncatedException(segmentIsTruncated.toString()));
             }
         }
         

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -133,17 +133,17 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
     }
 
     @Override
-    public Iterator<Entry<Revision, T>> readFrom(Revision start) {
-        log.trace("Read segment {} from revision {}", segment, start);
+    public Iterator<Entry<Revision, T>> readFrom(Revision revision) {
+        log.trace("Read segment {} from revision {}", segment, revision);
         synchronized (lock) {
-            long startOffset = start.asImpl().getOffsetInSegment();
+            long startOffset = revision.asImpl().getOffsetInSegment();
             SegmentInfo segmentInfo = Futures.getThrowingException(meta.getSegmentInfo());
             long endOffset = segmentInfo.getWriteOffset();
             if (startOffset < segmentInfo.getStartingOffset()) {
-                throw new TruncatedDataException(format("Data at the supplied revision {%s} has been truncated. The current segment info is {%s}", start, segmentInfo));
+                throw new TruncatedDataException(format("Data at the supplied revision {%s} has been truncated. The current segment info is {%s}", revision, segmentInfo));
             }
             if (startOffset == endOffset) {
-                log.info("No new updates to be read from revision {}", start);
+                log.debug("No new updates to be read from revision {}", revision);
             }
             log.debug("Creating iterator from {} until {} for segment {} ", startOffset, endOffset, segment);
             return new StreamIterator(startOffset, endOffset);

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -142,6 +142,9 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
             if (startOffset < segmentInfo.getStartingOffset()) {
                 throw new TruncatedDataException(format("Data at the supplied revision {%s} has been truncated. The current segment info is {%s}", start, segmentInfo));
             }
+            if (startOffset == endOffset) {
+                log.info("No new updates to be read from revision {}", start);
+            }
             log.debug("Creating iterator from {} until {} for segment {} ", startOffset, endOffset, segment);
             return new StreamIterator(startOffset, endOffset);
         }

--- a/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/StateSynchronizerImpl.java
@@ -99,7 +99,7 @@ public class StateSynchronizerImpl<StateT extends Revisioned>
                 }
             }
         } catch (TruncatedDataException e) {
-            log.info("{} encountered truncation on segment {}", this, segment);
+            log.info("{} encountered truncation on segment {}, Details: {}", this, segment, e.getMessage());
             RETRY_INDEFINITELY
                  .retryingOn(TruncatedDataException.class)
                  .throwingOn(RuntimeException.class)

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -393,6 +393,10 @@ public class EventStreamReaderImpl<Type> implements EventStreamReader<Type> {
                 DelegationTokenProviderFactory.create(controller, segmentId, AccessOperation.READ));
         try {
             long startingOffset = Futures.getThrowingException(metadataClient.getSegmentInfo()).getStartingOffset();
+            if (segmentReader.getOffset() == startingOffset) {
+                log.warn("Attempt to fetch the next available read offset on the segment {} returned a truncated offset {}",
+                         segmentId, startingOffset);
+            }
             segmentReader.setOffset(startingOffset);
         } catch (NoSuchSegmentException e) {
             handleEndOfSegment(segmentReader, true);


### PR DESCRIPTION
**Change log description**  
Ensure RevisionedStreamClient logs the fact that no new updates are present to read post a revision.

**Purpose of the change**  
Fixes #6128 

**What the code does**  
Ensure RevisionedStreamClient logs the fact that no new updates are present to read post a revision. Improve logging for scnearios where the client observes Segment truncation. These logs will simplify debugging of scenarios where readers do not progress due to segment truncation.

**How to verify it**  
No Changes in functionality. All the existing tests should continue to pass.
