### PR TITLE
Issue 6137: Large Appends SegmentStore

### DIFF
--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/Attributes.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/Attributes.java
@@ -129,7 +129,7 @@ public class Attributes {
      * Defines an attribute that is used to store the current epoch that the segment was created in. This is used to clean
      * up any transient segments that were not able to be cleaned up during normal shutdown/close procedures.
      */
-    public static final AttributeId CREATION_EPOCH = AttributeId.uuid(CORE_ATTRIBUTE_ID_PREFIX, 13);
+    public static final AttributeId CREATION_EPOCH = AttributeId.uuid(CORE_ATTRIBUTE_ID_PREFIX, 15);
 
     /**
      * Determines whether the given attribute cannot be modified once originally set on the Segment.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/Attributes.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/Attributes.java
@@ -126,6 +126,12 @@ public class Attributes {
     public static final AttributeId ATTRIBUTE_ID_LENGTH = AttributeId.uuid(CORE_ATTRIBUTE_ID_PREFIX, 12);
 
     /**
+     * Defines an attribute that is used to store the current epoch that the segment was created in. This is used to clean
+     * up any transient segments that were not able to be cleaned up during normal shutdown/close procedures.
+     */
+    public static final AttributeId CREATION_EPOCH = AttributeId.uuid(CORE_ATTRIBUTE_ID_PREFIX, 13);
+
+    /**
      * Determines whether the given attribute cannot be modified once originally set on the Segment.
      *
      * @param attributeId The Attribute Id to check.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
@@ -37,6 +37,10 @@ public class SegmentType {
      * General Table Segment with no special roles.
      */
     public static final SegmentType TABLE_SEGMENT_HASH = SegmentType.builder().tableSegment().build();
+    /**
+     * General Transient Segment with no special roles.
+     */
+    public static final SegmentType TRANSIENT_SEGMENT = SegmentType.builder().transientSegment().build();
 
     //endregion
 
@@ -60,7 +64,8 @@ public class SegmentType {
     static final long ROLE_SYSTEM = 0b0010_0000L | ROLE_INTERNAL;
     @VisibleForTesting
     static final long ROLE_CRITICAL = 0b0100_0000L;
-
+    @VisibleForTesting
+    static final long ROLE_TRANSIENT = 0b1000_0000;
     private final long flags;
 
     //endregion
@@ -110,6 +115,15 @@ public class SegmentType {
     }
 
     /**
+     * Whether this {@link SegmentType} refers to a Transient Segment (which implies {@link #isTransient()}.
+     *
+     * @return True if Transient Segment, false otherwise.
+     */
+    public boolean isTransient() {
+        return (this.flags & ROLE_TRANSIENT) == ROLE_TRANSIENT;
+    }
+
+    /**
      * Whether this {@link SegmentType} refers to a Segment (regardless of Format) that is for exclusive internal access.
      * If so, external requests may be denied on such Segments.
      *
@@ -150,6 +164,10 @@ public class SegmentType {
             result.append(", Table Segment (Fixed-Key-Length)");
         } else if (isTableSegment()) {
             result.append(", Table Segment");
+        }
+
+        if (isTableSegment()) {
+            result.append(", Transient");
         }
 
         if (isSystem()) {
@@ -244,6 +262,11 @@ public class SegmentType {
 
         public Builder fixedKeyLengthTableSegment() {
             this.flags |= FORMAT_FIXED_KEY_LENGTH_TABLE_SEGMENT;
+            return this;
+        }
+
+        public Builder transientSegment() {
+            this.flags |= ROLE_TRANSIENT;
             return this;
         }
 

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
@@ -65,7 +65,7 @@ public class SegmentType {
     @VisibleForTesting
     static final long ROLE_CRITICAL = 0b0100_0000L;
     @VisibleForTesting
-    static final long ROLE_TRANSIENT = 0b1000_0000;
+    static final long ROLE_TRANSIENT = 0b1000_0000L;
     private final long flags;
 
     //endregion
@@ -115,11 +115,11 @@ public class SegmentType {
     }
 
     /**
-     * Whether this {@link SegmentType} refers to a Transient Segment (which implies {@link #isTransient()}.
+     * Whether this {@link SegmentType} refers to a Transient Segment.
      *
      * @return True if Transient Segment, false otherwise.
      */
-    public boolean isTransient() {
+    public boolean isTransientSegment() {
         return (this.flags & ROLE_TRANSIENT) == ROLE_TRANSIENT;
     }
 
@@ -166,7 +166,7 @@ public class SegmentType {
             result.append(", Table Segment");
         }
 
-        if (isTableSegment()) {
+        if (isTransientSegment()) {
             result.append(", Transient");
         }
 

--- a/segmentstore/contracts/src/test/java/io/pravega/segmentstore/contracts/SegmentTypeTests.java
+++ b/segmentstore/contracts/src/test/java/io/pravega/segmentstore/contracts/SegmentTypeTests.java
@@ -41,7 +41,7 @@ public class SegmentTypeTests {
         checkBuilder(SegmentType.builder().internal().build(), SegmentType.ROLE_INTERNAL, SegmentType::isInternal);
         checkBuilder(SegmentType.builder().system().build(), SegmentType.ROLE_SYSTEM, SegmentType::isSystem, SegmentType::isInternal);
         checkBuilder(SegmentType.builder().critical().build(), SegmentType.ROLE_CRITICAL, SegmentType::isCritical);
-        checkBuilder(SegmentType.builder().transientSegment().build(), SegmentType.ROLE_TRANSIENT, SegmentType::isTransient);
+        checkBuilder(SegmentType.builder().transientSegment().build(), SegmentType.ROLE_TRANSIENT, SegmentType::isTransientSegment);
     }
 
     /**

--- a/segmentstore/contracts/src/test/java/io/pravega/segmentstore/contracts/SegmentTypeTests.java
+++ b/segmentstore/contracts/src/test/java/io/pravega/segmentstore/contracts/SegmentTypeTests.java
@@ -41,6 +41,7 @@ public class SegmentTypeTests {
         checkBuilder(SegmentType.builder().internal().build(), SegmentType.ROLE_INTERNAL, SegmentType::isInternal);
         checkBuilder(SegmentType.builder().system().build(), SegmentType.ROLE_SYSTEM, SegmentType::isSystem, SegmentType::isInternal);
         checkBuilder(SegmentType.builder().critical().build(), SegmentType.ROLE_CRITICAL, SegmentType::isCritical);
+        checkBuilder(SegmentType.builder().transientSegment().build(), SegmentType.ROLE_TRANSIENT, SegmentType::isTransient);
     }
 
     /**

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -81,8 +81,6 @@ import org.slf4j.LoggerFactory;
 import static io.pravega.segmentstore.contracts.Attributes.ATTRIBUTE_SEGMENT_TYPE;
 import static io.pravega.segmentstore.contracts.Attributes.CREATION_TIME;
 import static io.pravega.segmentstore.contracts.Attributes.EVENT_COUNT;
-import static io.pravega.segmentstore.contracts.Attributes.SCALE_POLICY_RATE;
-import static io.pravega.segmentstore.contracts.Attributes.SCALE_POLICY_TYPE;
 
 /**
  * Process incoming Append requests and write them to the SegmentStore.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -102,6 +102,7 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
     private final boolean replyWithStackTraceOnError;
     private final ConcurrentHashMap<Pair<String, UUID>, WriterState> writerStates = new ConcurrentHashMap<>();
     private final ScheduledExecutorService tokenExpiryHandlerExecutor;
+    private final Collection<String> transientSegmentNames;
 
     //endregion
 
@@ -118,6 +119,7 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
         this.tokenVerifier = tokenVerifier;
         this.replyWithStackTraceOnError = replyWithStackTraceOnError;
         this.tokenExpiryHandlerExecutor = tokenExpiryHandlerExecutor;
+        this.transientSegmentNames = Collections.emptySet();
     }
 
     /**
@@ -442,6 +444,7 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
     @Override
     public void close() {
         connection.close();
+        transientSegmentNames.forEach(name -> store.deleteStreamSegment(name, TIMEOUT));
     }
 
     //endregion

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -448,7 +448,7 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
     @Override
     public void close() {
         connection.close();
-        // The AppendProccessor marks the tracked Transient Segments for deletion -- but does not synchronously wait for
+        // The AppendProcessor marks the tracked Transient Segments for deletion -- but does not synchronously wait for
         // the deletion to complete. The Transient Segemnts will be cleaned up at the SegmentStore's discretion.
         transientSegmentNames.forEach(name -> store.deleteStreamSegment(name, TIMEOUT));
     }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -120,7 +120,7 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
         this.tokenVerifier = tokenVerifier;
         this.replyWithStackTraceOnError = replyWithStackTraceOnError;
         this.tokenExpiryHandlerExecutor = tokenExpiryHandlerExecutor;
-        this.transientSegmentNames = new HashSet<>();
+        this.transientSegmentNames = Collections.synchronizedSet(new HashSet<>());
     }
 
     /**
@@ -448,6 +448,8 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
     @Override
     public void close() {
         connection.close();
+        // The AppendProccessor marks the tracked Transient Segments for deletion -- but does not synchronously wait for
+        // the deletion to complete. The Transient Segemnts will be cleaned up at the SegmentStore's discretion.
         transientSegmentNames.forEach(name -> store.deleteStreamSegment(name, TIMEOUT));
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -269,6 +269,7 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
         );
         String parentSegment = createTransientSegment.getParentSegment();
         store.createStreamSegment(parentSegment, SegmentType.TRANSIENT_SEGMENT, attributes, TIMEOUT);
+        LoggerHelpers.traceLeave(log, "createTransientSegment", traceId);
     }
 
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
@@ -102,6 +102,10 @@ public class ServerConnectionInboundHandler extends ChannelInboundHandlerAdapter
                 // wait for all messages to be sent before closing the channel.
                 ch.eventLoop().execute(() -> ch.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE));
             }
+            RequestProcessor rp = processor.get();
+            if (rp != null) {
+                rp.connectionDropped();
+            }
         }
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/TrackedConnection.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/TrackedConnection.java
@@ -16,9 +16,7 @@
 package io.pravega.segmentstore.server.host.handler;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.pravega.common.function.RunnableWithException;
 import io.pravega.shared.protocol.netty.WireCommand;
-import io.pravega.common.function.Callbacks;
 
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -76,11 +74,6 @@ public class TrackedConnection implements AutoCloseable {
     @Override
     public void close() {
         this.connection.close();
-    }
-
-    public void close(RunnableWithException callback) {
-        this.close();
-        Callbacks.invokeSafely(callback, ex -> log.error("Unable to run callback on TrackedConnection close.", ex));
     }
 
     @Override

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/TrackedConnection.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/TrackedConnection.java
@@ -83,7 +83,6 @@ public class TrackedConnection implements AutoCloseable {
         Callbacks.invokeSafely(callback, ex -> log.error("Unable to run callback on TrackedConnection close.", ex));
     }
 
-
     @Override
     public String toString() {
         return String.format("%s [%s/%s]", this.connection, this.outstandingBytes, this.connectionTracker.getTotalOutstanding());

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/TrackedConnection.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/TrackedConnection.java
@@ -16,15 +16,11 @@
 package io.pravega.segmentstore.server.host.handler;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.pravega.shared.protocol.netty.Append;
 import io.pravega.shared.protocol.netty.WireCommand;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 /**
  * Tracks outstanding data for a single connection and pauses or resumes reading from it as appropriate.

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/TrackedConnection.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/TrackedConnection.java
@@ -16,10 +16,15 @@
 package io.pravega.segmentstore.server.host.handler;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.pravega.shared.protocol.netty.Append;
 import io.pravega.shared.protocol.netty.WireCommand;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 /**
  * Tracks outstanding data for a single connection and pauses or resumes reading from it as appropriate.
@@ -37,7 +42,6 @@ public class TrackedConnection implements AutoCloseable {
     @NonNull
     private final ConnectionTracker connectionTracker;
     private final AtomicLong outstandingBytes = new AtomicLong();
-
     /**
      * To be used only in tests. Creates a new tracker.
      *
@@ -72,6 +76,12 @@ public class TrackedConnection implements AutoCloseable {
     public void close() {
         this.connection.close();
     }
+
+    public void close(Runnable callback) {
+        this.close();
+        callback.run();
+    }
+
 
     @Override
     public String toString() {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/TrackedConnection.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/TrackedConnection.java
@@ -16,16 +16,21 @@
 package io.pravega.segmentstore.server.host.handler;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.pravega.common.function.RunnableWithException;
 import io.pravega.shared.protocol.netty.WireCommand;
+import io.pravega.common.function.Callbacks;
+
 import java.util.concurrent.atomic.AtomicLong;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Tracks outstanding data for a single connection and pauses or resumes reading from it as appropriate.
  */
 @RequiredArgsConstructor
+@Slf4j
 public class TrackedConnection implements AutoCloseable {
     /**
      * The {@link ServerConnection} to manage.
@@ -73,9 +78,9 @@ public class TrackedConnection implements AutoCloseable {
         this.connection.close();
     }
 
-    public void close(Runnable callback) {
+    public void close(RunnableWithException callback) {
         this.close();
-        callback.run();
+        Callbacks.invokeSafely(callback, ex -> log.error("Unable to run callback on TrackedConnection close.", ex));
     }
 
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
@@ -40,6 +40,7 @@ public class ContainerConfig {
     public static final Property<Integer> MAX_CACHED_EXTENDED_ATTRIBUTE_COUNT = Property.named("extended.attribute.cached.count.max", 4096, "maxCachedExtendedAttributeCount");
     public static final Property<Integer> EVENT_PROCESSOR_ITERATION_DELAY_MS = Property.named("eventprocessor.iteration.delay.ms", 100);
     public static final Property<Integer> EVENT_PROCESSOR_OPERATION_TIMEOUT_MS = Property.named("eventprocessor.operation.timeout.ms", 5000);
+    public static final Property<Integer> TRANSIENT_SEGMENT_DELETE_TIMEOUT_MS = Property.named("segment.transient.delete.timeout.ms", 1000);
     private static final String COMPONENT_CODE = "containers";
 
     /**
@@ -90,6 +91,12 @@ public class ContainerConfig {
     @Getter
     private final Duration eventProcessorOperationTimeout;
 
+    /**
+     * Default timeout for the deletion of Transient Segments from Metadata.
+     */
+    @Getter
+    private final Duration transientSegmentDeleteTimeout;
+
     //endregion
 
     //region Constructor
@@ -113,6 +120,7 @@ public class ContainerConfig {
         this.maxCachedExtendedAttributeCount = properties.getPositiveInt(MAX_CACHED_EXTENDED_ATTRIBUTE_COUNT);
         this.eventProcessorIterationDelay = properties.getDuration(EVENT_PROCESSOR_ITERATION_DELAY_MS, ChronoUnit.MILLIS);
         this.eventProcessorOperationTimeout = properties.getDuration(EVENT_PROCESSOR_OPERATION_TIMEOUT_MS, ChronoUnit.MILLIS);
+        this.transientSegmentDeleteTimeout = properties.getDuration(TRANSIENT_SEGMENT_DELETE_TIMEOUT_MS, ChronoUnit.MILLIS);
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
@@ -40,7 +40,7 @@ public class ContainerConfig {
     public static final Property<Integer> MAX_CACHED_EXTENDED_ATTRIBUTE_COUNT = Property.named("extended.attribute.cached.count.max", 4096, "maxCachedExtendedAttributeCount");
     public static final Property<Integer> EVENT_PROCESSOR_ITERATION_DELAY_MS = Property.named("eventprocessor.iteration.delay.ms", 100);
     public static final Property<Integer> EVENT_PROCESSOR_OPERATION_TIMEOUT_MS = Property.named("eventprocessor.operation.timeout.ms", 5000);
-    public static final Property<Integer> TRANSIENT_SEGMENT_DELETE_TIMEOUT_MS = Property.named("segment.transient.delete.timeout.ms", 1000);
+    public static final Property<Integer> TRANSIENT_SEGMENT_DELETE_TIMEOUT_MS = Property.named("segment.transient.delete.timeout.ms", 30000);
     private static final String COMPONENT_CODE = "containers";
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataCleaner.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataCleaner.java
@@ -183,7 +183,7 @@ class MetadataCleaner extends AbstractThreadPoolService {
         val deletionTasks = this.metadata.getEvictionCandidates(lastSeqNo, this.config.getMaxConcurrentSegmentEvictionCount())
                 .stream()
                 .filter(sm -> sm.getType().isTransientSegment())
-                .filter(sm -> !sm.isDeleted() || sm.getAttributes().get(Attributes.CREATION_EPOCH) < metadata.getContainerEpoch())
+                .filter(sm -> sm.getAttributes().get(Attributes.CREATION_EPOCH) < metadata.getContainerEpoch())
                 .map(sm -> metadataStore.deleteSegment(sm.getName(), this.config.getTransientSegmentDeleteTimeout()))
                 .collect(Collectors.toList());
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataCleaner.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataCleaner.java
@@ -187,10 +187,11 @@ class MetadataCleaner extends AbstractThreadPoolService {
                 .map(sm -> metadataStore.deleteSegment(sm.getName(), this.config.getTransientSegmentDeleteTimeout()))
                 .collect(Collectors.toList());
 
-        return Futures.allOf(deletionTasks)
-                .thenRunAsync(() -> {
-                    LoggerHelpers.traceLeave(log, this.traceObjectId, "deleteUnusedTransientSegments", traceId);
-                }, this.executor);
+        val result = Futures.allOf(deletionTasks);
+        if (log.isTraceEnabled()) {
+            result.thenRun(() -> LoggerHelpers.traceLeave(log, this.traceObjectId, "deleteUnusedTransientSegments", traceId));
+        }
+        return result;
     }
 
     private CompletableFuture<Void> runOnceInternal() {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataCleaner.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataCleaner.java
@@ -187,7 +187,7 @@ class MetadataCleaner extends AbstractThreadPoolService {
         // Serialize only those segments that are still alive (not deleted or merged - those will get removed anyway).
         this.metadata.getEvictionCandidates(lastSeqNo, this.config.getMaxConcurrentSegmentEvictionCount())
                 .stream()
-                .filter(sm -> sm.getType() == SegmentType.TRANSIENT_SEGMENT && !sm.isDeleted() && !sm.isMerged())
+                .filter(sm -> sm.getType() == SegmentType.TRANSIENT_SEGMENT && sm.isDeleted())
                 .forEach(sm -> {
                     // Todo: AppendProcessor - isTransientSegmentActive()?
                 });

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -487,7 +487,6 @@ public abstract class MetadataStore implements AutoCloseable {
             return Futures.failedFuture(new StreamSegmentNotExistsException(properties.getName()));
         }
 
-
         if (segmentInfo.getSegmentType() == SegmentType.TRANSIENT_SEGMENT.getValue()) {
             Map<AttributeId, Long> attributes = new HashMap<>();
             attributes.put(Attributes.CREATION_EPOCH, this.connector.containerMetadata.getContainerEpoch());

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -159,7 +159,7 @@ public abstract class MetadataStore implements AutoCloseable {
         if (segmentType != SegmentType.TRANSIENT_SEGMENT) {
             result = createSegment(segmentName, segmentInfo, new TimeoutTimer(timeout));
         } else {
-            result = CompletableFuture.runAsync(() -> submitAssignment(newSegment(segmentName, segmentType, attributes), true, timeout));
+            result = CompletableFuture.runAsync(() -> submitAssignment(newSegment(segmentName, segmentType, attributes), false, timeout));
         }
 
         if (log.isTraceEnabled()) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -157,12 +157,7 @@ public abstract class MetadataStore implements AutoCloseable {
         }
 
         ArrayView segmentInfo = SegmentInfo.serialize(SegmentInfo.newSegment(segmentName, segmentType, attributes));
-        CompletableFuture<Void> result;
-        if (segmentType.isTransient()) {
-            result = registerPinnedSegment(segmentName, segmentType, attributes, timeout).thenApply(null);
-        } else {
-            result = createSegment(segmentName, segmentInfo, new TimeoutTimer(timeout));
-        }
+        CompletableFuture<Void> result = createSegment(segmentName, segmentInfo, new TimeoutTimer(timeout));
         if (log.isTraceEnabled()) {
             result.thenAccept(v -> LoggerHelpers.traceLeave(log, traceObjectId, "createSegment", traceId, segmentName));
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -17,7 +17,6 @@ package io.pravega.segmentstore.server.containers;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import io.netty.util.concurrent.CompleteFuture;
 import io.pravega.common.Exceptions;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.ObjectBuilder;
@@ -33,7 +32,6 @@ import io.pravega.common.util.BufferView;
 import io.pravega.segmentstore.contracts.AttributeId;
 import io.pravega.segmentstore.contracts.AttributeUpdate;
 import io.pravega.segmentstore.contracts.Attributes;
-import io.pravega.segmentstore.contracts.BadSegmentTypeException;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 import io.pravega.segmentstore.contracts.SegmentType;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/SegmentMetadataUpdateTransaction.java
@@ -46,6 +46,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiPredicate;
 import javax.annotation.concurrent.NotThreadSafe;
+
+import io.pravega.shared.NameUtils;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -478,6 +480,9 @@ class SegmentMetadataUpdateTransaction implements UpdateableSegmentMetadata {
             if (Attributes.isUnmodifiable(u.getAttributeId())) {
                 throw new MetadataUpdateException(this.containerId,
                         String.format("Attribute Id '%s' on Segment Id %s ('%s') may not be modified.", u.getAttributeId(), this.id, this.name));
+            } else if (NameUtils.isTransientSegment(this.name) && !Attributes.isCoreAttribute(u.getAttributeId())) {
+                throw new MetadataUpdateException(this.containerId,
+                        String.format("Extended Attribute '%s' may not be used on Transient Segment '%s'.", u.getAttributeId(), this.name));
             }
 
             AttributeUpdateType updateType = u.getUpdateType();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataCleanerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataCleanerTests.java
@@ -22,6 +22,7 @@ import io.pravega.common.util.BufferView;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.segmentstore.contracts.AttributeId;
 import io.pravega.segmentstore.contracts.Attributes;
+import io.pravega.segmentstore.contracts.SegmentType;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.server.SegmentMetadata;
@@ -34,10 +35,13 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.GuardedBy;
@@ -46,6 +50,9 @@ import lombok.NonNull;
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for the {@link MetadataCleaner} class.
@@ -98,7 +105,7 @@ public class MetadataCleanerTests extends ThreadPooledTestSuite {
             }
 
             val attributeCount = sm.getAttributes((k, v) -> !Attributes.isCoreAttribute(k)).size();
-            Assert.assertEquals("Unexpected number of remaining non-core attributes.", CONFIG.getMaxCachedExtendedAttributeCount(), attributeCount);
+            assertEquals("Unexpected number of remaining non-core attributes.", CONFIG.getMaxCachedExtendedAttributeCount(), attributeCount);
         }
     }
 
@@ -118,12 +125,70 @@ public class MetadataCleanerTests extends ThreadPooledTestSuite {
                 .filter(sm -> !sm.isDeleted() && !sm.isMerged())
                 .collect(Collectors.toList());
         AssertExtensions.assertGreaterThan("Expected at least one eligible segment.", 0, expectedSegments.size());
-        Assert.assertEquals("Unexpected number of segments persisted.", expectedSegments.size(), context.metadataStore.getSegmentCount());
+        assertEquals("Unexpected number of segments persisted.", expectedSegments.size(), context.metadataStore.getSegmentCount());
 
         for (val sm : expectedSegments) {
             val info = context.metadataStore.getSegmentInfo(sm.getName(), TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             Assert.assertNotNull("No persisted info for " + sm.getName(), info);
-            Assert.assertEquals("Unexpected length for " + sm.getName(), sm.getLength(), info.getLength());
+            assertEquals("Unexpected length for " + sm.getName(), sm.getLength(), info.getLength());
+        }
+    }
+
+    /**
+     * Verifies that all in-memory metadata used to support Transient Segments are cleaned up accordingly.
+     */
+    @Test
+    public void testTransientSegmentCleanup() throws ExecutionException, InterruptedException, TimeoutException {
+        @Cleanup
+        val context = new TransientTestContext();
+        Assert.assertNotEquals(0, context.metadata.getActiveSegmentCount());
+
+        // Cleanup #1. We expect half of the deleted segments to be evicted (due to how they're set up).
+        val expected1 = context.metadata.getEvictionCandidates(0, 1000);
+        AssertExtensions.assertGreaterThan("Expected at least one eligible segment.", 0, expected1.size());
+        context.cleaner.runOnce().get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        AssertExtensions.assertContainsSameElements("Unexpected evicted segments on the first round.",
+                expected1, context.cleanedUpMetadata, Comparator.comparingLong(SegmentMetadata::getId));
+
+        // Cleanup #2. We expect all the remaining Transient Segments to not have been marked as deleted and therefore
+        // will not be evicted.
+        context.cleanedUpMetadata.clear();
+        val expected2 = context.metadata.getEvictionCandidates(context.metadata.getOperationSequenceNumber(), 1000);
+        assertEquals("Expected no eviction candidates", 0, expected2.size());
+        context.cleaner.runOnce().get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        // Make sure that there is no trace of deleted segments and non-deleted segments still exist.
+
+        val expectedSegments = context.metadata.getAllStreamSegmentIds().stream()
+                .map(context.metadata::getStreamSegmentMetadata)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        assertEquals("Unexpected number of remaining Transient Segments.", TransientTestContext.TRANSIENT_COUNT, expectedSegments.size());
+        for (val sm : expectedSegments) {
+            val info = context.metadataStore.getSegmentInfo(sm.getName(), TIMEOUT).get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+            Assert.assertNotNull("No persisted info for " + sm.getName(), info);
+            assertTrue("Unexpected Segment ID: " + sm.getId(), sm.getId() < TransientTestContext.TRANSIENT_COUNT);
+            assertTrue("SegmentMetadata unexpectedaly deleted.", !sm.isDeleted());
+        }
+    }
+
+    private void populateMetadataTransient(UpdateableContainerMetadata metadata, int transientCount, int transientDeletedCount) {
+        val truncationSeqNo = 10000L;
+        metadata.removeTruncationMarkers(truncationSeqNo);
+        val segmentId = new AtomicLong(metadata.getAllStreamSegmentIds().stream().max(Long::compareTo).orElse(1L));
+
+        for (int i = 0; i < transientCount + transientDeletedCount; i++) {
+            val id = segmentId.incrementAndGet();
+            val name = String.format("#transient.32%d", id + i);
+            val m = metadata.mapStreamSegmentId(name, i);
+            m.setLength(1000 + i);
+            // Only mark transientDeletedCount segments as deleted.
+            if (i >= transientCount) {
+                m.markDeleted();
+            }
+            // Metadata must have a segment type of TRANSIENT to be handled accordingly.
+            m.updateAttributes(Map.of(Attributes.ATTRIBUTE_SEGMENT_TYPE, SegmentType.TRANSIENT_SEGMENT.getValue()));
+            m.refreshDerivedProperties();
         }
     }
 
@@ -199,6 +264,10 @@ public class MetadataCleanerTests extends ThreadPooledTestSuite {
 
             this.metadataStore = new TestMetadataStore(connector);
             this.cleaner = new MetadataCleaner(CONFIG, this.metadata, this.metadataStore, this.cleanedUpMetadata::addAll, executorService(), "");
+            this.populate();
+        }
+
+        public void populate() {
             populateMetadata(this.metadata, 10, 20, 30, 40, ATTRIBUTES_PER_SEGMENT);
         }
 
@@ -206,6 +275,17 @@ public class MetadataCleanerTests extends ThreadPooledTestSuite {
         public void close() {
             this.cleaner.close();
             this.metadataStore.close();
+        }
+    }
+
+    private class TransientTestContext extends TestContext {
+
+        public static final int TRANSIENT_COUNT = 10;
+        public static final int TRANSIENT_DELETED_COUNT = 20;
+
+        @Override
+        public void populate() {
+            populateMetadataTransient(this.metadata, TRANSIENT_COUNT, TRANSIENT_DELETED_COUNT);
         }
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
@@ -722,6 +722,9 @@ public abstract class MetadataStoreTestBase extends ThreadPooledTestSuite {
     /**
      * Verifies that a {@link SegmentType} marked as {@link SegmentType#isTransient()} is rejected if it has an improperly
      * formatted name.
+     *
+     * @throws ExecutionException ExecutionException if any occurs.
+     * @throws InterruptedException InterruptedException if any occurs.
      */
     @Test
     public void testTransientSegmentFormat() throws ExecutionException, InterruptedException {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
@@ -762,7 +762,7 @@ public abstract class MetadataStoreTestBase extends ThreadPooledTestSuite {
         // Make sure our Transient Segment name maps to a valid Segment ID.
         TestUtils.await(() -> {
             return context.getMetadata().getStreamSegmentId(validTransientSegment, false) != ContainerMetadata.NO_STREAM_SEGMENT_ID;
-        }, 100, 1000);
+        }, 1000, TIMEOUT.toMillis());
         // Attempt to create a Transient Segment with an ill-formatted name.
         AssertExtensions.assertThrows(
             "createSegment did not throw an exception given an invalid Transient Segment name.",

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
@@ -741,6 +741,11 @@ public abstract class MetadataStoreTestBase extends ThreadPooledTestSuite {
         );
     }
 
+    @Test
+    public void testTransientSegmentCleanup() {
+
+    }
+
     private String getName(long segmentId) {
         return String.format("Segment_%d", segmentId);
     }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
@@ -31,7 +31,6 @@ import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
 import io.pravega.segmentstore.contracts.TooManyActiveSegmentsException;
-import io.pravega.segmentstore.server.Container;
 import io.pravega.segmentstore.server.ContainerMetadata;
 import io.pravega.segmentstore.server.MetadataBuilder;
 import io.pravega.segmentstore.server.SegmentMetadata;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/writer/StorageWriterTests.java
@@ -719,7 +719,6 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
                 .with(WriterConfig.MAX_ITEMS_TO_READ_AT_ONCE, 100)
                 .with(WriterConfig.MIN_READ_TIMEOUT_MILLIS, 100L)
                 .with(WriterConfig.MAX_READ_TIMEOUT_MILLIS, 250L)
-
                 .build();
         @Cleanup
         TestContext context = new TestContext(config);
@@ -745,6 +744,14 @@ public class StorageWriterTests extends ThreadPooledTestSuite {
         val ff2 = context.writer.forceFlush(context.metadata.getOperationSequenceNumber(), TIMEOUT);
         val result2 = ff2.get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         Assert.assertFalse("Not expected anything to be flushed the second time.", result2);
+    }
+
+    /**
+     * Verifies that the StorageWriter does not create an Attribute Aggregator for Transient Segments.
+     */
+    @Test
+    public void testNoAttributeAggregatorTransientSegments() {
+
     }
 
     /**

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NonNull;
 
 /**
  * Utility methods for StreamSegment Names.
@@ -227,6 +228,7 @@ public final class NameUtils {
      *
      * @return The start position of the delimiter contained within streamSegmentName.
      */
+    @NonNull
     private static int getDelimiterPosition(String streamSegmentName, String delimiter, int idLength) {
         int endOfStreamNamePos = streamSegmentName.lastIndexOf(delimiter);
         if (endOfStreamNamePos < 0 || endOfStreamNamePos + delimiter.length() + idLength > streamSegmentName.length()) {

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -236,8 +236,8 @@ public final class NameUtils {
     }
 
     /**
-     * Attempts to extract the name of the Parent StreamSegment for the given Transaction StreamSegment. This method returns a
-     * valid value only if the Transaction StreamSegmentName was generated using the generateTransactionStreamSegmentName method.
+     * Attempts to extract the name of the Parent StreamSegment for the given Transaction/Transient StreamSegment. This method returns a
+     * valid value only if the Transaction/Transient StreamSegmentName was generated using the generateTransactionStreamSegmentName method.
      *
      * @param segmentName The name of the Transaction StreamSegment or Transient Segment to extract the name of the Parent StreamSegment.
      * @return The name of the Parent StreamSegment, or null if not a valid StreamSegment.

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NonNull;
 
 /**
  * Utility methods for StreamSegment Names.

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -203,15 +203,19 @@ public final class NameUtils {
      * Returns the transient name for a TransientSegment based on the name of the current Parent StreamSegment, and the transientId.
      *
      * @param parentStreamSegmentName The name of the Parent StreamSegment for this transient segment.
-     * @param transientId             The unique Id for the transient segment.
+     * @param writerId The Writer Id used to create the transient segment.
      * @return The name of the Transient StreamSegmentId.
      */
-    public static String getTransientNameFromId(String parentStreamSegmentName, UUID transientId) {
+    public static String getTransientNameFromId(String parentStreamSegmentName, UUID writerId) {
+        UUID random = UUID.randomUUID();
         StringBuilder result = new StringBuilder();
         result.append(parentStreamSegmentName);
         result.append(TRANSIENT_DELIMITER);
-        result.append(String.format(FULL_HEX_FORMAT, transientId.getMostSignificantBits()));
-        result.append(String.format(FULL_HEX_FORMAT, transientId.getLeastSignificantBits()));
+        result.append(String.format(FULL_HEX_FORMAT, writerId.getMostSignificantBits()));
+        result.append(String.format(FULL_HEX_FORMAT, writerId.getLeastSignificantBits()));
+        result.append('.');
+        result.append(String.format(FULL_HEX_FORMAT, random.getMostSignificantBits()));
+        result.append(String.format(FULL_HEX_FORMAT, random.getLeastSignificantBits()));
         return result.toString();
     }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -228,7 +228,6 @@ public final class NameUtils {
      *
      * @return The start position of the delimiter contained within streamSegmentName.
      */
-    @NonNull
     private static int getDelimiterPosition(String streamSegmentName, String delimiter, int idLength) {
         int endOfStreamNamePos = streamSegmentName.lastIndexOf(delimiter);
         if (endOfStreamNamePos < 0 || endOfStreamNamePos + delimiter.length() + idLength > streamSegmentName.length()) {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
@@ -155,4 +155,9 @@ public abstract class DelegatingRequestProcessor implements RequestProcessor {
     public void createTransientSegment(WireCommands.CreateTransientSegment createTransientSegment) {
         getNextRequestProcessor().createTransientSegment(createTransientSegment);
     }
+
+    @Override
+    public void connectionDropped() {
+        getNextRequestProcessor().connectionDropped();
+    }
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
@@ -160,4 +160,9 @@ public class FailingRequestProcessor implements RequestProcessor {
         throw new IllegalStateException("Unexpected operation");
     }
 
+    @Override
+    public void connectionDropped() {
+        throw new IllegalStateException("Unexpected operation");
+    }
+
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
@@ -88,4 +88,6 @@ public interface RequestProcessor {
     void readTableEntriesDelta(WireCommands.ReadTableEntriesDelta readTableEntriesDelta);
 
     void createTransientSegment(WireCommands.CreateTransientSegment createTransientSegment);
+
+    void connectionDropped();
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -202,10 +202,23 @@ public class NameUtilsTest {
 
     @Test
     public void testIsTransientSegment() {
-        Assert.assertTrue(NameUtils.isTransientSegment("scope/stream/transientSegment#transient.01234567890123456789012345678901"));
+        Assert.assertFalse(NameUtils.isTransientSegment(""));
+        Assert.assertTrue(NameUtils.isTransientSegment(getSegmentName("#transient.")));
         Assert.assertFalse(NameUtils.isTransientSegment("scope/stream/transientSegment"));
         Assert.assertTrue(NameUtils.isTransientSegment("#transient.01234567890123456789012345678901"));
         Assert.assertFalse(NameUtils.isTransientSegment("#transient"));
     }
 
+    @Test
+    public void testTransientAndTransactionConflicts() {
+        String transientSegmentName = getSegmentName("#transient.");
+        String transactionSegmentName = getSegmentName("#transaction.");
+        // First validate they are valid formats themselves, then ensure each naming convention can't be confused for the other.
+        Assert.assertTrue(NameUtils.isTransactionSegment(transactionSegmentName) && !NameUtils.isTransientSegment(transactionSegmentName));
+        Assert.assertTrue(NameUtils.isTransientSegment(transientSegmentName) && !NameUtils.isTransactionSegment(transientSegmentName));
+    }
+
+    private String getSegmentName(String delimiter) {
+        return String.format("scope/stream/transactionSegment%s01234567890123456789012345678901", delimiter);
+    }
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -208,13 +208,4 @@ public class NameUtilsTest {
         Assert.assertFalse(NameUtils.isTransientSegment("#transient"));
     }
 
-    @Test
-    public void testTransientSegmentName() {
-        UUID uuid = UUID.fromString("00000065-0000-000a-0000-000000000064");
-        Assert.assertEquals(String.format("scope/stream/parentSegment#transient.%s", uuid.toString().replace("-", "")),
-                NameUtils.getTransientNameFromId("scope/stream/parentSegment", uuid));
-
-    }
-
-
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -199,4 +199,22 @@ public class NameUtilsTest {
     public void testGetEventProcessorSegmentName() {
         Assert.assertEquals(NameUtils.getEventProcessorSegmentName(0, "test"), "_system/containers/event_processor_test_0");
     }
+
+    @Test
+    public void testIsTransientSegment() {
+        Assert.assertTrue(NameUtils.isTransientSegment("scope/stream/transientSegment#transient.01234567890123456789012345678901"));
+        Assert.assertFalse(NameUtils.isTransientSegment("scope/stream/transientSegment"));
+        Assert.assertTrue(NameUtils.isTransientSegment("#transient.01234567890123456789012345678901"));
+        Assert.assertFalse(NameUtils.isTransientSegment("#transient"));
+    }
+
+    @Test
+    public void testTransientSegmentName() {
+        UUID uuid = UUID.fromString("00000065-0000-000a-0000-000000000064");
+        Assert.assertEquals(String.format("scope/stream/parentSegment#transient.%s", uuid.toString().replace("-", "")),
+                NameUtils.getTransientNameFromId("scope/stream/parentSegment", uuid));
+
+    }
+
+
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/StreamSegmentNameUtilsTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/StreamSegmentNameUtilsTests.java
@@ -93,6 +93,23 @@ public class StreamSegmentNameUtilsTests {
     }
 
     @Test
+    public void testTransientStreamSegmentName() {
+        long segmentId = NameUtils.computeSegmentId(10, 100);
+        String qualifiedName = NameUtils.getQualifiedStreamSegmentName("scope", "stream", segmentId);
+
+        UUID writerId = UUID.randomUUID();
+        String transientSegment = NameUtils.getTransientNameFromId(qualifiedName, writerId);
+        assertTrue(NameUtils.isTransientSegment(transientSegment));
+        assertEquals(qualifiedName, NameUtils.getParentStreamSegmentName(transientSegment));
+
+        String primary = NameUtils.extractPrimaryStreamSegmentName(qualifiedName);
+        assertEquals("scope/stream/10", primary);
+
+        String primaryFromTransient = NameUtils.extractPrimaryStreamSegmentName(transientSegment);
+        assertEquals("scope/stream/10", primaryFromTransient);
+    }
+
+    @Test
     public void testQualifiedStreamSegmentName() {
         long segmentId = NameUtils.computeSegmentId(10, 100);
         String qualifiedName = NameUtils.getQualifiedStreamSegmentName("scope", "stream", segmentId);

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessorTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessorTest.java
@@ -72,6 +72,7 @@ public class DelegatingRequestProcessorTest {
         rp.createTableSegment(new WireCommands.CreateTableSegment(0, "", false, 0, ""));
         rp.readTableEntriesDelta(new WireCommands.ReadTableEntriesDelta(0, "", "", 0, 0));
         rp.createTransientSegment(new WireCommands.CreateTransientSegment(0, new UUID(0, 0), "", null));
+        rp.connectionDropped();
 
         verify(rp.getNextRequestProcessor(), times(1)).hello(any());
         verify(rp.getNextRequestProcessor(), times(1)).setupAppend(any());
@@ -98,5 +99,6 @@ public class DelegatingRequestProcessorTest {
         verify(rp.getNextRequestProcessor(), times(1)).readTableEntries(any());
         verify(rp.getNextRequestProcessor(), times(1)).readTableEntriesDelta(any());
         verify(rp.getNextRequestProcessor(), times(1)).createTransientSegment(any());
+        verify(rp.getNextRequestProcessor(), times(1)).connectionDropped();
     }
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/FailingRequestProcessorTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/FailingRequestProcessorTest.java
@@ -81,6 +81,7 @@ public class FailingRequestProcessorTest {
         assertThrows(IllegalStateException.class, () -> rp.createTableSegment(new CreateTableSegment(0, "", false, 0, "")));
         assertThrows(IllegalStateException.class, () -> rp.readTableEntriesDelta(new ReadTableEntriesDelta(0, "", "", 0, 0)));
         assertThrows(IllegalStateException.class, () -> rp.createTransientSegment(new CreateTransientSegment(0, new UUID(0, 0), "", "")));
+        assertThrows(IllegalStateException.class, () -> rp.connectionDropped());
     }
 
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/segment/SegmentToContainerMapperTests.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/segment/SegmentToContainerMapperTests.java
@@ -114,6 +114,29 @@ public class SegmentToContainerMapperTests {
         }
     }
 
+    /**
+     * Tests that Transient Segments are mapped to the same container as their parents.
+     */
+    @Test
+    public void testTransientMapping() {
+        int containerCount = 16;
+        int streamSegmentCount = 256;
+        int transientPerParentCount = 10;
+
+        SegmentToContainerMapper m = new SegmentToContainerMapper(containerCount, true);
+
+        // Generate all possible names with the given length and assign them to a container.
+        for (int segmentId = 0; segmentId < streamSegmentCount; segmentId++) {
+            String segmentName = getSegmentName(segmentId);
+            int containerId = m.getContainerId(segmentName);
+            for (int i = 0; i < transientPerParentCount; i++) {
+                String transientSegmentName = NameUtils.getTransientNameFromId(segmentName, UUID.randomUUID());
+                int transientContainerId = m.getContainerId(transientSegmentName);
+                Assert.assertEquals("Parent and Transient Segment were not assigned to the same container.", containerId, transientContainerId);
+            }
+        }
+    }
+
     @Test
     public void testSegmentMapping() {
         int containerCount = 16;


### PR DESCRIPTION
**Change log description**  

* Adds new `TransientSegment` type/role. 
* Adds `createTransientSegment` call in the `AppendProcessor`.
* Overload the `close` call on a `TrackedConnection` to allow for a call back.
* Adds a `close` call on the `AppendProcessor`, which will be called on the closure of its `TrackedConnection`.
* Create according `NameUtils` methods for new `TransientSegment` type.
* Setup boilerplate code for deleting unused transient segements.

**Purpose of the change**  
Partially completes #6137.

**What the code does**  

* See above.

**How to verify it**  

* Run unit tests (TBD).
