### PR TITLE
Issue 6195: Bug fix for KeyValueTableImpl.exists() when the key actually exists.

### DIFF
--- a/client/src/main/java/io/pravega/client/tables/impl/KeyValueTableImpl.java
+++ b/client/src/main/java/io/pravega/client/tables/impl/KeyValueTableImpl.java
@@ -153,6 +153,7 @@ public class KeyValueTableImpl implements KeyValueTable, AutoCloseable {
         return update(new Remove(key, Version.NOT_EXISTS))
                 .handle((r, ex) -> {
                     if (ex != null) {
+                        ex = Exceptions.unwrap(ex);
                         if (ex instanceof ConditionalTableUpdateException) {
                             return true;
                         } else {

--- a/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableTestBase.java
+++ b/client/src/test/java/io/pravega/client/tables/impl/KeyValueTableTestBase.java
@@ -776,6 +776,8 @@ public abstract class KeyValueTableTestBase extends LeakDetectorTestSuite {
             val expectedValue = k.getValue() == null ? null : new TableEntry(new TableKey(k.getKey()), k.getValue(), getValue(k.getKey(), iteration));
             val actualEntry = kvt.get(new TableKey(k.getKey())).join();
             Assert.assertTrue(areEqual(expectedValue, actualEntry));
+            boolean exists = kvt.exists(new TableKey(k.getKey())).join();
+            Assert.assertEquals(expectedValue != null, exists);
         }
 
         // Using multi-get.


### PR DESCRIPTION
**Change log description**  
Fixed a bug in KeyValueTableImpl where exists() would throw an unexpected exception instead of returning true.

Also properly covering this method in unit tests.

**Purpose of the change**  
Fixes #6195.

**What the code does**  
Unwrapping the exception from the conditional remove method.

**How to verify it**  
The KeyValueTableImpl.exists() method was not previously covered by unit tests. This has been resolved and this method is properly tested now.