### PR TITLE
Issue 5560: Read the contents of a segment from the storage

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/ReadSegmentRangeCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/ReadSegmentRangeCommand.java
@@ -15,6 +15,7 @@
  */
 package io.pravega.cli.admin.segmentstore;
 
+import com.google.common.base.Preconditions;
 import io.pravega.cli.admin.CommandArgs;
 import io.pravega.controller.server.SegmentHelper;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
@@ -25,15 +26,19 @@ import org.apache.curator.framework.CuratorFramework;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static java.lang.Math.min;
+
 public class ReadSegmentRangeCommand extends SegmentStoreCommand {
 
     private static final int REQUEST_TIMEOUT_SECONDS = 10;
+    private static final int READ_WRITE_BUFFER_SIZE = 2 * 1024 * 1024;
 
     /**
      * Creates a new instance of the ReadSegmentRangeCommand.
@@ -53,13 +58,28 @@ public class ReadSegmentRangeCommand extends SegmentStoreCommand {
         final int length = getIntArg(2);
         final String segmentStoreHost = getArg(3);
         final String fileName = getArg(4);
+
+        Preconditions.checkArgument(offset >= 0, "The provided offset cannot be negative.");
+        Preconditions.checkArgument(length >= 0, "The provided length cannot be negative.");
+
         @Cleanup
         CuratorFramework zkClient = createZKClient();
         @Cleanup
         SegmentHelper segmentHelper = instantiateSegmentHelper(zkClient);
-        CompletableFuture<WireCommands.SegmentRead> reply = segmentHelper.readSegment(fullyQualifiedSegmentName,
-                offset, length, new PravegaNodeUri(segmentStoreHost, getServiceConfig().getAdminGatewayPort()), "");
-        WireCommands.SegmentRead segmentRead = reply.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        File file = createFileAndDirectory(fileName);
+        readAndWriteSegmentToFile(segmentHelper, segmentStoreHost, fullyQualifiedSegmentName, offset, length, file);
+        output("The segment data has been successfully written into %s", fileName);
+    }
+
+    /**
+     * Creates the file (and parent directory if required) into which thee segment data is written.
+     *
+     * @param fileName
+     * @return A {@link File} object representing the filename provided.
+     * @throws FileAlreadyExistsException if the file already exists, to avoid any accidental overwrites.
+     * @throws IOException if the file/directory creation fails.
+     */
+    private File createFileAndDirectory(String fileName) throws IOException {
         File f = new File(fileName);
         // If file exists throw FileAlreadyExistsException, an existing file should not be overwritten with new data.
         if (f.exists()) {
@@ -69,11 +89,41 @@ public class ReadSegmentRangeCommand extends SegmentStoreCommand {
             f.getParentFile().mkdirs();
         }
         f.createNewFile();
-        // Write data into the file.
-        @Cleanup
-        FileOutputStream fileStream = new FileOutputStream(f);
-        fileStream.write(segmentRead.getData().array());
-        output("The segment data has been successfully written into %s", fileName);
+        return f;
+    }
+
+    /**
+     * Reads the contents of the segment starting from the given offset and writes into the provided file.
+     *
+     * @param segmentHelper             A {@link SegmentHelper} instance to read the segment.
+     * @param segmentStoreHost          Address of the segment-store to read from.
+     * @param fullyQualifiedSegmentName The name of the segment.
+     * @param offset                    The starting point from where the segment is to be read.
+     * @param length                    The number of bytes to read.
+     * @param file                      A {@link File} object referring to the file in which the data will be written.
+     * @throws IOException if the file write fails.
+     * @throws InterruptedException if the request fails.
+     * @throws ExecutionException if the request fails.
+     * @throws TimeoutException if the request fails.
+     */
+    private void readAndWriteSegmentToFile(SegmentHelper segmentHelper, String segmentStoreHost, String fullyQualifiedSegmentName,
+                                           int offset, int length, File file) throws IOException, InterruptedException, ExecutionException, TimeoutException {
+        int currentOffset = offset;
+        int bytesToRead = length;
+        while (bytesToRead > 0) {
+            int bufferLength = min(READ_WRITE_BUFFER_SIZE, bytesToRead);
+            CompletableFuture<WireCommands.SegmentRead> reply = segmentHelper.readSegment(fullyQualifiedSegmentName,
+                    currentOffset, bufferLength, new PravegaNodeUri(segmentStoreHost, getServiceConfig().getAdminGatewayPort()), "");
+            WireCommands.SegmentRead bufferRead = reply.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            // Write the buffer into the file.
+            try (FileOutputStream fileOutputStream = new FileOutputStream(file, true)) {
+                bufferRead.getData().readBytes(fileOutputStream, bufferLength);
+            }
+
+            currentOffset += READ_WRITE_BUFFER_SIZE;
+            bytesToRead -= READ_WRITE_BUFFER_SIZE;
+        }
     }
 
     public static CommandDescriptor descriptor() {

--- a/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/ReadSegmentRangeCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/ReadSegmentRangeCommand.java
@@ -25,7 +25,6 @@ import org.apache.curator.framework.CuratorFramework;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -61,22 +60,20 @@ public class ReadSegmentRangeCommand extends SegmentStoreCommand {
         CompletableFuture<WireCommands.SegmentRead> reply = segmentHelper.readSegment(fullyQualifiedSegmentName,
                 offset, length, new PravegaNodeUri(segmentStoreHost, getServiceConfig().getAdminGatewayPort()), "");
         WireCommands.SegmentRead segmentRead = reply.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
         File f = new File(fileName);
         // If file exists throw FileAlreadyExistsException, an existing file should not be overwritten with new data.
         if (f.exists()) {
             throw new FileAlreadyExistsException("Cannot write segment data into a file that already exists.");
         }
-
         if (!f.getParentFile().exists()) {
             f.getParentFile().mkdirs();
         }
         f.createNewFile();
-
         // Write data into the file.
         @Cleanup
         FileOutputStream fileStream = new FileOutputStream(f);
         fileStream.write(segmentRead.getData().array());
+        output("The segment data has been successfully written into %s", fileName);
     }
 
     public static CommandDescriptor descriptor() {

--- a/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/ReadSegmentRangeCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/ReadSegmentRangeCommand.java
@@ -114,7 +114,7 @@ public class ReadSegmentRangeCommand extends SegmentStoreCommand {
             // TODO: readSegment should take in longs as described here: https://github.com/pravega/pravega/issues/6183
             // TODO: Remove casting to int once 6183 is resolved.
             CompletableFuture<WireCommands.SegmentRead> reply = segmentHelper.readSegment(fullyQualifiedSegmentName,
-                    (int)currentOffset, (int)bufferLength, new PravegaNodeUri(segmentStoreHost, getServiceConfig().getAdminGatewayPort()), super.authHelper.retrieveMasterToken());
+                    (int) currentOffset, (int) bufferLength, new PravegaNodeUri(segmentStoreHost, getServiceConfig().getAdminGatewayPort()), super.authHelper.retrieveMasterToken());
             WireCommands.SegmentRead bufferRead = reply.get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             int bytesRead = bufferRead.getData().readableBytes();
             // Write the buffer into the file.

--- a/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/AbstractSegmentStoreCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/AbstractSegmentStoreCommandsTest.java
@@ -40,6 +40,7 @@ import org.junit.rules.Timeout;
 import java.io.File;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Properties;
@@ -120,7 +121,10 @@ public abstract class AbstractSegmentStoreCommandsTest {
 
     @Test
     public void testReadSegmentRangeCommand() throws Exception {
-        String filename = "./tmp/readSegmentTest.txt";
+        // Create a temporary directory.
+        Path tempDirPath = Files.createTempDirectory("readSegmentDir");
+        String filename = Paths.get(tempDirPath.toString(), "tmp" + System.currentTimeMillis(), "readSegmentTest.txt").toString();
+
         TestUtils.createScopeStream(SETUP_UTILS.getController(), "segmentstore", "readsegment", StreamConfiguration.builder().build());
 
         @Cleanup
@@ -147,6 +151,9 @@ public abstract class AbstractSegmentStoreCommandsTest {
         Assert.assertNotNull(ReadSegmentRangeCommand.descriptor());
         // Delete file created during the test.
         Files.deleteIfExists(Paths.get(filename));
+
+        // Delete the temporary directory.
+        tempDirPath.toFile().deleteOnExit();
     }
 
     @Test

--- a/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/SegmentStoreCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/SegmentStoreCommandsTest.java
@@ -30,6 +30,10 @@ import lombok.Cleanup;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -60,6 +64,7 @@ public class SegmentStoreCommandsTest extends AbstractAdminCommandTest {
 
     @Test
     public void testReadSegmentRangeCommand() throws Exception {
+        String filename = "./tmp/readSegmentTest.txt";
         TestUtils.createScopeStream(SETUP_UTILS.getController(), "segmentstore", "readsegment", StreamConfiguration.builder().build());
         ClientConfig clientConfig = ClientConfig.builder().controllerURI(SETUP_UTILS.getControllerUri()).build();
         @Cleanup
@@ -68,12 +73,23 @@ public class SegmentStoreCommandsTest extends AbstractAdminCommandTest {
         EventStreamWriter<String> writer = factory.createEventWriter("readsegment", new JavaSerializer<>(), EventWriterConfig.builder().build());
         writer.writeEvents("rk", Arrays.asList("a", "2", "3"));
         writer.flush();
-        String commandResult = TestUtils.executeCommand("segmentstore read-segment segmentstore/readsegment/0.#epoch.0 0 8 localhost", STATE.get());
-        Assert.assertTrue(commandResult.contains("ReadSegment:"));
-        commandResult = TestUtils.executeCommand("segmentstore read-segment _system/_RGcommitStreamReaders/0.#epoch.0 0 8 localhost", STATE.get());
-        Assert.assertTrue(commandResult.contains("ReadSegment:"));
-        AssertExtensions.assertThrows(WireCommandFailedException.class, () -> TestUtils.executeCommand("segmentstore read-segment not/exists/0 0 1 localhost", STATE.get()));
+
+        // Check to make sure that the file exists and data is written into it.
+        String commandResult = TestUtils.executeCommand("segmentstore read-segment segmentstore/readsegment/0.#epoch.0 0 8 localhost " + filename, STATE.get());
+        Assert.assertTrue(commandResult.contains("The segment data has been successfully written into"));
+        File file = new File(filename);
+        Assert.assertTrue(file.exists());
+        Assert.assertNotEquals(0, file.length());
+
+        AssertExtensions.assertThrows(FileAlreadyExistsException.class, () ->
+                TestUtils.executeCommand("segmentstore read-segment _system/_RGcommitStreamReaders/0.#epoch.0 0 8 localhost " + filename, STATE.get()));
+
+        AssertExtensions.assertThrows(WireCommandFailedException.class, () ->
+                TestUtils.executeCommand("segmentstore read-segment not/exists/0 0 1 localhost " + filename, STATE.get()));
         Assert.assertNotNull(ReadSegmentRangeCommand.descriptor());
+
+        // Delete file created during the test.
+        Files.deleteIfExists(Paths.get(filename));
     }
 
     @Test

--- a/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/SegmentStoreCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/SegmentStoreCommandsTest.java
@@ -83,11 +83,12 @@ public class SegmentStoreCommandsTest extends AbstractAdminCommandTest {
 
         AssertExtensions.assertThrows(FileAlreadyExistsException.class, () ->
                 TestUtils.executeCommand("segmentstore read-segment _system/_RGcommitStreamReaders/0.#epoch.0 0 8 localhost " + filename, STATE.get()));
+        // Delete file created during the test.
+        Files.deleteIfExists(Paths.get(filename));
 
         AssertExtensions.assertThrows(WireCommandFailedException.class, () ->
                 TestUtils.executeCommand("segmentstore read-segment not/exists/0 0 1 localhost " + filename, STATE.get()));
         Assert.assertNotNull(ReadSegmentRangeCommand.descriptor());
-
         // Delete file created during the test.
         Files.deleteIfExists(Paths.get(filename));
     }


### PR DESCRIPTION
**Change log description**  
The CLI command `segmentstore read-segment` has been tweaked to write the obtained segment data into a specified file. The file will contain a byte array. 

**Purpose of the change**  
Fixes #5560 

**What the code does**  
- `ReadSegmentRangeCommand` now has a new argument pertaining to the filename where the segment byte array will be written.
- If the file exists then a `FileAlreadyExistsException` is thrown to ensure that files are not accidentally overwritten by the user using the command.
- The contents are written into the file using the `java.io.FileOutputStream` class.

**How to verify it**  
All tests must pass.
