### PR TITLE
Issue 6139: (SegmentStore) Improving Table Segment Pre-Caching and Background Indexing

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/dataRecovery/DurableLogRecoveryCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/dataRecovery/DurableLogRecoveryCommand.java
@@ -36,6 +36,7 @@ import io.pravega.segmentstore.server.reading.ContainerReadIndexFactory;
 import io.pravega.segmentstore.server.reading.ReadIndexConfig;
 import io.pravega.segmentstore.server.tables.ContainerTableExtension;
 import io.pravega.segmentstore.server.tables.ContainerTableExtensionImpl;
+import io.pravega.segmentstore.server.tables.TableExtensionConfig;
 import io.pravega.segmentstore.server.writer.StorageWriterFactory;
 import io.pravega.segmentstore.server.writer.WriterConfig;
 import io.pravega.segmentstore.storage.Storage;
@@ -217,7 +218,7 @@ public class DurableLogRecoveryCommand extends DataRecoveryCommand {
         }
 
         private ContainerTableExtension createTableExtension(SegmentContainer c, ScheduledExecutorService e) {
-            return new ContainerTableExtensionImpl(c, this.cacheManager, e);
+            return new ContainerTableExtensionImpl(TableExtensionConfig.builder().build(), c, this.cacheManager, e);
         }
 
         @Override

--- a/common/src/main/java/io/pravega/common/util/TypedProperties.java
+++ b/common/src/main/java/io/pravega/common/util/TypedProperties.java
@@ -154,28 +154,27 @@ public class TypedProperties {
      *                                does not have a default value set, or when the property cannot be parsed as a positive Integer.
      */
     public int getPositiveInt(Property<Integer> property) {
-        return getPositiveInt(property, true);
+        int value = getInt(property);
+        if (value <= 0) {
+            throw new ConfigurationException(String.format("Property '%s' must be a positive integer.", property));
+        }
+        return value;
     }
 
     /**
-     * Gets the value of an Integer property only if it is greater than 0.
+     * Gets the value of an Integer property only if it is non-negative (greater than or equal to 0).
      *
      * @param property The Property to get.
-     * @param strict   If true, then the value must be strictly greater than 0; otherwise 0 is accepted.
      * @return The property value or default value, if no such is defined in the base Properties.
      * @throws ConfigurationException When the given property name does not exist within the current component and the property
-     *                                does not have a default value set, or when the property cannot be parsed as a positive Integer.
+     *                                does not have a default value set, or when the property cannot be parsed as a
+     *                                non-negative Integer.
      */
-    public int getPositiveInt(Property<Integer> property, boolean strict) {
+    public int getNonNegativeInt(Property<Integer> property) {
         int value = getInt(property);
-        if (strict) {
-            if (value <= 0) {
-                throw new ConfigurationException(String.format("Property '%s' must be a positive integer.", property));
-            }
-        } else if (value < 0) {
+        if (value < 0) {
             throw new ConfigurationException(String.format("Property '%s' must be a non-negative integer.", property));
         }
-
         return value;
     }
 

--- a/common/src/main/java/io/pravega/common/util/TypedProperties.java
+++ b/common/src/main/java/io/pravega/common/util/TypedProperties.java
@@ -17,12 +17,11 @@ package io.pravega.common.util;
 
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
-import lombok.extern.slf4j.Slf4j;
-
 import java.time.Duration;
 import java.time.temporal.TemporalUnit;
 import java.util.Properties;
 import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * *
@@ -155,9 +154,43 @@ public class TypedProperties {
      *                                does not have a default value set, or when the property cannot be parsed as a positive Integer.
      */
     public int getPositiveInt(Property<Integer> property) {
+        return getPositiveInt(property, true);
+    }
+
+    /**
+     * Gets the value of an Integer property only if it is greater than 0.
+     *
+     * @param property The Property to get.
+     * @param strict   If true, then the value must be strictly greater than 0; otherwise 0 is accepted.
+     * @return The property value or default value, if no such is defined in the base Properties.
+     * @throws ConfigurationException When the given property name does not exist within the current component and the property
+     *                                does not have a default value set, or when the property cannot be parsed as a positive Integer.
+     */
+    public int getPositiveInt(Property<Integer> property, boolean strict) {
         int value = getInt(property);
+        if (strict) {
+            if (value <= 0) {
+                throw new ConfigurationException(String.format("Property '%s' must be a positive integer.", property));
+            }
+        } else if (value < 0) {
+            throw new ConfigurationException(String.format("Property '%s' must be a non-negative integer.", property));
+        }
+
+        return value;
+    }
+
+    /**
+     * Gets the value of an Long property only if it is greater than 0.
+     *
+     * @param property The Property to get.
+     * @return The property value or default value, if no such is defined in the base Properties.
+     * @throws ConfigurationException When the given property name does not exist within the current component and the property
+     *                                does not have a default value set, or when the property cannot be parsed as a positive Long.
+     */
+    public long getPositiveLong(Property<Long> property) {
+        long value = getLong(property);
         if (value <= 0) {
-            throw new ConfigurationException(String.format("Property '%s' must be a positive integer.", property));
+            throw new ConfigurationException(String.format("Property '%s' must be a positive long.", property));
         }
         return value;
     }

--- a/common/src/test/java/io/pravega/common/util/TypedPropertiesTests.java
+++ b/common/src/test/java/io/pravega/common/util/TypedPropertiesTests.java
@@ -140,9 +140,9 @@ public class TypedPropertiesTests {
         TypedProperties typedProps = new TypedProperties(props, "getPositiveInteger");
         Assert.assertEquals(1000, typedProps.getPositiveInt(Property.named("positiveInteger")));
         AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveInt(Property.named("zero")));
-        Assert.assertEquals(0, typedProps.getPositiveInt(Property.named("zero"), false));
+        Assert.assertEquals(0, typedProps.getNonNegativeInt(Property.named("zero")));
         AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveInt(Property.named("negativeInteger")));
-        AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveInt(Property.named("negativeInteger"), false));
+        AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getNonNegativeInt(Property.named("negativeInteger")));
         AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveInt(Property.named("notAnInteger")));
     }
 

--- a/common/src/test/java/io/pravega/common/util/TypedPropertiesTests.java
+++ b/common/src/test/java/io/pravega/common/util/TypedPropertiesTests.java
@@ -16,7 +16,6 @@
 package io.pravega.common.util;
 
 import io.pravega.test.common.AssertExtensions;
-
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -141,8 +140,24 @@ public class TypedPropertiesTests {
         TypedProperties typedProps = new TypedProperties(props, "getPositiveInteger");
         Assert.assertEquals(1000, typedProps.getPositiveInt(Property.named("positiveInteger")));
         AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveInt(Property.named("zero")));
+        Assert.assertEquals(0, typedProps.getPositiveInt(Property.named("zero"), false));
         AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveInt(Property.named("negativeInteger")));
+        AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveInt(Property.named("negativeInteger"), false));
         AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveInt(Property.named("notAnInteger")));
+    }
+
+    @Test
+    public void testGetPositiveLong() {
+        Properties props = new Properties();
+        props.setProperty("getPositiveLong.positiveLong", "1000000000000");
+        props.setProperty("getPositiveLong.zero", "0");
+        props.setProperty("getPositiveLong.negativeLong", "-1");
+        props.setProperty("getPositiveLong.notALong", "hello");
+        TypedProperties typedProps = new TypedProperties(props, "getPositiveLong");
+        Assert.assertEquals(1000000000000L, typedProps.getPositiveLong(Property.named("positiveLong")));
+        AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveLong(Property.named("zero")));
+        AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveLong(Property.named("negativeLong")));
+        AssertExtensions.assertThrows(ConfigurationException.class, () -> typedProps.getPositiveLong(Property.named("notALong")));
     }
 
     @Test

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilder.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceBuilder.java
@@ -44,6 +44,7 @@ import io.pravega.segmentstore.server.reading.ContainerReadIndexFactory;
 import io.pravega.segmentstore.server.reading.ReadIndexConfig;
 import io.pravega.segmentstore.server.tables.ContainerTableExtension;
 import io.pravega.segmentstore.server.tables.ContainerTableExtensionImpl;
