### PR TITLE
Issue 6139: (SegmentStore) Improving StorageWriter workflow when SLTS metadata is not available

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -94,7 +94,7 @@ plugins.withId('java') {
         testLogging.showCauses = true
         testLogging.showExceptions = true
         testLogging.showStackTraces = true
-        testLogging.events = ["STARTED", "PASSED", "SKIPPED", "FAILED"]
+        testLogging.events = ["STARTED", "SKIPPED", "FAILED"]
         maxParallelForks = System.properties['maxParallelForks'] ? System.properties['maxParallelForks'].toInteger() : Math.min(4, Runtime.runtime.availableProcessors())
         minHeapSize = "128m"
         maxHeapSize = "512m"


### PR DESCRIPTION
**Change log description**  
 Improved the StorageWriter workflow by allowing it to flush (if possible) even if it's unable to initialize new segments.

**Purpose of the change**  
Fixes #6139.

**What the code does**  
The `StorageWriter` can now ignore (after logging) non-critical errors while it's processing its read result (`processReadResult`) and moving on to the `flush` stage. This can help alleviate pressure and exit from a possible deadlock (see #6139).

Unrelated change (but reverting a previous unwanted change):
- `java.gradle`: Removed redundant "PASSED" message for every test. Since we are logging "START", if we don't see anything else, then we know the test succeeded. "FAILED" and "SKIPPED" are the only important ones and represent exceptional cases. This change helps reduce build output clutter.

**How to verify it**  
All existing unit and integration tests must pass.
A new unit test was added to verify this functionality.