### PR TITLE
Issue 6130: Fix HealthServiceManager Race Condition

### DIFF
--- a/shared/health/src/main/java/io/pravega/shared/health/HealthServiceManager.java
+++ b/shared/health/src/main/java/io/pravega/shared/health/HealthServiceManager.java
@@ -81,10 +81,10 @@ public class HealthServiceManager implements AutoCloseable {
     @Override
     public void close() {
         if (!this.closed.getAndSet(true)) {
-            this.root.close();
             this.updater.close();
             this.updater.stopAsync();
             this.updater.awaitTerminated();
+            this.root.close();
         }
     }
 

--- a/shared/health/src/main/java/io/pravega/shared/health/impl/AbstractHealthContributor.java
+++ b/shared/health/src/main/java/io/pravega/shared/health/impl/AbstractHealthContributor.java
@@ -100,7 +100,7 @@ public abstract class AbstractHealthContributor implements HealthContributor {
         Collection<Status> statuses = new ArrayList<>();
         Map<String, Health> children = new HashMap<>();
 
-        for (val  entry : contributors.entrySet()) {
+        for (val entry : contributors.entrySet()) {
             HealthContributor contributor = entry.getValue();
             synchronized (contributor) {
                 if (!contributor.isClosed()) {

--- a/shared/health/src/main/java/io/pravega/shared/health/impl/HealthServiceUpdaterImpl.java
+++ b/shared/health/src/main/java/io/pravega/shared/health/impl/HealthServiceUpdaterImpl.java
@@ -88,7 +88,7 @@ public class HealthServiceUpdaterImpl extends AbstractScheduledService implement
      */
     @Override
     protected void startUp() {
-        log.info("Starting the HealthServiceUpdater, running at {} SECOND intervals.", interval);
+        log.info("Starting the HealthServiceUpdater, running at {} intervals.", interval);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Colin Hryniowski <colin.hryniowski@dell.com>

**Change log description**  

* Makes the `close` method of `AbstractHealthContributor` synchronized.
* Add a synchronized block gated on the child `contributor`.
* Fix extra white space and fix log message.

**Purpose of the change**  
Fixes #6130 

**What the code does**  

* The `synchronized` block protects against the case where a `HealthContributor` is closed after the `contributor.isClosed()` is called but before `Exceptions.checkNotClosed(isClosed(), this);` in the child `HealthContributor`s `getHealthSnapshot` call.

**How to verify it**  

Execute the unit tests.
* Verified no errors after ~5000 iterations.