+import io.pravega.segmentstore.server.tables.TableExtensionConfig;
 import io.pravega.segmentstore.server.tables.TableService;
 import io.pravega.segmentstore.server.writer.StorageWriterFactory;
 import io.pravega.segmentstore.server.writer.WriterConfig;
@@ -294,7 +295,8 @@ public class ServiceBuilder implements AutoCloseable {
 
     private Map<Class<? extends SegmentContainerExtension>, SegmentContainerExtension> createContainerExtensions(
             SegmentContainer container, ScheduledExecutorService executor) {
-        return Collections.singletonMap(ContainerTableExtension.class, new ContainerTableExtensionImpl(container, this.cacheManager, executor));
+        TableExtensionConfig config = this.serviceBuilderConfig.getConfig(TableExtensionConfig::builder);
+        return Collections.singletonMap(ContainerTableExtension.class, new ContainerTableExtensionImpl(config, container, this.cacheManager, executor));
     }
 
     private SegmentContainerRegistry createSegmentContainerRegistry() {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.TimeoutTimer;
+import io.pravega.common.Timer;
 import io.pravega.common.concurrent.AsyncSemaphore;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.concurrent.MultiKeySequentialProcessor;
@@ -54,6 +55,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -617,45 +619,62 @@ class ContainerKeyIndex implements AutoCloseable {
      *
      * @param segment A {@link DirectSegmentAccess} representing the Segment for which to cache the tail index.
      */
-    private void triggerCacheTailIndex(DirectSegmentAccess segment, long lastIndexedOffset, long segmentLength) {
-        long tailIndexLength = segmentLength - lastIndexedOffset;
-        if (lastIndexedOffset >= segmentLength) {
+    private void triggerCacheTailIndex(DirectSegmentAccess segment, long lastIndexedOffset, SegmentTracker.RecoveryTask task) {
+        long tailIndexLength = task.triggerIndexOffset - lastIndexedOffset;
+        if (lastIndexedOffset >= task.triggerIndexOffset) {
             // Fully caught up. Nothing else to do.
             log.debug("{}: Table Segment {} fully indexed.", this.traceObjectId, segment.getSegmentId());
             return;
         } else if (tailIndexLength > this.config.getMaxTailCachePreIndexLength()) {
-            log.debug("{}: Table Segment {} cannot perform tail-caching because tail index too long ({}).", this.traceObjectId,
+            log.info("{}: Table Segment {} cannot perform tail-caching because tail index too long ({}).", this.traceObjectId,
                     segment.getSegmentId(), tailIndexLength);
             return;
         }
 
         // Read the tail section of the segment and process its updates. All of this should already be in the cache so
         // we are not going to do any Storage reads.
-        SegmentProperties segmentInfo = segment.getInfo();
-        log.debug("{}: Tail-caching started for Table Segment {}. LastIndexedOffset={}, SegmentLength={}.",
-                this.traceObjectId, segment.getSegmentId(), lastIndexedOffset, segmentLength);
-        ReadResult rr = segment.read(lastIndexedOffset, (int) tailIndexLength, this.config.getRecoveryTimeout());
-        AsyncReadResultProcessor
+        log.info("{}: Tail-caching started for Table Segment {}. LastIndexedOffset={}, SegmentLength={}.",
+                this.traceObjectId, segment.getSegmentId(), lastIndexedOffset, task.triggerIndexOffset);
+        val preIndexOffset = new AtomicLong(lastIndexedOffset);
+
+        // Begin a loop which will end when either we've reached the target offset (defined in the RecoveryTask) or when
+        // the recovery task itself has been cancelled (i.e., segment evicted, shutting down, etc.).
+        Futures.loop(
+                () -> !task.task.isDone() && preIndexOffset.get() < task.triggerIndexOffset,
+                () -> {
+                    int maxLength = (int) Math.min(this.config.getMaxTailCachePreIndexBatchLength(), task.triggerIndexOffset - preIndexOffset.get());
+                    return preIndexBatch(segment, preIndexOffset.get(), maxLength)
+                            .thenAccept(preIndexOffset::set);
+                },
+                this.executor)
+                .exceptionally(ex -> {
+                    log.warn("{}: Tail-caching failed for Table Segment {}; LastIndexedOffset={}, CurrentOffset={}, SegmentLength={}.", this.traceObjectId, segment.getSegmentId(), lastIndexedOffset, preIndexOffset, task.triggerIndexOffset, Exceptions.unwrap(ex));
+                    return null;
+                });
+    }
+
+    private CompletableFuture<Long> preIndexBatch(DirectSegmentAccess segment, long startOffset, int maxLength) {
+        log.trace("{}: Tail-caching batch started for Table Segment {}. StartOffset={}, MaxLength={}.",
+                this.traceObjectId, segment.getSegmentId(), startOffset, maxLength);
+        val timer = new Timer();
+        ReadResult rr = segment.read(startOffset, maxLength, this.config.getRecoveryTimeout());
+        return AsyncReadResultProcessor
                 .processAll(rr, this.executor, this.config.getRecoveryTimeout())
-                .thenAcceptAsync(inputData -> {
+                .thenApplyAsync(inputData -> {
                     // Parse out all Table Keys and collect their latest offsets, as well as whether they were deleted.
                     val updates = new TailUpdates();
-                    collectLatestOffsets(inputData, lastIndexedOffset, (int) tailIndexLength, updates);
+                    collectLatestOffsets(inputData, startOffset, maxLength, updates);
 
                     // Incorporate that into the cache.
                     this.cache.includeTailCache(segment.getSegmentId(), updates.byBucket);
 
-                    log.debug("{}: Tail-caching complete for Table Segment {}. Key Update Count={}, Bucket Update Count={}.",
-                            this.traceObjectId, segment.getSegmentId(), updates.getKeyCount(), updates.byBucket.size());
+                    log.debug("{}: Tail-caching batch complete for Table Segment {}. StartOffset={}, EndOffset={}, Key Update Count={}, Bucket Update Count={}, Elapsed={}ms.",
+                            this.traceObjectId, segment.getSegmentId(), startOffset, updates.getMaxOffset(), updates.getKeyCount(), updates.byBucket.size(), timer.getElapsedMillis());
 
-                    // Notify the Segment Tracker that this segment has been recovered, so it can unblock any calls it
-                    // may have collected.
-                    this.segmentTracker.updateSegmentIndexOffset(segment.getSegmentId(), segmentLength, 0, updates.byBucket.size() > 0);
-                }, this.executor)
-                .exceptionally(ex -> {
-                    log.warn("{}: Tail-caching failed for Table Segment {}.", this.traceObjectId, segment.getSegmentId(), Exceptions.unwrap(ex));
-                    return null;
-                });
+                    // Notify the Segment Tracker that this segment has been recovered up to whatever offset we were able to process.
+                    this.segmentTracker.updateSegmentIndexOffset(segment.getSegmentId(), updates.getMaxOffset(), 0, updates.byBucket.size() > 0);
+                    return updates.getMaxOffset();
+                }, this.executor);
     }
 
     @SneakyThrows(IOException.class)
@@ -664,11 +683,17 @@ class ContainerKeyIndex implements AutoCloseable {
         long nextOffset = startOffset;
         final long maxOffset = startOffset + maxLength;
         val inputReader = input.getBufferViewReader();
-        while (nextOffset < maxOffset) {
-            val e = AsyncTableEntryReader.readEntryComponents(inputReader, nextOffset, serializer);
-            val hash = this.keyHasher.hash(e.getKey());
-            result.add(hash, nextOffset, e.getHeader().isDeletion());
-            nextOffset += e.getHeader().getTotalLength();
+        try {
+            while (nextOffset < maxOffset) {
+                val e = AsyncTableEntryReader.readEntryComponents(inputReader, nextOffset, serializer);
+                val hash = this.keyHasher.hash(e.getKey());
+                result.add(hash, nextOffset, e.getHeader().getTotalLength(), e.getHeader().isDeletion());
+                nextOffset += e.getHeader().getTotalLength();
+            }
+        } catch (BufferView.Reader.OutOfBoundsException ex) {
+            // We chose an arbitrary end offset, which may have been in the middle of an entry. As such, this exception
+            // is the only way we know when to stop. When this happens, the TailUpdate will be positioned on an entry
+            // boundary, which will be the first one to be read in the next iteration.
         }
     }
 
@@ -689,11 +714,14 @@ class ContainerKeyIndex implements AutoCloseable {
         final Map<UUID, CacheBucketOffset> byBucket = new HashMap<>();
         @Getter
         private int keyCount = 0;
+        @Getter
+        private long maxOffset = -1;
 
-        void add(UUID keyHash, long offset, boolean isDeletion) {
+        void add(UUID keyHash, long offset, int serializationLength, boolean isDeletion) {
             CacheBucketOffset cbo = new CacheBucketOffset(offset, isDeletion);
             this.byBucket.put(keyHash, cbo);
             this.keyCount++;
+            this.maxOffset = offset + serializationLength;
         }
     }
 
@@ -779,11 +807,11 @@ class ContainerKeyIndex implements AutoCloseable {
             if (task != null) {
                 if (removed) {
                     // Normally nobody should be waiting on this, but in case they did, there's nothing we can do about it now.
-                    log.debug("{}: TableSegment {} evicted; cancelling dependent tasks.", traceObjectId, segmentId);
+                    log.info("{}: TableSegment {} evicted; cancelling dependent tasks.", traceObjectId, segmentId);
                     task.task.cancel(true);
-                } else {
+                } else if (indexOffset >= task.triggerIndexOffset) {
                     // Notify whoever is waiting that it's all clear to execute.
-                    log.debug("{}: TableSegment {} fully recovered; triggering dependent tasks.", traceObjectId, segmentId);
+                    log.info("{}: TableSegment {} fully recovered ({} ms); triggering dependent tasks.", traceObjectId, segmentId, task.timer.getElapsedMillis());
                     task.task.complete(cacheUpdated);
                 }
             }
@@ -888,7 +916,7 @@ class ContainerKeyIndex implements AutoCloseable {
                 if (firstTask) {
                     setupRecoveryTask(task);
                     assert lastIndexedOffset >= 0;
-                    triggerCacheTailIndex(segment, lastIndexedOffset, segmentLength);
+                    triggerCacheTailIndex(segment, lastIndexedOffset, task);
                 }
 
                 // A recovery task is registered. Queue behind it.
@@ -929,6 +957,7 @@ class ContainerKeyIndex implements AutoCloseable {
             final long segmentId;
             final long triggerIndexOffset;
             final CompletableFuture<Boolean> task = new CompletableFuture<>();
+            final Timer timer = new Timer();
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerTableExtensionImpl.java
@@ -73,17 +73,19 @@ public class ContainerTableExtensionImpl implements ContainerTableExtension {
     /**
      * Creates a new instance of the ContainerTableExtensionImpl class.
      *
+     * @param config           Configuration.
      * @param segmentContainer The {@link SegmentContainer} to associate with.
      * @param cacheManager     The {@link CacheManager} to use to manage the cache.
      * @param executor         An Executor to use for async tasks.
      */
-    public ContainerTableExtensionImpl(SegmentContainer segmentContainer, CacheManager cacheManager, ScheduledExecutorService executor) {
-        this(TableExtensionConfig.builder().build(), segmentContainer, cacheManager, KeyHasher.sha256(), executor);
+    public ContainerTableExtensionImpl(TableExtensionConfig config, SegmentContainer segmentContainer, CacheManager cacheManager, ScheduledExecutorService executor) {
+        this(config, segmentContainer, cacheManager, KeyHasher.sha256(), executor);
     }
 
     /**
      * Creates a new instance of the ContainerTableExtensionImpl class with custom {@link KeyHasher}.
      *
+     * @param config           Configuration.
      * @param segmentContainer The {@link SegmentContainer} to associate with.
      * @param cacheManager     The {@link CacheManager} to use to manage the cache.
      * @param hasher           The {@link KeyHasher} to use.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableExtensionConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableExtensionConfig.java
@@ -109,11 +109,11 @@ public class TableExtensionConfig {
 
     private TableExtensionConfig(TypedProperties properties) throws ConfigurationException {
         this.maxTailCachePreIndexLength = properties.getPositiveLong(MAX_TAIL_CACHE_PREINDEX_LENGTH);
-        this.maxTailCachePreIndexBatchLength = properties.getPositiveInt(MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE, true);
+        this.maxTailCachePreIndexBatchLength = properties.getPositiveInt(MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE);
         this.maxUnindexedLength = properties.getPositiveInt(MAX_UNINDEXED_LENGTH);
         this.maxCompactionSize = properties.getPositiveInt(MAX_COMPACTION_SIZE);
         this.compactionFrequency = properties.getDuration(COMPACTION_FREQUENCY, ChronoUnit.MILLIS);
-        this.defaultMinUtilization = properties.getPositiveInt(DEFAULT_MIN_UTILIZATION, false);
+        this.defaultMinUtilization = properties.getNonNegativeInt(DEFAULT_MIN_UTILIZATION);
         if (this.defaultMinUtilization > 100) {
             throw new ConfigurationException(String.format("Property '%s' must be a value within [0, 100].", DEFAULT_MIN_UTILIZATION));
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableExtensionConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableExtensionConfig.java
@@ -39,7 +39,8 @@ import lombok.Getter;
  */
 @Getter
 public class TableExtensionConfig {
-    public static final Property<Integer> MAX_TAIL_CACHE_PREINDEX_LENGTH = Property.named("preindex.bytes.max", EntrySerializer.MAX_BATCH_SIZE * 4);
+    public static final Property<Long> MAX_TAIL_CACHE_PREINDEX_LENGTH = Property.named("preindex.bytes.max", (long) EntrySerializer.MAX_BATCH_SIZE * 4);
+    public static final Property<Integer> MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE = Property.named("preindex.batch.bytes.max", EntrySerializer.MAX_BATCH_SIZE * 4);
     public static final Property<Integer> RECOVERY_TIMEOUT = Property.named("recovery.timeout.millis", 60000);
     public static final Property<Integer> MAX_UNINDEXED_LENGTH = Property.named("unindexed.bytes.max", EntrySerializer.MAX_BATCH_SIZE * 4);
     public static final Property<Integer> MAX_COMPACTION_SIZE = Property.named("compaction.bytes.max", EntrySerializer.MAX_SERIALIZATION_LENGTH * 4);
@@ -53,7 +54,13 @@ public class TableExtensionConfig {
      * The maximum unindexed length ({@link SegmentProperties#getLength() - {@link TableAttributes#INDEX_OFFSET}}) of a
      * Segment for which {@link ContainerKeyIndex} {@code triggerCacheTailIndex} can be invoked.
      */
-    private final int maxTailCachePreIndexLength;
+    private final long maxTailCachePreIndexLength;
+
+    /**
+     * The maximum number of bytes to read and process at once from the segment while performing preindexing.
+     * See {@link #getMaxTailCachePreIndexLength()}.
+     */
+    private final int maxTailCachePreIndexBatchLength;
 
     /**
      * The maximum allowed unindexed length ({@link SegmentProperties#getLength() - {@link TableAttributes#INDEX_OFFSET}})
@@ -101,7 +108,8 @@ public class TableExtensionConfig {
     private final Duration recoveryTimeout;
 
     private TableExtensionConfig(TypedProperties properties) throws ConfigurationException {
-        this.maxTailCachePreIndexLength = properties.getPositiveInt(MAX_TAIL_CACHE_PREINDEX_LENGTH);
+        this.maxTailCachePreIndexLength = properties.getPositiveLong(MAX_TAIL_CACHE_PREINDEX_LENGTH);
+        this.maxTailCachePreIndexBatchLength = properties.getPositiveInt(MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE, true);
         this.maxUnindexedLength = properties.getPositiveInt(MAX_UNINDEXED_LENGTH);
         this.maxCompactionSize = properties.getPositiveInt(MAX_COMPACTION_SIZE);
         this.compactionFrequency = properties.getDuration(COMPACTION_FREQUENCY, ChronoUnit.MILLIS);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableExtensionConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableExtensionConfig.java
@@ -17,28 +17,43 @@ package io.pravega.segmentstore.server.tables;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import io.pravega.common.util.ConfigBuilder;
+import io.pravega.common.util.ConfigurationException;
+import io.pravega.common.util.Property;
+import io.pravega.common.util.TypedProperties;
 import io.pravega.segmentstore.contracts.AttributeId;
 import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.tables.TableAttributes;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
-import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
 /**
  * Configuration for {@link ContainerTableExtensionImpl} and sub-components.
+ * NOTE: This should only be used for testing or cluster repair purposes. Even though these settings can be set externally,
+ * it is not recommended to expose them to users. The defaults are chosen conservatively to ensure proper system functioning
+ * under most circumstances.
  */
-@Data
-@Builder
+@Getter
 public class TableExtensionConfig {
+    public static final Property<Integer> MAX_TAIL_CACHE_PREINDEX_LENGTH = Property.named("preindex.bytes.max", EntrySerializer.MAX_BATCH_SIZE * 4);
+    public static final Property<Integer> RECOVERY_TIMEOUT = Property.named("recovery.timeout.millis", 60000);
+    public static final Property<Integer> MAX_UNINDEXED_LENGTH = Property.named("unindexed.bytes.max", EntrySerializer.MAX_BATCH_SIZE * 4);
+    public static final Property<Integer> MAX_COMPACTION_SIZE = Property.named("compaction.bytes.max", EntrySerializer.MAX_SERIALIZATION_LENGTH * 4);
+    public static final Property<Integer> COMPACTION_FREQUENCY = Property.named("compaction.frequency.millis", 30000);
+    public static final Property<Integer> DEFAULT_MIN_UTILIZATION = Property.named("utilization.min", 75);
+    public static final Property<Long> DEFAULT_ROLLOVER_SIZE = Property.named("rollover.size.bytes", (long) EntrySerializer.MAX_SERIALIZATION_LENGTH * 4 * 4);
+    public static final Property<Integer> MAX_BATCH_SIZE = Property.named("batch.size.bytes", EntrySerializer.MAX_BATCH_SIZE);
+    private static final String COMPONENT_CODE = "tables";
+
     /**
      * The maximum unindexed length ({@link SegmentProperties#getLength() - {@link TableAttributes#INDEX_OFFSET}}) of a
      * Segment for which {@link ContainerKeyIndex} {@code triggerCacheTailIndex} can be invoked.
      */
-    @Builder.Default
-    private int maxTailCachePreIndexLength = EntrySerializer.MAX_BATCH_SIZE * 4;
+    private final int maxTailCachePreIndexLength;
 
     /**
      * The maximum allowed unindexed length ({@link SegmentProperties#getLength() - {@link TableAttributes#INDEX_OFFSET}})
@@ -47,49 +62,69 @@ public class TableExtensionConfig {
      * {@link ContainerKeyIndex#notifyIndexOffsetChanged} indicates that this value has been reduced sufficiently in order
      * to allow it to proceed.
      */
-    @Builder.Default
-    private final int maxUnindexedLength = EntrySerializer.MAX_BATCH_SIZE * 4;
+    private final int maxUnindexedLength;
 
     /**
      * The default value to supply to a {@link WriterTableProcessor} to indicate how big compactions need to be.
      * We need to return a value that is large enough to encompass the largest possible Table Entry (otherwise
      * compaction will stall), but not too big, as that will introduce larger indexing pauses when compaction is running.
      */
-    @Builder.Default
-    private final int maxCompactionSize = EntrySerializer.MAX_SERIALIZATION_LENGTH * 4;
+    private final int maxCompactionSize;
 
     /**
      * The amount of time to wait between successive compaction attempts on the same Table Segment. This may not apply
      * to all Table Segment Layouts (i.e., it only applies to Fixed-Key-Length Table Segments).
      */
-    @Builder.Default
-    private final Duration compactionFrequency = Duration.ofSeconds(30);
+    private final Duration compactionFrequency;
 
     /**
      * Default value to set for the {@link TableAttributes#MIN_UTILIZATION} for every new Table Segment.
      */
-    @Builder.Default
-    private final long defaultMinUtilization = 75L;
+    private final long defaultMinUtilization;
 
     /**
      * Default value to set for the {@link Attributes#ROLLOVER_SIZE} for every new Table Segment.
      */
-    @Builder.Default
-    private final long defaultRolloverSize = EntrySerializer.MAX_SERIALIZATION_LENGTH * 4 * 4;
+    private final long defaultRolloverSize;
 
     /**
-     * The maximum size of a single update batch. For unit test purposes only. Do not tinker with in production code.
+     * The maximum size of a single update batch. For unit test purposes only.
+     * IMPORTANT: Do not tinker with in production code. Enforced to be at most {@link EntrySerializer#MAX_BATCH_SIZE}.
      */
-    @Builder.Default
     @VisibleForTesting
-    private final int maxBatchSize = EntrySerializer.MAX_BATCH_SIZE;
+    private final int maxBatchSize;
 
     /**
      * The maximum amount of time to wait for a Table Segment Recovery. If any recovery takes more than this amount of time,
      * all registered calls will be failed with a {@link TimeoutException}.
      */
-    @Builder.Default
-    private Duration recoveryTimeout = Duration.ofSeconds(60);
+    private final Duration recoveryTimeout;
+
+    private TableExtensionConfig(TypedProperties properties) throws ConfigurationException {
+        this.maxTailCachePreIndexLength = properties.getPositiveInt(MAX_TAIL_CACHE_PREINDEX_LENGTH);
+        this.maxUnindexedLength = properties.getPositiveInt(MAX_UNINDEXED_LENGTH);
+        this.maxCompactionSize = properties.getPositiveInt(MAX_COMPACTION_SIZE);
+        this.compactionFrequency = properties.getDuration(COMPACTION_FREQUENCY, ChronoUnit.MILLIS);
+        this.defaultMinUtilization = properties.getPositiveInt(DEFAULT_MIN_UTILIZATION, false);
+        if (this.defaultMinUtilization > 100) {
+            throw new ConfigurationException(String.format("Property '%s' must be a value within [0, 100].", DEFAULT_MIN_UTILIZATION));
+        }
+        this.defaultRolloverSize = properties.getPositiveLong(DEFAULT_ROLLOVER_SIZE);
+        this.maxBatchSize = properties.getPositiveInt(MAX_BATCH_SIZE);
+        if (this.maxBatchSize > EntrySerializer.MAX_BATCH_SIZE) {
+            throw new ConfigurationException(String.format("Property '%s' must be a value within [0, %s].", DEFAULT_MIN_UTILIZATION, EntrySerializer.MAX_BATCH_SIZE));
+        }
+        this.recoveryTimeout = properties.getDuration(RECOVERY_TIMEOUT, ChronoUnit.MILLIS);
+    }
+
+    /**
+     * Creates a new ConfigBuilder that can be used to create instances of this class.
+     *
+     * @return A new Builder for this class.
+     */
+    public static ConfigBuilder<TableExtensionConfig> builder() {
+        return new ConfigBuilder<>(COMPONENT_CODE, TableExtensionConfig::new);
+    }
 
     /**
      * The default Segment Attributes to set for every new Table Segment. These values will override the corresponding

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableWriterConnector.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableWriterConnector.java
@@ -73,6 +73,14 @@ interface TableWriterConnector extends AutoCloseable {
     int getMaxCompactionSize();
 
     /**
+     * Gets a value representing the maximum number of bytes to attempt to index (flush) at once.
+     * @return The maximum flush size.
+     */
+    default int getMaxFlushSize() {
+        return 134217728; // 128MB
+    }
+
+    /**
      * This method will be invoked by the {@link WriterTableProcessor} when it is closed.
      */
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/WriterTableProcessor.java
@@ -15,6 +15,7 @@
  */
 package io.pravega.segmentstore.server.tables;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.TimeoutTimer;
@@ -32,7 +33,7 @@ import io.pravega.segmentstore.server.WriterSegmentProcessor;
 import io.pravega.segmentstore.server.logs.operations.CachedStreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import java.time.Duration;
-import java.util.ArrayList;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -274,7 +275,6 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
      */
     private void flushComplete(TableWriterFlushResult flushResult) {
         log.debug("{}: FlushComplete (State={}).", this.traceObjectId, this.aggregator);
-        this.aggregator.reset();
         this.aggregator.setLastIndexedOffset(flushResult.lastIndexedOffset);
         this.connector.notifyIndexOffsetChanged(this.aggregator.getLastIndexedOffset(), flushResult.processedBytes);
     }
@@ -292,7 +292,13 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
      */
     private CompletableFuture<TableWriterFlushResult> flushOnce(DirectSegmentAccess segment, TimeoutTimer timer) {
         // Index all the keys in the segment range pointed to by the aggregator.
-        KeyUpdateCollection keyUpdates = readKeysFromSegment(segment, this.aggregator.getFirstOffset(), this.aggregator.getLastOffset(), timer);
+        long lastOffset = this.aggregator.getLastIndexToProcessAtOnce(this.connector.getMaxFlushSize());
+        assert lastOffset - this.aggregator.getFirstOffset() <= this.connector.getMaxFlushSize();
+        if (lastOffset < this.aggregator.getLastOffset()) {
+            log.info("{}: Partial flush initiated up to offset {}. State: {}.", this.traceObjectId, lastOffset, this.aggregator);
+        }
+
+        KeyUpdateCollection keyUpdates = readKeysFromSegment(segment, this.aggregator.getFirstOffset(), lastOffset, timer);
         log.debug("{}: Flush.ReadFromSegment KeyCount={}, UpdateCount={}, HighestCopiedOffset={}, LastIndexedOffset={}.", this.traceObjectId,
                 keyUpdates.getUpdates().size(), keyUpdates.getTotalUpdateCount(), keyUpdates.getHighestCopiedOffset(), keyUpdates.getLastIndexedOffset());
 
@@ -464,51 +470,36 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
     //region Helper Classes
 
     @ThreadSafe
-    private static class OperationAggregator {
-        @GuardedBy("this")
-        private long firstSeqNo;
-        @GuardedBy("this")
-        private long lastOffset;
+    @VisibleForTesting
+    static class OperationAggregator {
         @GuardedBy("this")
         private long lastIndexedOffset;
         @GuardedBy("this")
-        private final ArrayList<Long> appendOffsets;
+        private final ArrayDeque<CachedStreamSegmentAppendOperation> appends;
 
         OperationAggregator(long lastIndexedOffset) {
-            this.appendOffsets = new ArrayList<>();
-            reset();
+            this.appends = new ArrayDeque<>();
             this.lastIndexedOffset = lastIndexedOffset;
         }
 
-        synchronized void reset() {
-            this.firstSeqNo = Operation.NO_SEQUENCE_NUMBER;
-            this.lastOffset = -1;
-            this.appendOffsets.clear();
-        }
-
         synchronized void add(CachedStreamSegmentAppendOperation op) {
-            if (this.appendOffsets.size() == 0) {
-                this.firstSeqNo = op.getSequenceNumber();
-            }
-
-            this.lastOffset = op.getLastStreamSegmentOffset();
-            this.appendOffsets.add(op.getStreamSegmentOffset());
+            this.appends.add(op);
         }
 
         synchronized boolean isEmpty() {
-            return this.appendOffsets.isEmpty();
+            return this.appends.isEmpty();
         }
 
         synchronized long getFirstSequenceNumber() {
-            return this.firstSeqNo;
+            return this.appends.isEmpty() ? Operation.NO_SEQUENCE_NUMBER : this.appends.peekFirst().getSequenceNumber();
         }
 
         synchronized long getFirstOffset() {
-            return this.appendOffsets.size() == 0 ? -1 : this.appendOffsets.get(0);
+            return this.appends.isEmpty() ? -1 : this.appends.peekFirst().getStreamSegmentOffset();
         }
 
         synchronized long getLastOffset() {
-            return this.lastOffset;
+            return this.appends.isEmpty() ? -1 : this.appends.peekLast().getLastStreamSegmentOffset();
         }
 
         synchronized long getLastIndexedOffset() {
@@ -516,19 +507,22 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
         }
 
         synchronized boolean setLastIndexedOffset(long value) {
-            if (this.appendOffsets.size() > 0) {
+            if (!this.appends.isEmpty()) {
                 if (value >= getLastOffset()) {
                     // Clear everything - anyway we do not have enough info to determine if this is valid or not.
-                    reset();
+                    this.appends.clear();
                 } else {
-                    // First, make sure we set this to a valid value.
-                    int index = this.appendOffsets.indexOf(value);
-                    if (index < 0) {
-                        return false;
+                    // Remove all appends whose entries have been fully indexed.
+                    while (!this.appends.isEmpty() && this.appends.peekFirst().getLastStreamSegmentOffset() <= value) {
+                        // All the entries in this append have been indexed. It's safe to remove it.
+                        this.appends.removeFirst();
                     }
 
-                    // Clear out smaller offsets.
-                    this.appendOffsets.subList(0, index).clear();
+                    // If we have any leftover appends, check if the desired lastIndexedOffset falls on an append boundary.
+                    // If not, do not change it and report back.
+                    if (!this.appends.isEmpty() && this.appends.peekFirst().getStreamSegmentOffset() != value) {
+                        return false;
+                    }
                 }
             }
 
@@ -539,14 +533,36 @@ public class WriterTableProcessor implements WriterSegmentProcessor {
             return true;
         }
 
+        synchronized long getLastIndexToProcessAtOnce(int maxLength) {
+            val first = this.appends.peekFirst();
+            if (first == null) {
+                return -1; // Nothing to process.
+            }
+
+            // We are optimistic. The majority of our cases will fit in one batch, so we start from the end.
+            long maxOffset = first.getStreamSegmentOffset() + maxLength;
+            val i = this.appends.descendingIterator();
+            while (i.hasNext()) {
+                val lastOffset = i.next().getLastStreamSegmentOffset();
+                if (lastOffset <= maxOffset) {
+                    // We found the last append which can fit wholly within the given maxLength
+                    return lastOffset;
+                }
+            }
+
+            // If we get here, then maxLength is smaller than the first append's length. In order to continue, we have
+            // no choice but to process that first append anyway.
+            return first.getLastStreamSegmentOffset();
+        }
+
         synchronized int size() {
-            return this.appendOffsets.size();
+            return this.appends.size();
         }
 
         @Override
         public synchronized String toString() {
             return String.format("Count = %d, FirstSN = %d, FirstOffset = %d, LastOffset = %d, LIdx = %s",
-                    this.appendOffsets.size(), this.firstSeqNo, getFirstOffset(), getLastOffset(), getLastIndexedOffset());
+                    this.appends.size(), getFirstSequenceNumber(), getFirstOffset(), getLastOffset(), getLastIndexedOffset());
         }
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/DebugStreamSegmentContainerTests.java
@@ -40,6 +40,7 @@ import io.pravega.segmentstore.server.reading.ContainerReadIndexFactory;
 import io.pravega.segmentstore.server.reading.ReadIndexConfig;
 import io.pravega.segmentstore.server.tables.ContainerTableExtension;
 import io.pravega.segmentstore.server.tables.ContainerTableExtensionImpl;
+import io.pravega.segmentstore.server.tables.TableExtensionConfig;
 import io.pravega.segmentstore.server.writer.StorageWriterFactory;
 import io.pravega.segmentstore.server.writer.WriterConfig;
 import io.pravega.segmentstore.storage.AsyncStorageWrapper;
@@ -533,7 +534,7 @@ public class DebugStreamSegmentContainerTests extends ThreadPooledTestSuite {
         }
 
         private ContainerTableExtension createTableExtension(SegmentContainer c, ScheduledExecutorService e) {
-            return new ContainerTableExtensionImpl(c, this.cacheManager, e);
+            return new ContainerTableExtensionImpl(TableExtensionConfig.builder().build(), c, this.cacheManager, e);
         }
 
         @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -89,6 +89,7 @@ import io.pravega.segmentstore.server.reading.ReadIndexConfig;
 import io.pravega.segmentstore.server.reading.TestReadResultHandler;
 import io.pravega.segmentstore.server.tables.ContainerTableExtension;
 import io.pravega.segmentstore.server.tables.ContainerTableExtensionImpl;
+import io.pravega.segmentstore.server.tables.TableExtensionConfig;
 import io.pravega.segmentstore.server.writer.StorageWriterFactory;
 import io.pravega.segmentstore.server.writer.WriterConfig;
 import io.pravega.segmentstore.storage.AsyncStorageWrapper;
@@ -2759,7 +2760,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
         }
 
         private ContainerTableExtension createTableExtension(SegmentContainer c, ScheduledExecutorService e) {
-            return new ContainerTableExtensionImpl(c, this.cacheManager, e);
+            return new ContainerTableExtensionImpl(TableExtensionConfig.builder().build(), c, this.cacheManager, e);
         }
 
         private SegmentContainerFactory.CreateExtensions createExtensions(SegmentContainerFactory.CreateExtensions additional) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/TableMetadataStoreTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/TableMetadataStoreTests.java
@@ -88,7 +88,10 @@ public class TableMetadataStoreTests extends MetadataStoreTestBase {
         TableTestContext(TestConnector connector) {
             super(connector);
             this.tableStore = new TestTableStore(executorService());
-            this.config = TableExtensionConfig.builder().defaultRolloverSize(12345).defaultMinUtilization(90).build();
+            this.config = TableExtensionConfig.builder()
+                    .with(TableExtensionConfig.DEFAULT_ROLLOVER_SIZE, 12345L)
+                    .with(TableExtensionConfig.DEFAULT_MIN_UTILIZATION, 90)
+                    .build();
             this.metadataStore = new TableMetadataStore(this.connector, this.tableStore, config, executorService());
             this.storageReadCount = new AtomicInteger(0);
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -952,9 +952,9 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
             this.segment = new SegmentMock(executorService());
             this.segment.updateAttributes(TableAttributes.DEFAULT_VALUES);
             this.defaultConfig = TableExtensionConfig.builder()
-                    .maxTailCachePreIndexLength(TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH)
-                    .maxUnindexedLength(maxUnindexedSize)
-                    .recoveryTimeout(Duration.ofMillis(ContainerKeyIndexTests.SHORT_TIMEOUT_MILLIS))
+                    .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_LENGTH, TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH)
+                    .with(TableExtensionConfig.MAX_UNINDEXED_LENGTH, maxUnindexedSize)
+                    .with(TableExtensionConfig.RECOVERY_TIMEOUT, (int) ContainerKeyIndexTests.SHORT_TIMEOUT_MILLIS)
                     .build();
             this.index = createIndex(this.defaultConfig, executorService());
             this.timer = new TimeoutTimer(TIMEOUT);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/HashTableSegmentLayoutTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/HashTableSegmentLayoutTests.java
@@ -185,8 +185,11 @@ public class HashTableSegmentLayoutTests extends TableSegmentLayoutTestBase {
         // Generate a set of TestEntryData (List<TableEntry>, ExpectedResults.
         // Process each TestEntryData in turn.  After each time, re-create the Extension.
         // Verify gets are blocked on indexing. Then index, verify unblocked and then re-create the Extension, and verify again.
+        val recoveryConfig = TableExtensionConfig.builder()
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE, (MAX_KEY_LENGTH + MAX_VALUE_LENGTH) * 11)
+                .build();
         @Cleanup
-        val context = new TableContext(executorService());
+        val context = new TableContext(recoveryConfig, executorService());
 
         // Create the Segment.
         context.ext.createSegment(SEGMENT_NAME, SegmentType.TABLE_SEGMENT_HASH, TIMEOUT).join();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/HashTableSegmentLayoutTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/HashTableSegmentLayoutTests.java
@@ -258,7 +258,7 @@ public class HashTableSegmentLayoutTests extends TableSegmentLayoutTestBase {
 
         // We set up throttling such that we allow 'unthrottledCount' through, but block (throttle) on the next one.
         val config = TableExtensionConfig.builder()
-                .maxUnindexedLength(unthrottledCount * (keyLength + valueLength + EntrySerializer.HEADER_LENGTH))
+                .with(TableExtensionConfig.MAX_UNINDEXED_LENGTH, unthrottledCount * (keyLength + valueLength + EntrySerializer.HEADER_LENGTH))
                 .build();
 
         val s = new EntrySerializer();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableEntryDeltaIteratorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableEntryDeltaIteratorTests.java
@@ -63,7 +63,9 @@ public class TableEntryDeltaIteratorTests extends ThreadPooledTestSuite {
 
     private static final int NUM_ENTRIES = 10;
     private static final int MAX_UPDATE_COUNT = 10000;
-    private static final TableExtensionConfig CONFIG = TableExtensionConfig.builder().maxCompactionSize(50000).build();
+    private static final TableExtensionConfig CONFIG = TableExtensionConfig.builder()
+            .with(TableExtensionConfig.MAX_COMPACTION_SIZE, 50000)
+            .build();
 
     private static final TableEntry NON_EXISTING_ENTRY = TableEntry.notExists(
             new ByteArraySegment("NULL".getBytes()),

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableExtensionConfigTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableExtensionConfigTests.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.server.tables;
+
+import io.pravega.common.util.ConfigurationException;
+import io.pravega.test.common.AssertExtensions;
+import java.time.Duration;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the {@link TableExtensionConfig} class.
+ */
+public class TableExtensionConfigTests {
+    @Test
+    public void testDefaultValues() {
+        val b = TableExtensionConfig.builder();
+        val defaultConfig = b.build();
+        Assert.assertEquals(EntrySerializer.MAX_BATCH_SIZE * 4, defaultConfig.getMaxTailCachePreIndexLength());
+        Assert.assertEquals(Duration.ofSeconds(60), defaultConfig.getRecoveryTimeout());
+        Assert.assertEquals(EntrySerializer.MAX_BATCH_SIZE * 4, defaultConfig.getMaxUnindexedLength());
+        Assert.assertEquals(EntrySerializer.MAX_SERIALIZATION_LENGTH * 4, defaultConfig.getMaxCompactionSize());
+        Assert.assertEquals(Duration.ofSeconds(30), defaultConfig.getCompactionFrequency());
+        Assert.assertEquals(75, defaultConfig.getDefaultMinUtilization());
+        Assert.assertEquals(EntrySerializer.MAX_SERIALIZATION_LENGTH * 4 * 4, defaultConfig.getDefaultRolloverSize());
+        Assert.assertEquals(EntrySerializer.MAX_BATCH_SIZE, defaultConfig.getMaxBatchSize());
+    }
+
+    @Test
+    public void testBuilder() {
+        val b = TableExtensionConfig.builder();
+        b.with(TableExtensionConfig.DEFAULT_MIN_UTILIZATION, 101);
+        AssertExtensions.assertThrows(ConfigurationException.class, b::build); // 101 is out of the range [0, 100]
+
+        b.with(TableExtensionConfig.DEFAULT_MIN_UTILIZATION, 10);
+        b.with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_LENGTH, 11);
+        b.with(TableExtensionConfig.RECOVERY_TIMEOUT, 12);
+        b.with(TableExtensionConfig.MAX_UNINDEXED_LENGTH, 13);
+        b.with(TableExtensionConfig.MAX_COMPACTION_SIZE, 14);
+        b.with(TableExtensionConfig.COMPACTION_FREQUENCY, 15);
+        b.with(TableExtensionConfig.DEFAULT_ROLLOVER_SIZE, 16L);
+        b.with(TableExtensionConfig.MAX_BATCH_SIZE, 17);
+
+        val c = b.build();
+        Assert.assertEquals(10, c.getDefaultMinUtilization());
+        Assert.assertEquals(11, c.getMaxTailCachePreIndexLength());
+        Assert.assertEquals(Duration.ofMillis(12), c.getRecoveryTimeout());
+        Assert.assertEquals(13, c.getMaxUnindexedLength());
+        Assert.assertEquals(14, c.getMaxCompactionSize());
+        Assert.assertEquals(Duration.ofMillis(15), c.getCompactionFrequency());
+        Assert.assertEquals(16, c.getDefaultRolloverSize());
+        Assert.assertEquals(17, c.getMaxBatchSize());
+    }
+}

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableExtensionConfigTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableExtensionConfigTests.java
@@ -31,6 +31,7 @@ public class TableExtensionConfigTests {
         val b = TableExtensionConfig.builder();
         val defaultConfig = b.build();
         Assert.assertEquals(EntrySerializer.MAX_BATCH_SIZE * 4, defaultConfig.getMaxTailCachePreIndexLength());
+        Assert.assertEquals(EntrySerializer.MAX_BATCH_SIZE * 4, defaultConfig.getMaxTailCachePreIndexBatchLength());
         Assert.assertEquals(Duration.ofSeconds(60), defaultConfig.getRecoveryTimeout());
         Assert.assertEquals(EntrySerializer.MAX_BATCH_SIZE * 4, defaultConfig.getMaxUnindexedLength());
         Assert.assertEquals(EntrySerializer.MAX_SERIALIZATION_LENGTH * 4, defaultConfig.getMaxCompactionSize());
@@ -47,7 +48,8 @@ public class TableExtensionConfigTests {
         AssertExtensions.assertThrows(ConfigurationException.class, b::build); // 101 is out of the range [0, 100]
 
         b.with(TableExtensionConfig.DEFAULT_MIN_UTILIZATION, 10);
-        b.with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_LENGTH, 11);
+        b.with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_LENGTH, 11L);
+        b.with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE, 111);
         b.with(TableExtensionConfig.RECOVERY_TIMEOUT, 12);
         b.with(TableExtensionConfig.MAX_UNINDEXED_LENGTH, 13);
         b.with(TableExtensionConfig.MAX_COMPACTION_SIZE, 14);
@@ -57,7 +59,8 @@ public class TableExtensionConfigTests {
 
         val c = b.build();
         Assert.assertEquals(10, c.getDefaultMinUtilization());
-        Assert.assertEquals(11, c.getMaxTailCachePreIndexLength());
+        Assert.assertEquals(11L, c.getMaxTailCachePreIndexLength());
+        Assert.assertEquals(111, c.getMaxTailCachePreIndexBatchLength());
         Assert.assertEquals(Duration.ofMillis(12), c.getRecoveryTimeout());
         Assert.assertEquals(13, c.getMaxUnindexedLength());
         Assert.assertEquals(14, c.getMaxCompactionSize());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableSegmentLayoutTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableSegmentLayoutTestBase.java
@@ -332,8 +332,8 @@ public abstract class TableSegmentLayoutTestBase extends ThreadPooledTestSuite {
     @SneakyThrows
     protected void testTableSegmentCompacted(KeyHasher keyHasher, CheckTable checkTable) {
         val config = TableExtensionConfig.builder()
-                .maxCompactionSize((MAX_KEY_LENGTH + MAX_VALUE_LENGTH) * BATCH_SIZE)
-                .compactionFrequency(Duration.ofMillis(1))
+                .with(TableExtensionConfig.MAX_COMPACTION_SIZE, (MAX_KEY_LENGTH + MAX_VALUE_LENGTH) * BATCH_SIZE)
+                .with(TableExtensionConfig.COMPACTION_FREQUENCY, 1)
                 .build();
         @Cleanup
         val context = new TableContext(config, keyHasher, executorService());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableServiceTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableServiceTests.java
@@ -105,6 +105,9 @@ public class TableServiceTests extends ThreadPooledTestSuite {
             .include(ReadIndexConfig
                     .builder()
                     .with(ReadIndexConfig.STORAGE_READ_ALIGNMENT, 1024))
+            .include(TableExtensionConfig
+                    .builder()
+                    .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE, (MAX_KEY_LENGTH + MAX_KEY_LENGTH) * 13))
             .include(WriterConfig
                     .builder()
                     .with(WriterConfig.FLUSH_THRESHOLD_BYTES, 1)

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/WriterTableProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/WriterTableProcessorTests.java
@@ -72,6 +72,8 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
     private static final int UPDATE_BATCH_SIZE = 689;
     private static final double REMOVE_FRACTION = 0.3; // 30% of generated operations are removes.
     private static final int MAX_COMPACT_LENGTH = (MAX_KEY_LENGTH + MAX_VALUE_LENGTH) * UPDATE_BATCH_SIZE;
+    private static final int DEFAULT_MAX_FLUSH_SIZE = 128 * 1024 * 1024; // Default from TableWriterConnector.
+    private static final int MAX_FLUSH_ATTEMPTS = 100; // To make sure we don't get stuck in an infinite flush loop.
     private static final Duration TIMEOUT = Duration.ofSeconds(30);
     @Rule
     public Timeout globalTimeout = new Timeout(TIMEOUT.toMillis() * 4, TimeUnit.MILLISECONDS);
@@ -146,13 +148,21 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
     }
 
     /**
+     * Tests the {@link WriterTableProcessor#flush} method using a non-collision-prone KeyHasher.
+     */
+    @Test
+    public void testFlushSmallBatches() throws Exception {
+        int maxBatchSize = (MAX_KEY_LENGTH + MAX_VALUE_LENGTH) * 7;
+        testFlushWithHasher(KeyHashers.DEFAULT_HASHER, 0, maxBatchSize);
+    }
+
+    /**
      * Tests the {@link WriterTableProcessor#flush} method using a collision-prone KeyHasher.
      */
     @Test
     public void testFlushCollisions() throws Exception {
         testFlushWithHasher(KeyHashers.COLLISION_HASHER);
     }
-
 
     /**
      * Tests the {@link WriterTableProcessor#flush} method using a non-collision-prone KeyHasher and forcing compactions.
@@ -232,16 +242,85 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
         Assert.assertFalse("Unexpected result from mustFlush() after full reconciliation.", context.processor.mustFlush());
     }
 
+    /**
+     * Tests {@link WriterTableProcessor.OperationAggregator}
+     */
+    @Test
+    public void testOperationAggregator() {
+        @Cleanup
+        val context = new TestContext();
+        val a = new WriterTableProcessor.OperationAggregator(123L);
+
+        // Empty (nothing in it).
+        Assert.assertEquals(123L, a.getLastIndexedOffset());
+        Assert.assertEquals(-1L, a.getFirstOffset());
+        Assert.assertEquals(-1L, a.getLastOffset());
+        Assert.assertEquals(Operation.NO_SEQUENCE_NUMBER, a.getFirstSequenceNumber());
+        Assert.assertTrue(a.isEmpty());
+        Assert.assertEquals(0, a.size());
+        Assert.assertEquals(-1L, a.getLastIndexToProcessAtOnce(12345));
+
+        a.setLastIndexedOffset(124L);
+        Assert.assertEquals(124L, a.getLastIndexedOffset());
+
+        // Add one operation.
+        val op1 = generateSimulatedAppend(123L, 1000, context);
+        a.add(op1);
+        Assert.assertEquals(124L, a.getLastIndexedOffset());
+        Assert.assertEquals(op1.getStreamSegmentOffset(), a.getFirstOffset());
+        Assert.assertEquals(op1.getLastStreamSegmentOffset(), a.getLastOffset());
+        Assert.assertEquals(op1.getSequenceNumber(), a.getFirstSequenceNumber());
+        Assert.assertFalse(a.isEmpty());
+        Assert.assertEquals(1, a.size());
+        Assert.assertEquals(op1.getLastStreamSegmentOffset(), a.getLastIndexToProcessAtOnce(12));
+        Assert.assertEquals(op1.getLastStreamSegmentOffset(), a.getLastIndexToProcessAtOnce(123456));
+
+        // Add a second operation.
+        val op2 = generateSimulatedAppend(op1.getLastStreamSegmentOffset() + 1, 1000, context);
+        a.add(op2);
+        Assert.assertEquals(124L, a.getLastIndexedOffset());
+        Assert.assertEquals(op1.getStreamSegmentOffset(), a.getFirstOffset());
+        Assert.assertEquals(op2.getLastStreamSegmentOffset(), a.getLastOffset());
+        Assert.assertEquals(op1.getSequenceNumber(), a.getFirstSequenceNumber());
+        Assert.assertFalse(a.isEmpty());
+        Assert.assertEquals(2, a.size());
+        Assert.assertEquals(op1.getLastStreamSegmentOffset(), a.getLastIndexToProcessAtOnce(12));
+        Assert.assertEquals(op1.getLastStreamSegmentOffset(), a.getLastIndexToProcessAtOnce((int) op1.getLength() + 1));
+        Assert.assertEquals(op2.getLastStreamSegmentOffset(), a.getLastIndexToProcessAtOnce(123456));
+
+        // Test setLastIndexedOffset.
+        boolean r = a.setLastIndexedOffset(op1.getStreamSegmentOffset() + 1);
+        Assert.assertFalse(r);
+        Assert.assertEquals(124L, a.getLastIndexedOffset());
+        Assert.assertEquals(2, a.size());
+
+        r = a.setLastIndexedOffset(op2.getStreamSegmentOffset());
+        Assert.assertTrue(r);
+        Assert.assertEquals(op2.getStreamSegmentOffset(), a.getLastIndexedOffset());
+        Assert.assertEquals(1, a.size());
+
+        r = a.setLastIndexedOffset(op2.getLastStreamSegmentOffset() + 1);
+        Assert.assertTrue(r);
+        Assert.assertEquals(op2.getLastStreamSegmentOffset() + 1, a.getLastIndexedOffset());
+        Assert.assertEquals(0, a.size());
+    }
+
     private void testFlushWithHasher(KeyHasher hasher) throws Exception {
         testFlushWithHasher(hasher, 0);
     }
 
     private void testFlushWithHasher(KeyHasher hasher, int minSegmentUtilization) throws Exception {
+        testFlushWithHasher(hasher, minSegmentUtilization, DEFAULT_MAX_FLUSH_SIZE);
+    }
+
+    private void testFlushWithHasher(KeyHasher hasher, int minSegmentUtilization, int maxFlushSize) throws Exception {
         // Generate a set of operations, each containing one or more entries. Each entry is an update or a remove.
         // Towards the beginning we have more updates than removes, then removes will prevail.
         @Cleanup
         val context = new TestContext(hasher);
         context.setMinUtilization(minSegmentUtilization);
+        context.setMaxFlushSize(maxFlushSize);
+
         val batches = generateAndPopulateEntries(context);
         val allKeys = new HashMap<BufferView, UUID>(); // All keys, whether added or removed.
 
@@ -256,12 +335,16 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
             Assert.assertEquals("Unexpected LUSN before call to flush().",
                     batch.operations.get(0).getSequenceNumber(), context.processor.getLowestUncommittedSequenceNumber());
 
-            // Flush.
-            val initialNotifyCount = context.connector.notifyCount.get();
-            val f1 = context.processor.flush(TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-            AssertExtensions.assertGreaterThan("No calls to notifyIndexOffsetChanged().",
-                    initialNotifyCount, context.connector.notifyCount.get());
-            Assert.assertTrue(f1.isAnythingFlushed());
+            // Flush at least once. If maxFlushSize is not the default, then we're in a test that wants to verify repeated
+            // flushes; in that case we should flush until there's nothing more to flush.
+            int remainingFlushes = MAX_FLUSH_ATTEMPTS;
+            do {
+                val initialNotifyCount = context.connector.notifyCount.get();
+                val f1 = context.processor.flush(TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                AssertExtensions.assertGreaterThan("No calls to notifyIndexOffsetChanged().",
+                        initialNotifyCount, context.connector.notifyCount.get());
+                Assert.assertTrue(f1.isAnythingFlushed());
+            } while (maxFlushSize < DEFAULT_MAX_FLUSH_SIZE && --remainingFlushes > 0 && context.processor.mustFlush());
 
             // Post-flush validation.
             Assert.assertFalse("Unexpected value from mustFlush() after call to flush().", context.processor.mustFlush());
@@ -496,7 +579,7 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
     }
 
     @RequiredArgsConstructor
-    private class TestBatchData {
+    private static class TestBatchData {
         final HashMap<BufferView, TableEntry> expectedEntries;
         final List<CachedStreamSegmentAppendOperation> operations = new ArrayList<>();
     }
@@ -513,6 +596,7 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
         final IndexReader indexReader;
         final Random random;
         final AtomicLong sequenceNumber;
+        final AtomicInteger maxFlushSize = new AtomicInteger(128 * 1024 * 1024);
 
         TestContext() {
             this(KeyHashers.DEFAULT_HASHER);
@@ -539,6 +623,10 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
 
         long nextSequenceNumber() {
             return this.sequenceNumber.incrementAndGet();
+        }
+
+        void setMaxFlushSize(int value) {
+            this.maxFlushSize.set(value);
         }
 
         void setMinUtilization(int value) {
@@ -608,6 +696,11 @@ public class WriterTableProcessorTests extends ThreadPooledTestSuite {
             @Override
             public int getMaxCompactionSize() {
                 return MAX_COMPACT_LENGTH;
+            }
+
+            @Override
+            public int getMaxFlushSize() {
+                return maxFlushSize.get();
             }
 
             @Override


### PR DESCRIPTION
**Change log description**  
- Made `TableExtensionConfig` externally-configurable. This should allow us to properly tweak this if we have to (for debugging/repair purposes).
- Changed `ContainerKeyIndex` pre-caching to execute in batches, no bigger than 128MB. This will enable precaching of larger segments without the risk of running out of memory.
- Changed `WriterTableProcessor` to index a maximum of 128MB at once, even if the backlog is bigger. Remaining unindexed data will be processed in later iterations.

**Purpose of the change**  
Fixes #6139.

**What the code does**  
- `TableExtensionConfig` 
    - This defines the major config points for the `ContainerTableExtensionConfig` component. The original purpose was to make unit testing easier.
    - This change converts it to an externally-configurable component (just like any other config components) which should enable us to tweak these values if we need to get the Pravega cluster out of a bad state.
- `ContainerKeyIndex` pre-caching
    - Using an async loop to break down the pre-cache segment range into smaller ranges and process them in sequence. This way, no more than 128MB (or whatever is configured) of data will be read in memory at any given time.
 - `WriterTableProcessor`
     - Changed the `flush` behavior to cap the amount of data to process at 128MB. The actual exact amount of data will vary, as it will try to stop on an append boundary (otherwise it may try to stop in the middle of a table entry).


**How to verify it**  
All existing unit tests must pass - this was an "idempotent" change.
Some unit tests have been updated to check for new cases and new unit tests have been added to verify the same.