### PR TITLE
Issue 5525: Adding support for reading influxdb credentials from a file

### DIFF
--- a/docker/pravega/scripts/init_controller.sh
+++ b/docker/pravega/scripts/init_controller.sh
@@ -19,5 +19,10 @@ init_controller() {
     [ ! -z "$HOSTNAME" ] && add_system_property "controller.metrics.prefix" "${HOSTNAME}"
     add_system_property "controller.zk.connect.uri" "${ZK_URL}"
     add_system_property "controller.server.store.host.type" "Zookeeper"
+    [ -d "$INFLUX_DB_SECRET_MOUNT_PATH" ] \
+    && [ -f "$INFLUX_DB_SECRET_MOUNT_PATH"/username ] && [ -f  "$INFLUX_DB_SECRET_MOUNT_PATH"/password ] \
+    && add_system_property "metrics.influxDB.connect.credentials.username"  "$(cat "$INFLUX_DB_SECRET_MOUNT_PATH"/username)" \
+    && add_system_property "metrics.influxDB.connect.credentials.pwd" "$(cat "$INFLUX_DB_SECRET_MOUNT_PATH"/password)"
     echo "JAVA_OPTS=${JAVA_OPTS}"
+
 }

--- a/docker/pravega/scripts/init_segmentstore.sh
+++ b/docker/pravega/scripts/init_segmentstore.sh
@@ -24,5 +24,9 @@ init_segmentstore() {
     add_system_property "autoScale.controller.connect.uri" "${CONTROLLER_URL}"
     add_system_property "bookkeeper.zk.connect.uri" "${BK_ZK_URL:-${ZK_URL}}"
     add_system_property "pravegaservice.storageThreadPool.size" "${STORAGE_THREAD_POOL_SIZE}"
+    [ -d "$INFLUX_DB_SECRET_MOUNT_PATH" ] \
+    && [ -f "$INFLUX_DB_SECRET_MOUNT_PATH"/username ] && [ -f  "$INFLUX_DB_SECRET_MOUNT_PATH"/password ] \
+    && add_system_property "metrics.influxDB.connect.credentials.username"  "$(cat "$INFLUX_DB_SECRET_MOUNT_PATH"/username)" \
+    && add_system_property "metrics.influxDB.connect.credentials.pwd" "$(cat "$INFLUX_DB_SECRET_MOUNT_PATH"/password)"
     echo "JAVA_OPTS=${JAVA_OPTS}"
 }


### PR DESCRIPTION
Signed-off-by: anishakj <anisha.kj@dell.com>

**Change log description**  
Currently, influxdb credentails are set as part of java options in plain text.  Made change in pravega-operator to pass those credentials as secret and mount in a volume. Changes are done to read the credentials from file and populate in java options.

**Purpose of the change**  
 Fixes #5525

**What the code does**  
Modified controller and segment store initscripts to read credentials from a file and add to java options

**How to verify it**  
Verified that java options are set correctly