### PR TITLE
Issue: 6166: Cherry-pick #6118 into r0.9

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -480,9 +480,9 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         // Length must be at least StorageLength.
         metadata.setLength(Math.max(mapping.getLength(), metadata.getLength()));
 
-        // StartOffset must not exceed the last offset of the Segment.
+        // StartOffset must be a value in the interval [0, Length] (closed at both ends).
         if (metadata.getLength() > 0) {
-            metadata.setStartOffset(Math.min(mapping.getStartOffset(), metadata.getLength() - 1));
+            metadata.setStartOffset(Math.min(mapping.getStartOffset(), metadata.getLength()));
         }
 
         if (mapping.isSealed()) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
@@ -1038,6 +1038,21 @@ public class ContainerMetadataUpdateTransactionTests {
         txn2.commit(metadata);
         val pinnedMetadata = metadata.getStreamSegmentMetadata(metadata.getStreamSegmentId(pinnedMap.getStreamSegmentName(), false));
         Assert.assertTrue("Unexpected isPinned for pinned map.", pinnedMetadata.isPinned());
+
+        // Truncate offset is beyond the length.
+        val truncateMap = new StreamSegmentMapOperation(StreamSegmentInformation
+                .builder()
+                .name(mapOp.getStreamSegmentName() + "_truncate")
+                .length(storageLength)
+                .startOffset(storageLength) // StreamSegmentInformation does not allow us to exceed Length for this value.
+                .sealed(true)
+                .attributes(createAttributes())
+                .build());
+        txn2.preProcessOperation(truncateMap);
+        txn2.acceptOperation(truncateMap);
+        txn2.commit(metadata);
+        val truncatedMetadata = metadata.getStreamSegmentMetadata(metadata.getStreamSegmentId(truncateMap.getStreamSegmentName(), false));
+        Assert.assertEquals("Unexpected startOffset for over-zealously truncated segment.", truncatedMetadata.getLength(), truncatedMetadata.getStartOffset());
     }
 
     /**


### PR DESCRIPTION

**Change log description**  
Cherry-pick:
- Issue #6118: (SegmentStore) Bugfix for StartOffset decremented by 1 up on segment remapping
    - Fixed a bug where it was possible to subtract 1 from the StartOffset of the segment if the previous StartOffset was set to the Length of the segment.

**Purpose of the change**  
Fixes #6166.

**What the code does**  
Cherry-pick.

**How to verify it**  
Cherry-pick.