### PR TITLE
Issue 6193: Temporarily revert of Retry predicate change for Controller Events(#6064)

### DIFF
--- a/client/src/main/java/io/pravega/client/connection/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/ConnectionPoolImpl.java
@@ -128,11 +128,11 @@ public class ConnectionPoolImpl implements ConnectionPool {
 
             final Connection connection;
             if (suggestedConnection.isPresent() && (prunedConnectionList.size() >= clientConfig.getMaxConnectionsPerSegmentStore() || isUnused(suggestedConnection.get()))) {
-                log.trace("Reusing connection: {}", suggestedConnection.get());
+                log.info("Reusing connection: {}", suggestedConnection.get());
                 connection = suggestedConnection.get();
             } else {
                 // create a new connection.
-                log.trace("Creating a new connection to {}", location);
+                log.info("Creating a new connection to {}", location);
                 CompletableFuture<FlowHandler> establishedFuture = establishConnection(location);
                 connection = new Connection(location, establishedFuture);
                 prunedConnectionList.add(connection);

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/AbstractRequestProcessor.java
@@ -21,7 +21,6 @@ import io.pravega.common.concurrent.Futures;
 import io.pravega.common.tracing.RequestTag;
 import io.pravega.common.util.Retry;
 import io.pravega.controller.eventProcessor.impl.SerializedRequestHandler;
-import io.pravega.controller.store.stream.EpochTransitionOperationExceptions;
 import io.pravega.controller.store.stream.OperationContext;
 import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
@@ -67,18 +66,8 @@ import static io.pravega.controller.eventProcessor.impl.EventProcessorHelper.wit
 @Slf4j
 public abstract class AbstractRequestProcessor<T extends ControllerEvent> extends SerializedRequestHandler<T> 
         implements StreamRequestProcessor {
-    protected static final Predicate<Throwable> ILLEGAL_STATE_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.IllegalStateException;
-    protected static final Predicate<Throwable> DATA_NOT_FOUND_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException;
-    protected static final Predicate<Throwable> SEGMENT_NOT_FOUND_PREDICATE = e -> Exceptions.unwrap(e) instanceof StoreException.DataContainerNotFoundException;
-    protected static final Predicate<Throwable> NON_RETRYABLE_EXCEPTIONS = ILLEGAL_STATE_PREDICATE.or(DATA_NOT_FOUND_PREDICATE)
-                                                                            .or(SEGMENT_NOT_FOUND_PREDICATE)
-                                                                            .or(e -> Exceptions.unwrap(e) instanceof IllegalArgumentException)
-                                                                            .or(e -> Exceptions.unwrap(e) instanceof NullPointerException);
-    protected static final Predicate<Throwable> EVENT_RETRY_PREDICATE = NON_RETRYABLE_EXCEPTIONS.negate();
-    protected static final Predicate<Throwable> SCALE_EVENT_RETRY_PREDICATE = NON_RETRYABLE_EXCEPTIONS.or(e -> e instanceof EpochTransitionOperationExceptions.ConditionInvalidException)
-                                                                                .or(e -> e instanceof EpochTransitionOperationExceptions.InputInvalidException)
-                                                                                .or(e -> e instanceof EpochTransitionOperationExceptions.PreConditionFailureException)
-                                                                                .negate();
+    protected static final Predicate<Throwable> OPERATION_NOT_ALLOWED_PREDICATE = e -> Exceptions.unwrap(e) 
+            instanceof StoreException.OperationNotAllowedException;
 
     protected final StreamMetadataStore streamMetadataStore;
 
@@ -178,7 +167,7 @@ public abstract class AbstractRequestProcessor<T extends ControllerEvent> extend
                                                 stream, getProcessorName(), context, executor),
                                                 null, "Exception while trying to create waiting request. Logged and ignored.")
                                                 .thenCompose(ignore ->  retryIndefinitelyThenComplete(
-                                                        () -> task.writeBack(event), resultFuture, null));
+                                                        () -> task.writeBack(event), resultFuture, ex));
                                     } else {
                                         // Processing was done for this event, whether it succeeded or failed, we should remove
                                         // the waiting request if it matches the current processor.
@@ -199,11 +188,8 @@ public abstract class AbstractRequestProcessor<T extends ControllerEvent> extend
                                         + event + " so that waiting processor" + waitingRequestProcessor + " can work. "));
                     }
                 }).exceptionally(e -> {
-                    if (writeBackPredicate.test(e)) {
-                        retryIndefinitelyThenComplete(
-                                () -> task.writeBack(event), resultFuture, null);
-                    }
-                    return null;
+            resultFuture.completeExceptionally(e);
+            return null;
         });
 
         return resultFuture;

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -87,7 +87,7 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
 
     @Override
     public CompletableFuture<Void> processCommitTxnRequest(CommitEvent event) {
-        return withCompletion(this, event, event.getScope(), event.getStream(), EVENT_RETRY_PREDICATE);
+        return withCompletion(this, event, event.getScope(), event.getStream(), OPERATION_NOT_ALLOWED_PREDICATE);
     }
 
     /**

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
@@ -16,6 +16,7 @@
 package io.pravega.controller.server.eventProcessor.requesthandlers;
 
 import io.pravega.common.tracing.TagLogger;
+import io.pravega.controller.store.stream.EpochTransitionOperationExceptions;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.shared.controller.event.AutoScaleEvent;
 import io.pravega.shared.controller.event.ControllerEvent;
@@ -79,7 +80,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
         log.info(scaleOpEvent.getRequestId(), "Processing scale request for stream {}/{}", scaleOpEvent.getScope(), 
                 scaleOpEvent.getStream());
         return withCompletion(scaleOperationTask, scaleOpEvent, scaleOpEvent.getScope(), scaleOpEvent.getStream(),
-                SCALE_EVENT_RETRY_PREDICATE)
+                OPERATION_NOT_ALLOWED_PREDICATE.or(e -> e instanceof EpochTransitionOperationExceptions.ConflictException))
                 .thenAccept(v -> {
                     log.info(scaleOpEvent.getRequestId(), "Processing scale request for stream {}/{} complete",
                             scaleOpEvent.getScope(), scaleOpEvent.getStream());
@@ -91,7 +92,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
         log.info(updateStreamEvent.getRequestId(), "Processing update request for stream {}/{}",  
                 updateStreamEvent.getScope(), updateStreamEvent.getStream());
         return withCompletion(updateStreamTask, updateStreamEvent, updateStreamEvent.getScope(), updateStreamEvent.getStream(),
-                EVENT_RETRY_PREDICATE)
+                OPERATION_NOT_ALLOWED_PREDICATE)
                 .thenAccept(v -> {
                     log.info(updateStreamEvent.getRequestId(), "Processing update request for stream {}/{} complete", 
                             updateStreamEvent.getScope(), updateStreamEvent.getStream());
@@ -103,7 +104,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
         log.info(truncateStreamEvent.getRequestId(), "Processing truncate request for stream {}/{}", 
                 truncateStreamEvent.getScope(), truncateStreamEvent.getStream());
         return withCompletion(truncateStreamTask, truncateStreamEvent, truncateStreamEvent.getScope(), truncateStreamEvent.getStream(),
-                EVENT_RETRY_PREDICATE)
+                OPERATION_NOT_ALLOWED_PREDICATE)
                 .thenAccept(v -> {
                     log.info(truncateStreamEvent.getRequestId(), "Processing truncate request for stream {}/{} complete", 
                             truncateStreamEvent.getScope(), truncateStreamEvent.getStream());
@@ -115,7 +116,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
         log.info(sealStreamEvent.getRequestId(), "Processing seal request for stream {}/{}", 
                 sealStreamEvent.getScope(), sealStreamEvent.getStream());
         return withCompletion(sealStreamTask, sealStreamEvent, sealStreamEvent.getScope(), sealStreamEvent.getStream(),
-                EVENT_RETRY_PREDICATE)
+                OPERATION_NOT_ALLOWED_PREDICATE)
                 .thenAccept(v -> {
                     log.info(sealStreamEvent.getRequestId(), "Processing seal request for stream {}/{} complete", 
                             sealStreamEvent.getScope(), sealStreamEvent.getStream());
@@ -127,7 +128,7 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
         log.info(deleteStreamEvent.getRequestId(), "Processing delete request for stream {}/{}", 
                 deleteStreamEvent.getScope(), deleteStreamEvent.getStream());
         return withCompletion(deleteStreamTask, deleteStreamEvent, deleteStreamEvent.getScope(), deleteStreamEvent.getStream(),
-                EVENT_RETRY_PREDICATE)
+                OPERATION_NOT_ALLOWED_PREDICATE)
                 .thenAccept(v -> {
                     log.info(deleteStreamEvent.getRequestId(), "Processing delete request for stream {}/{} complete", 
                             deleteStreamEvent.getScope(), deleteStreamEvent.getStream());

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorTest.java
@@ -325,7 +325,8 @@ public abstract class ControllerEventProcessorTest {
         assertNull(streamStore.getWaitingRequestProcessor(SCOPE, STREAM, null, executor).join());
         streamStore.setState(SCOPE, STREAM, State.SCALING, null, executor).join();
 
-        commitEventProcessor.processEvent(new CommitEvent(SCOPE, STREAM, epoch)).join();
+        AssertExtensions.assertFutureThrows("Operation should be disallowed", commitEventProcessor.processEvent(new CommitEvent(SCOPE, STREAM, epoch)),
+                e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         assertEquals(commitEventProcessor.getProcessorName(), streamStore.getWaitingRequestProcessor(SCOPE, STREAM, null, executor).join());
 
         streamStore.setState(SCOPE, STREAM, State.ACTIVE, null, executor).join();

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -797,7 +797,8 @@ public abstract class RequestHandlersTest {
         ScaleOpEvent scaleEvent = new ScaleOpEvent(fairness, fairness, Collections.singletonList(0L), 
                 Collections.singletonList(new AbstractMap.SimpleEntry<>(0.0, 1.0)), 
                 false, System.currentTimeMillis(), 0L);
-        streamRequestHandler.process(scaleEvent, () -> false).join();
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(scaleEvent, () -> false),
+                e -> Exceptions.unwrap(e) instanceof RuntimeException);
         // verify that scale was started
         assertEquals(State.SCALING, streamStore.getState(fairness, fairness, true, null, executor).join());
 
@@ -818,7 +819,8 @@ public abstract class RequestHandlersTest {
         ScaleOpEvent scaleEvent2 = new ScaleOpEvent(fairness, fairness, Collections.singletonList(NameUtils.computeSegmentId(1, 1)),
                 Collections.singletonList(new AbstractMap.SimpleEntry<>(0.0, 1.0)),
                 false, System.currentTimeMillis(), 0L);
-        streamRequestHandler.process(scaleEvent2, () -> false).join();
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(scaleEvent2, () -> false),
+                e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         streamStore.deleteWaitingRequestConditionally(fairness, fairness, "myProcessor", null, executor).join();
     }
     
@@ -841,7 +843,7 @@ public abstract class RequestHandlersTest {
                 System.currentTimeMillis(), 0L).join();
 
         // 1. set segment helper mock to throw exception
-        doAnswer(x -> Futures.failedFuture(new NullPointerException()))
+        doAnswer(x -> Futures.failedFuture(new RuntimeException()))
                 .when(segmentHelper).updatePolicy(anyString(), anyString(), any(), anyLong(), anyString(), anyLong());
         
         // 2. start process --> this should fail with a retryable exception while talking to segment store!
@@ -852,7 +854,7 @@ public abstract class RequestHandlersTest {
         
         UpdateStreamEvent event = new UpdateStreamEvent(fairness, fairness, 0L);
         AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event, () -> false),
-                e -> Exceptions.unwrap(e) instanceof NullPointerException);
+                e -> Exceptions.unwrap(e) instanceof RuntimeException);
 
         verify(segmentHelper, atLeastOnce()).updatePolicy(anyString(), anyString(), any(), anyLong(), anyString(), anyLong());
         
@@ -893,8 +895,7 @@ public abstract class RequestHandlersTest {
                 System.currentTimeMillis(), 0L).join();
 
         // 1. set segment helper mock to throw exception
-        Exception exception = StoreException.create(StoreException.Type.DATA_NOT_FOUND, "Some processing exception");
-        doAnswer(x -> Futures.failedFuture(exception))
+        doAnswer(x -> Futures.failedFuture(new RuntimeException()))
                 .when(segmentHelper).truncateSegment(anyString(), anyString(), anyLong(), anyLong(), anyString(), anyLong());
         
         // 2. start process --> this should fail with a retryable exception while talking to segment store!
@@ -904,7 +905,7 @@ public abstract class RequestHandlersTest {
         
         TruncateStreamEvent event = new TruncateStreamEvent(fairness, fairness, 0L);
         AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event, () -> false),
-                e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException);
+                e -> Exceptions.unwrap(e) instanceof RuntimeException);
 
         verify(segmentHelper, atLeastOnce()).truncateSegment(anyString(), anyString(), anyLong(), anyLong(), anyString(), anyLong());
         
@@ -940,8 +941,7 @@ public abstract class RequestHandlersTest {
                 null, executor).join();
         
         // 1. set segment helper mock to throw exception
-        Exception exception = StoreException.create(StoreException.Type.ILLEGAL_STATE, "Some processing exception");
-        doAnswer(x -> Futures.failedFuture(exception))
+        doAnswer(x -> Futures.failedFuture(new RuntimeException()))
                 .when(segmentHelper).commitTransaction(anyString(), anyString(), anyLong(), anyLong(), any(), 
                 anyString(), anyLong());
         
@@ -954,7 +954,7 @@ public abstract class RequestHandlersTest {
         
         CommitEvent event = new CommitEvent(fairness, fairness, 0);
         AssertExtensions.assertFutureThrows("", requestHandler.process(event, () -> false),
-                e -> Exceptions.unwrap(e) instanceof StoreException.IllegalStateException);
+                e -> Exceptions.unwrap(e) instanceof RuntimeException);
 
         verify(segmentHelper, atLeastOnce()).commitTransaction(anyString(), anyString(), anyLong(), anyLong(), any(), 
                 anyString(), anyLong());
@@ -997,8 +997,7 @@ public abstract class RequestHandlersTest {
                 System.currentTimeMillis(), 0L).join();
 
         // 1. set segment helper mock to throw exception
-        Exception exception = StoreException.create(StoreException.Type.DATA_CONTAINER_NOT_FOUND, "Some processing exception");
-        doAnswer(x -> Futures.failedFuture(exception))
+        doAnswer(x -> Futures.failedFuture(new RuntimeException()))
                 .when(segmentHelper).sealSegment(anyString(), anyString(), anyLong(), anyString(), anyLong());
 
         // 2. start process --> this should fail with a retryable exception while talking to segment store!
@@ -1058,7 +1057,8 @@ public abstract class RequestHandlersTest {
         assertEquals(State.SEALED, streamStore.getState(fairness, fairness, true, null, executor).join());
 
         DeleteStreamEvent event = new DeleteStreamEvent(fairness, fairness, 0L, createTimestamp);
-        streamRequestHandler.process(event, () -> false).join();
+        AssertExtensions.assertFutureThrows("", streamRequestHandler.process(event, () -> false),
+                e -> Exceptions.unwrap(e) instanceof RuntimeException);
 
         verify(segmentHelper, atLeastOnce())
                 .deleteSegment(anyString(), anyString(), anyLong(), anyString(), anyLong());

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -286,7 +286,7 @@ public abstract class ScaleRequestHandlerTest {
         // This will bring down the test duration drastically because a retryable failure can keep retrying for few seconds.
         // And if someone changes retry durations and number of attempts in retry helper, it will impact this test's running time.
         // hence sending incorrect segmentsToSeal list which will result in a non retryable failure and this will fail immediately
-        assertTrue(Futures.await(multiplexer.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(five),
+        assertFalse(Futures.await(multiplexer.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(five),
                 Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.5, 1.0)), false, System.currentTimeMillis(), System.currentTimeMillis()), () -> false)));
         activeSegments = streamStore.getActiveSegments(scope, stream, null, executor).get();
         assertTrue(activeSegments.stream().noneMatch(z -> z.segmentId() == three));
@@ -503,9 +503,10 @@ public abstract class ScaleRequestHandlerTest {
         assertEquals(TxnStatus.COMMITTED, txnStatus);
 
         // 6. run scale. this should fail in scaleCreateNewEpochs with IllegalArgumentException with epochTransitionConsistent
-        requestHandler.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(1L),
+        AssertExtensions.assertFutureThrows("epoch transition should be inconsistent", requestHandler.process(new ScaleOpEvent(scope, stream, Lists.newArrayList(1L),
                 Lists.newArrayList(new AbstractMap.SimpleEntry<>(0.5, 0.75), new AbstractMap.SimpleEntry<>(0.75, 1.0)),
-                false, System.currentTimeMillis(), System.currentTimeMillis()), () -> false).join();
+                false, System.currentTimeMillis(), System.currentTimeMillis()), () -> false), e -> Exceptions.unwrap(e) instanceof IllegalStateException);
+
         state = streamStore.getState(scope, stream, true, null, executor).join();
         assertEquals(State.ACTIVE, state);
     }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestProcessorTest.java
@@ -115,7 +115,7 @@ public abstract class StreamRequestProcessorTest extends ThreadPooledTestSuite {
         }
 
         public CompletableFuture<Void> testProcess(TestEvent1 event) {
-            return withCompletion(this, event, event.scope, event.stream, EVENT_RETRY_PREDICATE);
+            return withCompletion(this, event, event.scope, event.stream, OPERATION_NOT_ALLOWED_PREDICATE);
         }
 
         @Override
@@ -144,7 +144,7 @@ public abstract class StreamRequestProcessorTest extends ThreadPooledTestSuite {
         }
 
         public CompletableFuture<Void> testProcess(TestEvent2 event) {
-            return withCompletion(this, event, event.scope, event.stream, EVENT_RETRY_PREDICATE);
+            return withCompletion(this, event, event.scope, event.stream, OPERATION_NOT_ALLOWED_PREDICATE);
         }
 
         @Override
@@ -228,7 +228,8 @@ public abstract class StreamRequestProcessorTest extends ThreadPooledTestSuite {
         started1.join();
 
         // 2. start test event2 processing on processor 2. Make this fail with OperationNotAllowed and verify that it gets postponed.
-        requestProcessor2.process(event21, () -> false).join();
+        AssertExtensions.assertFutureThrows("Fail first processing with operation not allowed", requestProcessor2.process(event21, () -> false),
+                e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         // also verify that store has set the processor name of processor 2.
         String waitingProcessor = getStore().getWaitingRequestProcessor(scope, stream, null, executorService()).join();
         assertEquals(TestRequestProcessor2.class.getSimpleName(), waitingProcessor);
@@ -298,7 +299,8 @@ public abstract class StreamRequestProcessorTest extends ThreadPooledTestSuite {
         started1.join();
 
         // 2. start test event2 processing on processor 2. Make this fail with OperationNotAllowed and verify that it gets postponed.
-        requestProcessor2.process(event2, () -> false).join();
+        AssertExtensions.assertFutureThrows("Fail first processing with operation not allowed", requestProcessor2.process(event2, () -> false),
+                e -> Exceptions.unwrap(e) instanceof StoreException.OperationNotAllowedException);
         // also verify that store has set the processor name of processor 2.
         String waitingProcessor = getStore().getWaitingRequestProcessor(scope, stream, null, executorService()).join();
         assertEquals(TestRequestProcessor2.class.getSimpleName(), waitingProcessor);
@@ -306,10 +308,10 @@ public abstract class StreamRequestProcessorTest extends ThreadPooledTestSuite {
         assertEquals(taken2, event2);
 
         // 3. Fail processing on processor 1 
-        waitForIt1.completeExceptionally(new IllegalArgumentException());
+        waitForIt1.completeExceptionally(new RuntimeException());
 
         // processing11 should complete successfully.
-        AssertExtensions.assertFutureThrows("", processing11, e -> Exceptions.unwrap(e) instanceof IllegalArgumentException);
+        AssertExtensions.assertFutureThrows("", processing11, e -> Exceptions.unwrap(e) instanceof RuntimeException); 
 
         // set ignore started to true
         requestProcessor1.ignoreStarted = true;
@@ -342,16 +344,18 @@ public abstract class StreamRequestProcessorTest extends ThreadPooledTestSuite {
         FailingEvent event1 = new FailingEvent("scope", "stream", 
                 Futures.failedFuture(new RuntimeException("hasStarted")), CompletableFuture.completedFuture(null));
 
-        processor.process(event1, () -> false).join();
+        AssertExtensions.assertFutureThrows("exception should be thrown after has started", processor.process(event1, () -> false),
+                e -> Exceptions.unwrap(e) instanceof RuntimeException && Exceptions.unwrap(e).getMessage().equals("hasStarted"));
 
         verify(processor, times(1)).hasTaskStarted(event1);
-        verify(processor, times(1)).writeBack(event1);
+        verify(processor, never()).writeBack(event1);
         verify(processor, never()).execute(event1);
         
         FailingEvent event2 = new FailingEvent("scope", "stream", 
                 CompletableFuture.completedFuture(true), Futures.failedFuture(new RuntimeException("execute")));
 
-        processor.process(event2, () -> false).join();
+        AssertExtensions.assertFutureThrows("exception should be thrown after execute", processor.process(event2, () -> false),
+                e -> Exceptions.unwrap(e) instanceof RuntimeException && Exceptions.unwrap(e).getMessage().equals("execute"));
         verify(processor, times(1)).writeBack(event2);
         verify(processor, times(1)).hasTaskStarted(event2);
         verify(processor, times(1)).execute(event2);


### PR DESCRIPTION
**Change log description**  
This PR temporarily reverts PR #6064 as it shows instability in system tests.

**Purpose of the change**  
Fixes #6193 

**What the code does**  
Temporarily reverts changes in #6064 .
This reverts commit 3de28524f02fb7b3f8c677237e1c5d7fa3d09e43.

**How to verify it**  
System tests should pass consistently.
