### PR TITLE
Issue 5699: SLTS - Old system journal files should be garbage collected.

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -897,9 +897,7 @@ public class SystemJournal {
                 },
                 v -> epochToRecover.incrementAndGet(),
                 executor)
-                .thenAcceptAsync(vv -> {
-                    pendingGarbageChunks.addAll(journalsProcessed);
-                }, executor);
+                .thenRunAsync(() -> pendingGarbageChunks.addAll(journalsProcessed), executor);
     }
 
     private CompletableFuture<Void> processJournalContents(MetadataTransaction txn, BootstrapState state, String systemLogName, ByteArrayInputStream input) {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -180,6 +181,11 @@ public class SystemJournal {
      * Handle to current journal file.
      */
     final private AtomicReference<ChunkHandle> currentHandle = new AtomicReference<>();
+
+    /**
+     * List of chunks (journals & snapshots) to delete after snapshot.
+     */
+    final private List<String> pendingGarbageChunks = Collections.synchronizedList(new ArrayList<>());
 
     /**
      * Configuration {@link ChunkedSegmentStorageConfig} for the {@link ChunkedSegmentStorage}.
@@ -512,7 +518,11 @@ public class SystemJournal {
                 shouldSave = false;
             }
             if (shouldSave) {
-                return writeSnapshotInfo(lastSavedSystemSnapshotId.get());
+                return writeSnapshotInfo(lastSavedSystemSnapshotId.get())
+                        .thenRunAsync(() -> {
+                            garbageCollector.addToGarbage(pendingGarbageChunks);
+                            pendingGarbageChunks.clear();
+                        }, executor);
             }
         }
 
@@ -531,8 +541,13 @@ public class SystemJournal {
                             .build();
                     return snapshotInfoStore.writeSnapshotInfo(info)
                             .thenAcceptAsync(v1 -> {
+                                val oldSnapshotInfo = lastSavedSnapshotInfo.get();
                                 log.info("SystemJournal[{}] Snapshot info saved.{}", containerId, info);
                                 lastSavedSnapshotInfo.set(info);
+                                if (null != oldSnapshotInfo) {
+                                    val oldSnapshotFile = NameUtils.getSystemJournalSnapshotFileName(containerId, epoch, oldSnapshotInfo.getSnapshotId());
+                                    pendingGarbageChunks.add(oldSnapshotFile);
+                                }
                             }, executor)
                             .exceptionally(e -> {
                                 log.error("Unable to persist snapshot info.{}", currentSnapshotIndex, e);
@@ -588,7 +603,8 @@ public class SystemJournal {
         } catch (Exception e) {
             val ex = Exceptions.unwrap(e);
             if (ex instanceof EOFException) {
-                log.warn("SystemJournal[{}] Incomplete snapshot found, skipping {}.", containerId, snapshotInfo, e);
+                log.error("SystemJournal[{}] Incomplete snapshot found, skipping {}.", containerId, snapshotInfo, e);
+                throw new CompletionException(e);
             } else if (ex instanceof ChunkNotFoundException) {
                 log.warn("SystemJournal[{}] Missing snapshot, skipping {}.", containerId, snapshotInfo, e);
             } else {
@@ -833,6 +849,7 @@ public class SystemJournal {
 
         val epochToStartScanning = new AtomicLong();
         val fileIndexToRecover = new AtomicInteger(1);
+        val journalsProcessed = Collections.synchronizedList(new ArrayList<String>());
         // Starting with journal file after last snapshot,
         if (null != systemSnapshotRecord) {
             epochToStartScanning.set(systemSnapshotRecord.epoch);
@@ -865,6 +882,7 @@ public class SystemJournal {
                                                         containerId, epochToRecover.get(), fileIndexToRecover.get());
                                                 return CompletableFuture.completedFuture(null);
                                             } else {
+                                                journalsProcessed.add(systemLogName);
                                                 // Read contents.
                                                 return getContents(systemLogName)
                                                         // Apply record batches from the file.
@@ -880,7 +898,10 @@ public class SystemJournal {
                             executor);
                 },
                 v -> epochToRecover.incrementAndGet(),
-                executor);
+                executor)
+                .thenAcceptAsync(vv -> {
+                    pendingGarbageChunks.addAll(journalsProcessed);
+                }, executor);
     }
 
     private CompletableFuture<Void> processJournalContents(MetadataTransaction txn, BootstrapState state, String systemLogName, ByteArrayInputStream input) {
@@ -1287,6 +1308,7 @@ public class SystemJournal {
                     new ByteArrayInputStream(bytes.array(), bytes.arrayOffset(), bytes.getLength()))
                     .thenAcceptAsync(h -> {
                         currentHandle.set(h);
+                        pendingGarbageChunks.add(h.getChunkName());
                         systemJournalOffset.addAndGet(bytes.getLength());
                         newChunkRequired.set(false);
                     }, executor);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalOperationsTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalOperationsTests.java
@@ -192,6 +192,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         val testContext = new TestContext(CONTAINER_ID);
         testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .maxJournalUpdatesPerSnapshot(2)
+                .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
                 .build());
 
@@ -269,6 +270,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         val testContext = new TestContext(CONTAINER_ID);
         testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .maxJournalUpdatesPerSnapshot(3)
+                .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
                 .build());
 
@@ -347,6 +349,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         val testContext = new TestContext(CONTAINER_ID);
         testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .maxJournalUpdatesPerSnapshot(2)
+                .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
                 .build());
 
@@ -418,6 +421,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         val testContext = new TestContext(CONTAINER_ID);
         testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .maxJournalUpdatesPerSnapshot(2)
+                .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
                 .build());
         val testSegmentName = testContext.segmentNames[0];
@@ -496,6 +500,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
                 val testContext = new TestContext(CONTAINER_ID);
                 testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                         .maxJournalUpdatesPerSnapshot(2)
+                        .garbageCollectionDelay(Duration.ZERO)
                         .selfCheckEnabled(true)
                         .build());
                 val testSegmentName = testContext.segmentNames[0];
@@ -529,6 +534,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         val testContext = new TestContext(CONTAINER_ID);
         testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .maxJournalUpdatesPerSnapshot(2)
+                .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
                 .build());
         val testSegmentName = testContext.segmentNames[0];
@@ -558,6 +564,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         val testContext = new TestContext(CONTAINER_ID, chunkStorage);
         testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .maxJournalUpdatesPerSnapshot(2)
+                .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
                 .build());
         val testSegmentName = testContext.segmentNames[0];
@@ -816,6 +823,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
     @Data
     class TestContext implements AutoCloseable {
         ChunkedSegmentStorageConfig config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
                 .build();
         ChunkStorage chunkStorage;
@@ -889,6 +897,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
 
         void bootstrap() throws Exception {
             systemJournal.bootstrap(epoch, snapshotInfoStore).join();
+            garbageCollector.deleteGarbage(false, 1000).get();
         }
 
         /**

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -29,6 +29,7 @@ import io.pravega.shared.NameUtils;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.io.ByteArrayInputStream;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.function.Consumer;
 import lombok.Cleanup;


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Old system journal files are now added garbage collector queue after new snapshot is saved.

**Purpose of the change**  
Fixes #5699

**What the code does**  
Keeps track of all journal files added since last snapshot and then after new snapshot is created these file are added to GC queue.

Note - This code will not clean up previously created garbage. It just prevents GC leaks in future. 

**How to verify it**  
All tests should pass.
System tests should be green.
