### PR TITLE
Cherry-pick 6184: SLTS - Fix generation of inconsistent snapshots (#6185)

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -748,7 +748,14 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
      * */
     private <R> CompletableFuture<R> executeSerialized(Callable<CompletableFuture<R>> operation, String... segmentNames) {
         Exceptions.checkNotClosed(this.closed.get(), this);
-        return this.taskProcessor.add(Arrays.asList(segmentNames), () -> executeExclusive(operation, segmentNames));
+        if (segmentNames.length == 1 && this.systemJournal.isStorageSystemSegment(segmentNames[0])) {
+            // To maintain consistency of snapshot, all operations on any of the storage system segments are linearized
+            // on the entire group.
+            val segments = this.systemJournal.getSystemSegments();
+            return this.taskProcessor.add(Arrays.asList(segments), () -> executeExclusive(operation, segments));
+        } else {
+            return this.taskProcessor.add(Arrays.asList(segmentNames), () -> executeExclusive(operation, segmentNames));
+        }
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -222,7 +223,7 @@ public class SystemJournal {
         this.garbageCollector = Preconditions.checkNotNull(garbageCollector, "garbageCollector");
         this.containerId = containerId;
         this.systemSegments = getChunkStorageSystemSegments(containerId);
-        this.systemSegmentsPrefix = NameUtils.INTERNAL_SCOPE_NAME;
+        this.systemSegmentsPrefix = NameUtils.INTERNAL_CONTAINER_PREFIX;
         this.currentTimeSupplier = Preconditions.checkNotNull(currentTimeSupplier, "currentTimeSupplier");
         this.executor = Preconditions.checkNotNull(executor, "executor");
         this.taskProcessor = new MultiKeySequentialProcessor<>(this.executor);
@@ -264,23 +265,23 @@ public class SystemJournal {
         /**
          * Keep track of offsets at which chunks were added to the system segments.
          */
-        final private Map<String, Long> chunkStartOffsets = new HashMap<>();
+        final private Map<String, Long> chunkStartOffsets = Collections.synchronizedMap(new HashMap<>());
 
         /**
          * Keep track of offsets at which system segments were truncated.
          * We don't need to apply each truncate operation, only need to apply the final truncate offset.
          */
-        final private Map<String, Long> finalTruncateOffsets = new HashMap<>();
+        final private Map<String, Long> finalTruncateOffsets = Collections.synchronizedMap(new HashMap<>());
 
         /**
          * Final first chunk start offsets for all segments.
          */
-        final private Map<String, Long> finalFirstChunkStartsAtOffsets = new HashMap<>();
+        final private Map<String, Long> finalFirstChunkStartsAtOffsets = Collections.synchronizedMap(new HashMap<>());
 
         /**
          * Keep track of already processed records.
          */
-        final private HashSet<SystemJournalRecord> visitedRecords = new HashSet<>();
+        final private Set<SystemJournalRecord> visitedRecords = Collections.synchronizedSet(new HashSet<>());
 
         /**
          * Number of journals processed.
@@ -618,7 +619,7 @@ public class SystemJournal {
                     systemSnapshot.epoch, systemSnapshot.fileIndex);
             log.trace("SystemJournal[{}] Processing system log snapshot {}.", containerId, systemSnapshot);
             // Initialize the segments and their chunks.
-            for (SegmentSnapshotRecord segmentSnapshot : systemSnapshot.segmentSnapshotRecords) {
+            for (val segmentSnapshot : systemSnapshot.segmentSnapshotRecords) {
                 // Update segment data.
                 segmentSnapshot.segmentMetadata.setActive(true)
                         .setOwnershipChanged(true)
@@ -633,7 +634,7 @@ public class SystemJournal {
 
                 // Add chunk metadata and keep track of start offsets for each chunk.
                 long offset = segmentSnapshot.segmentMetadata.getFirstChunkStartOffset();
-                for (ChunkMetadata metadata : segmentSnapshot.chunkMetadataCollection) {
+                for (val metadata : segmentSnapshot.chunkMetadataCollection) {
                     txn.create(metadata);
 
                     // make sure that the record is marked pinned.
@@ -646,8 +647,8 @@ public class SystemJournal {
         } else {
             log.debug("SystemJournal[{}] No previous snapshot present.", containerId);
             // Initialize with default values.
-            for (String systemSegment : systemSegments) {
-                SegmentMetadata segmentMetadata = SegmentMetadata.builder()
+            for (val systemSegment : systemSegments) {
+                val segmentMetadata = SegmentMetadata.builder()
                         .name(systemSegment)
                         .ownerEpoch(epoch)
                         .maxRollinglength(config.getStorageMetadataRollingPolicy().getMaxLength())
@@ -963,10 +964,10 @@ public class SystemJournal {
      */
     private CompletableFuture<Void> adjustLastChunkLengths(MetadataTransaction txn) {
         val futures = new ArrayList<CompletableFuture<Void>>();
-        for (String systemSegment : systemSegments) {
+        for (val systemSegment : systemSegments) {
             val f = txn.get(systemSegment)
                     .thenComposeAsync(m -> {
-                        SegmentMetadata segmentMetadata = (SegmentMetadata) m;
+                        val segmentMetadata = (SegmentMetadata) m;
                         segmentMetadata.checkInvariants();
                         CompletableFuture<Void> ff;
                         // Update length of last chunk in metadata to what we actually find on LTS.
@@ -976,7 +977,7 @@ public class SystemJournal {
                                         long length = chunkInfo.getLength();
                                         return txn.get(segmentMetadata.getLastChunk())
                                                 .thenAcceptAsync(mm -> {
-                                                    ChunkMetadata lastChunk = (ChunkMetadata) mm;
+                                                    val lastChunk = (ChunkMetadata) mm;
                                                     Preconditions.checkState(null != lastChunk, "lastChunk must not be null. Segment=%s", segmentMetadata);
                                                     lastChunk.setLength(length);
                                                     txn.update(lastChunk);
@@ -1009,7 +1010,7 @@ public class SystemJournal {
     private CompletableFuture<Void> applyFinalTruncateOffsets(MetadataTransaction txn,
                                                               BootstrapState state) {
         val futures = new ArrayList<CompletableFuture<Void>>();
-        for (String systemSegment : systemSegments) {
+        for (val systemSegment : systemSegments) {
             if (state.finalTruncateOffsets.containsKey(systemSegment)) {
                 val truncateAt = state.finalTruncateOffsets.get(systemSegment);
                 val firstChunkStartsAt = state.finalFirstChunkStartsAtOffsets.get(systemSegment);
@@ -1071,7 +1072,7 @@ public class SystemJournal {
                                                 oldChunk.setNextChunk(newChunkName);
 
                                                 // Set length
-                                                long oldLength = chunkStartOffsets.get(oldChunkName);
+                                                val oldLength = chunkStartOffsets.get(oldChunkName);
                                                 oldChunk.setLength(offset - oldLength);
 
                                                 txn.update(oldChunk);
@@ -1104,7 +1105,7 @@ public class SystemJournal {
     private CompletableFuture<Void> applyTruncate(MetadataTransaction txn, String segmentName, long truncateAt, long firstChunkStartsAt) {
         return txn.get(segmentName)
                 .thenComposeAsync(metadata -> {
-                    SegmentMetadata segmentMetadata = (SegmentMetadata) metadata;
+                    val segmentMetadata = (SegmentMetadata) metadata;
                     segmentMetadata.checkInvariants();
                     val currentChunkName = new AtomicReference<>(segmentMetadata.getFirstChunk());
                     val currentMetadata = new AtomicReference<ChunkMetadata>();
@@ -1160,7 +1161,7 @@ public class SystemJournal {
                 .build();
 
         val futures = Collections.synchronizedList(new ArrayList<CompletableFuture<Void>>());
-        for (String systemSegment : systemSegments) {
+        for (val systemSegment : systemSegments) {
             // Find segment metadata.
             val future = txn.get(systemSegment)
                     .thenComposeAsync(metadata -> {

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -11,6 +11,7 @@
 package io.pravega.segmentstore.storage.chunklayer;
 
 import io.pravega.common.Exceptions;
+import io.pravega.common.concurrent.Futures;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.SegmentRollingPolicy;
 import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
@@ -25,6 +26,8 @@ import io.pravega.test.common.ThreadPooledTestSuite;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import lombok.Cleanup;
 import lombok.val;
@@ -107,7 +110,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         //Assert.assertEquals(epoch, journal.getEpoch());
         Assert.assertEquals(0, journal.getCurrentFileIndex().get());
 
-        Assert.assertEquals(NameUtils.INTERNAL_SCOPE_NAME, journal.getSystemSegmentsPrefix());
+        Assert.assertEquals(NameUtils.INTERNAL_CONTAINER_PREFIX, journal.getSystemSegmentsPrefix());
         Assert.assertArrayEquals(SystemJournal.getChunkStorageSystemSegments(containerId), journal.getSystemSegments());
         journal.initialize();
     }
@@ -1183,6 +1186,97 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
     }
 
 
+    /**
+     * Test concurrent writes to storage system segments by simulating concurrent writes.
+     *
+     * @throws Exception Throws exception in case of any error.
+     */
+    @Test
+    public void testSystemSegmentConcurrency() throws Exception {
+        @Cleanup
+        ChunkStorage chunkStorage = getChunkStorage();
+        @Cleanup
+        ChunkMetadataStore metadataStoreBeforeCrash = getMetadataStore();
+        @Cleanup
+        ChunkMetadataStore metadataStoreAfterCrash = getMetadataStore();
+
+        int containerId = 42;
+        int maxLength = 8;
+        long epoch = 1;
+        val policy = new SegmentRollingPolicy(maxLength);
+        val config = getDefaultConfigBuilder(policy).build();
+
+        val snapshotData = new InMemorySnapshotInfoStore();
+        val snapshotInfoStore = new SnapshotInfoStore(containerId,
+                snapshotId -> snapshotData.setSnapshotId(containerId, snapshotId),
+                () -> snapshotData.getSnapshotId(containerId));
+
+        // Start container with epoch 1
+        @Cleanup
+        ChunkedSegmentStorage segmentStorage1 = new ChunkedSegmentStorage(containerId, chunkStorage, metadataStoreBeforeCrash, executorService(), config);
+
+        segmentStorage1.initialize(epoch);
+
+        // Bootstrap
+        segmentStorage1.bootstrap(snapshotInfoStore).join();
+        segmentStorage1.getGarbageCollector().deleteGarbage(false, 1000).get();
+
+        checkSystemSegmentsLayout(segmentStorage1);
+
+        // Simulate some writes to system segment, this should cause some new chunks being added.
+        val writeSize = 10;
+        val numWrites = 10;
+        val numOfStorageSystemSegments = SystemJournal.getChunkStorageSystemSegments(containerId).length;
+        val data = new byte[numOfStorageSystemSegments][writeSize * numWrites];
+
+        var futures = new ArrayList<CompletableFuture<Void>>();
+        val rnd = new Random(0);
+        for (int i = 0; i < numOfStorageSystemSegments; i++) {
+            final int k = i;
+            futures.add(CompletableFuture.runAsync(() -> {
+                rnd.nextBytes(data[k]);
+                String systemSegmentName = SystemJournal.getChunkStorageSystemSegments(containerId)[k];
+                val h = segmentStorage1.openWrite(systemSegmentName).join();
+                // Init
+                long offset = 0;
+                for (int j = 0; j < numWrites; j++) {
+                    segmentStorage1.write(h, offset, new ByteArrayInputStream(data[k], writeSize * j, writeSize), writeSize, null).join();
+                    offset += writeSize;
+                }
+                val info = segmentStorage1.getStreamSegmentInfo(systemSegmentName, null).join();
+                Assert.assertEquals(writeSize * numWrites, info.getLength());
+                byte[] out = new byte[writeSize * numWrites];
+                val hr = segmentStorage1.openRead(systemSegmentName).join();
+                segmentStorage1.read(hr, 0, out, 0, writeSize * numWrites, null).join();
+                Assert.assertArrayEquals(data[k], out);
+            }, executorService()));
+        }
+
+        Futures.allOf(futures).join();
+        // Step 2
+        // Start container with epoch 2
+        epoch++;
+
+        @Cleanup
+        ChunkedSegmentStorage segmentStorage2 = new ChunkedSegmentStorage(containerId, chunkStorage, metadataStoreAfterCrash, executorService(), config);
+        segmentStorage2.initialize(epoch);
+
+        // Bootstrap
+        segmentStorage2.bootstrap(snapshotInfoStore).join();
+        segmentStorage2.getGarbageCollector().deleteGarbage(false, 1000).get();
+        checkSystemSegmentsLayout(segmentStorage2);
+
+        // Validate
+        for (int i = 0; i < numOfStorageSystemSegments; i++) {
+            String systemSegmentName = SystemJournal.getChunkStorageSystemSegments(containerId)[i];
+            val info = segmentStorage2.getStreamSegmentInfo(systemSegmentName, null).join();
+            Assert.assertEquals(writeSize * numWrites, info.getLength());
+            byte[] out = new byte[writeSize * numWrites];
+            val hr = segmentStorage2.openRead(systemSegmentName).join();
+            segmentStorage2.read(hr, 0, out, 0, writeSize * numWrites, null).join();
+            Assert.assertArrayEquals(data[i], out);
+        }
+    }
 
     /**
      * Check system segment layout.

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -24,12 +24,15 @@ import lombok.Getter;
  */
 public final class NameUtils {
     //region Members
-    
+
     // The prefix which will be used to name all internal streams.
     public static final String INTERNAL_NAME_PREFIX = "_";
 
     // The scope name which has to be used when creating internally used pravega streams.
     public static final String INTERNAL_SCOPE_NAME = "_system";
+
+    // The prefix used for internal container segments.
+    public static final String INTERNAL_CONTAINER_PREFIX = "_system/containers/";
 
     // The prefix which has to be appended to streams created internally for readerGroups.
     public static final String READER_GROUP_STREAM_PREFIX = INTERNAL_NAME_PREFIX + "RG";
@@ -95,9 +98,19 @@ public final class NameUtils {
     private static final String BLOCK_INDEX_NAME_FORMAT_WITH_OFFSET = "%s.B-%d";
 
     /**
+     * Prefix for Container Metadata Segment name.
+     */
+    private static final String METADATA_SEGMENT_NAME_PREFIX = INTERNAL_CONTAINER_PREFIX + "metadata_";
+
+    /**
      * Format for Container Metadata Segment name.
      */
-    private static final String METADATA_SEGMENT_NAME_FORMAT = "_system/containers/metadata_%d";
+    private static final String METADATA_SEGMENT_NAME_FORMAT = METADATA_SEGMENT_NAME_PREFIX + "%d";
+
+    /**
+     * Prefix for Storage Metadata Segment name.
+     */
+    private static final String STORAGE_METADATA_SEGMENT_NAME_PREFIX = INTERNAL_CONTAINER_PREFIX + "storage_metadata_";
 
     /**
      * Format for Storage Metadata Segment name.
@@ -107,12 +120,12 @@ public final class NameUtils {
     /**
      * Format for Container System Journal file name.
      */
-    private static final String SYSJOURNAL_NAME_FORMAT = "_system/containers/_sysjournal.epoch%d.container%d.file%d";
+    private static final String SYSJOURNAL_NAME_FORMAT = INTERNAL_CONTAINER_PREFIX + "_sysjournal.epoch%d.container%d.file%d";
 
     /**
      * Format for Container System snapshot file name.
      */
-    private static final String SYSJOURNAL_SNAPSHOT_NAME_FORMAT = "_system/containers/_sysjournal.epoch%d.container%d.snapshot%d";
+    private static final String SYSJOURNAL_SNAPSHOT_NAME_FORMAT = INTERNAL_CONTAINER_PREFIX + "_sysjournal.epoch%d.container%d.snapshot%d";
 
     /**
      * The Transaction unique identifier is made of two parts, each having a length of 16 bytes (64 bits in Hex).
@@ -140,7 +153,7 @@ public final class NameUtils {
     private static final String KVTABLE_SUFFIX = "_kvtable";
 
     /**
-     * Prefix for identifying system created mark segments for storing watermarks. 
+     * Prefix for identifying system created mark segments for storing watermarks.
      */
     @Getter(AccessLevel.PUBLIC)
     private static final String MARK_PREFIX = INTERNAL_NAME_PREFIX + "MARK";
@@ -526,13 +539,13 @@ public final class NameUtils {
         sb.append(streamName);
         return sb;
     }
-    
+
     // region table names
 
     /**
      * Method to generate Fully Qualified table name using scope, and other tokens to be used to compose the table name.
      * The composed name has following format: {@literal <scope>/_tables/<tokens[0]>/<tokens[1]>...}
-     * 
+     *
      * @param scope scope in which table segment to create
      * @param tokens tokens used for composing table segment name
      * @return Fully qualified table segment name composed of supplied tokens.
@@ -550,11 +563,11 @@ public final class NameUtils {
 
     /**
      * Method to extract tokens that were used to compose fully qualified table segment name using method getQualifiedTableName.
-     * 
+     *
      * The first token in the returned list corresponds to scope. Remainder tokens correspond to tokens used to compose tableName.
      *
      * @param qualifiedName fully qualified table name
-     * @return tokens capturing different components of table segment name. First element in the list represents scope 
+     * @return tokens capturing different components of table segment name. First element in the list represents scope
      */
     public static List<String> extractTableSegmentTokens(String qualifiedName) {
         Preconditions.checkNotNull(qualifiedName);
@@ -567,7 +580,7 @@ public final class NameUtils {
         for (int i = 2; i < tokens.length; i++) {
             retVal.add(tokens[i]);
         }
-        
+
         return retVal;
     }
 
@@ -663,7 +676,7 @@ public final class NameUtils {
         return (segmentBaseName == null) ? segmentQualifiedName : segmentBaseName;
     }
     // endregion
-    
+
     /**
      * Construct an internal representation of stream name. This is required to distinguish between user created
      * and pravega internally created streams.
@@ -775,7 +788,7 @@ public final class NameUtils {
     public static String validateWriterId(String writerId) {
         return validateUserStreamName(writerId);
     }
-    
+
     // region watermark
     public static String getMarkStreamForStream(String stream) {
         StringBuffer sb = new StringBuffer();


### PR DESCRIPTION
SLTS - SystemJournal - Fix concurrency issue with inconsistent metadata during snapshot creation.

Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>



**Change log description**  
Cherry pick 6185 to 0.9.2 
- SLTS - SystemJournal - Fix concurrency issue with inconsistent metadata during snapshot creation.

**Purpose of the change**  
Fix #6189

**What the code does**  
Backport https://github.com/pravega/pravega/pull/6185 to 0.9.2 

**How to verify it**  
All tests should pass
