### PR TITLE
Issue 6205: ListKeyValueTables API throws NullPointerException if metadataTable storing list of KVTs in Scope is deleted.

### DIFF
--- a/client/src/main/java/io/pravega/client/connection/impl/ConnectionPoolImpl.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/ConnectionPoolImpl.java
@@ -128,11 +128,11 @@ public class ConnectionPoolImpl implements ConnectionPool {
 
             final Connection connection;
             if (suggestedConnection.isPresent() && (prunedConnectionList.size() >= clientConfig.getMaxConnectionsPerSegmentStore() || isUnused(suggestedConnection.get()))) {
-                log.info("Reusing connection: {}", suggestedConnection.get());
+                log.trace("Reusing connection: {}", suggestedConnection.get());
                 connection = suggestedConnection.get();
             } else {
                 // create a new connection.
-                log.info("Creating a new connection to {}", location);
+                log.trace("Creating a new connection to {}", location);
                 CompletableFuture<FlowHandler> establishedFuture = establishConnection(location);
                 connection = new Connection(location, establishedFuture);
                 prunedConnectionList.add(connection);

--- a/controller/src/main/java/io/pravega/controller/store/PravegaTablesScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/PravegaTablesScope.java
@@ -481,6 +481,6 @@ public class PravegaTablesScope implements Scope {
                                                              }
                                                              token.set(Base64.getEncoder().encodeToString(result.getKey().array()));
                                                              return new ImmutablePair<>(taken, token.get());
-                                                         }), DATA_NOT_FOUND_PREDICATE, new ImmutablePair<>(Collections.emptyList(), null));
+                                                         }), DATA_NOT_FOUND_PREDICATE, new ImmutablePair<>(Collections.emptyList(), token.get()));
     }
 }

--- a/controller/src/main/java/io/pravega/controller/store/kvtable/PravegaTablesKVTMetadataStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/kvtable/PravegaTablesKVTMetadataStore.java
@@ -65,6 +65,13 @@ public class PravegaTablesKVTMetadataStore extends AbstractKVTableMetadataStore 
         this.executor = executor;
     }
 
+    @VisibleForTesting
+    public PravegaTablesKVTMetadataStore(CuratorFramework curatorClient, ScheduledExecutorService executor, PravegaTablesStoreHelper storeHelper) {
+        super(new ZKHostIndex(curatorClient, "/hostRequestIndex", executor));
+        this.storeHelper = storeHelper;
+        this.executor = executor;
+    }
+
     @Override
     PravegaTablesKVTable newKeyValueTable(final String scope, final String name) {
         log.debug("Fetching KV Table from PravegaTables store {}/{}", scope, name);

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/PravegaTablesScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/PravegaTablesScaleRequestHandlerTest.java
@@ -60,7 +60,7 @@ public class PravegaTablesScaleRequestHandlerTest extends ScaleRequestHandlerTes
     @Override
     StreamMetadataStore getStore() {
         storeHelper = spy(new PravegaTablesStoreHelper(segmentHelper, GrpcAuthHelper.getDisabledAuthHelper(), executor));
-        return TestStreamStoreFactory.createPravegaTablesStore(zkClient, executor, storeHelper);
+        return TestStreamStoreFactory.createPravegaTablesStreamStore(zkClient, executor, storeHelper);
 
     }
 

--- a/controller/src/test/java/io/pravega/controller/store/kvtable/PravegaTablesKVTMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/kvtable/PravegaTablesKVTMetadataStoreTest.java
@@ -87,12 +87,7 @@ public class PravegaTablesKVTMetadataStoreTest extends KVTableMetadataStoreTest 
     @Test
     public void testPartiallyDeletedScope() throws Exception {
         final String scopeName = "partialScope";
-        /*
-        PravegaTablesStoreHelper storeHelperSpy = spy(new PravegaTablesStoreHelper(segmentHelperMockForTables, GrpcAuthHelper.getDisabledAuthHelper(), executor));
-        when(storeHelperSpy.getKeysPaginated(anyString(), any(), anyInt(), anyLong())).thenThrow(new CompletionException(StoreException.create(StoreException.Type.DATA_NOT_FOUND, "kvTablesInScope not found.")));
-        StreamMetadataStore testStreamStore = TestStreamStoreFactory.createPravegaTablesStreamStore(PRAVEGA_ZK_CURATOR_RESOURCE.client, executor, storeHelperSpy);
-        KVTableMetadataStore testKVStore = TestStreamStoreFactory.createPravegaTablesKVStore(PRAVEGA_ZK_CURATOR_RESOURCE.client, executor, storeHelperSpy);
-         */
+
         OperationContext context = streamStore.createScopeContext(scopeName, 0L);
         CompletableFuture<Controller.CreateScopeStatus> createScopeFuture = streamStore.createScope(scopeName, context, executor);
         Controller.CreateScopeStatus status = createScopeFuture.get();

--- a/controller/src/test/java/io/pravega/controller/store/kvtable/PravegaTablesKVTMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/kvtable/PravegaTablesKVTMetadataStoreTest.java
@@ -20,6 +20,7 @@ import io.pravega.controller.mocks.SegmentHelperMock;
 import io.pravega.controller.server.SegmentHelper;
 import io.pravega.controller.server.WireCommandFailedException;
 import io.pravega.controller.server.security.auth.GrpcAuthHelper;
+import io.pravega.controller.store.PravegaTablesStoreHelper;
 import io.pravega.controller.store.stream.*;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.shared.protocol.netty.WireCommandType;
@@ -32,11 +33,17 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.ClassRule;
 
-import java.util.*;
+import java.util.UUID;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * Zookeeper based stream metadata store tests.
@@ -88,21 +95,20 @@ public class PravegaTablesKVTMetadataStoreTest extends KVTableMetadataStoreTest 
     public void testPartiallyDeletedScope() throws Exception {
         final String scopeName = "partialScope";
 
-        OperationContext context = streamStore.createScopeContext(scopeName, 0L);
-        CompletableFuture<Controller.CreateScopeStatus> createScopeFuture = streamStore.createScope(scopeName, context, executor);
+        PravegaTablesStoreHelper storeHelperSpy = spy(new PravegaTablesStoreHelper(segmentHelperMockForTables, GrpcAuthHelper.getDisabledAuthHelper(), executor));
+        WireCommandFailedException wcfe = new WireCommandFailedException(WireCommandType.READ_TABLE_KEYS, WireCommandFailedException.Reason.TableKeyDoesNotExist);
+        when(storeHelperSpy.getKeysPaginated(anyString(), any(), anyInt(), anyLong())).thenReturn(CompletableFuture.failedFuture(new CompletionException(StoreException.create(StoreException.Type.DATA_NOT_FOUND, wcfe, "kvTablesInScope not found."))));
+        StreamMetadataStore testStreamStore = TestStreamStoreFactory.createPravegaTablesStreamStore(PRAVEGA_ZK_CURATOR_RESOURCE.client, executor, storeHelperSpy);
+        KVTableMetadataStore testKVStore = TestStreamStoreFactory.createPravegaTablesKVStore(PRAVEGA_ZK_CURATOR_RESOURCE.client, executor, storeHelperSpy);
+
+        OperationContext context = testStreamStore.createScopeContext(scopeName, 0L);
+        CompletableFuture<Controller.CreateScopeStatus> createScopeFuture = testStreamStore.createScope(scopeName, context, executor);
         Controller.CreateScopeStatus status = createScopeFuture.get();
         Assert.assertEquals(Controller.CreateScopeStatus.Status.SUCCESS, status.getStatus());
 
-        // setup KVTable Store
-        SegmentHelper segmentHelperFailingMockForTables = SegmentHelperMock.getFailingSegmentHelperMock();
-        doReturn(Controller.NodeUri.newBuilder().setEndpoint("localhost").setPort(123).build()).when(segmentHelperFailingMockForTables).getTableUri(anyString());
-        doThrow(new WireCommandFailedException(WireCommandType.READ_TABLE_KEYS, WireCommandFailedException.Reason.TableKeyDoesNotExist)).when(segmentHelperFailingMockForTables).readTableKeys(anyString(), anyInt(), any(), anyString(), anyLong());
-        KVTableMetadataStore testKVStore = KVTableStoreFactory.createPravegaTablesStore(segmentHelperFailingMockForTables, GrpcAuthHelper.getDisabledAuthHelper(),
-                PRAVEGA_ZK_CURATOR_RESOURCE.client, executor);
         String token = Controller.ContinuationToken.newBuilder().build().getToken();
         Pair<List<String>, String> kvtList = testKVStore.listKeyValueTables(scopeName, token, 2, context, executor).get();
         Assert.assertEquals(0, kvtList.getKey().size());
         Assert.assertEquals(token, kvtList.getValue());
     }
-
 }

--- a/controller/src/test/java/io/pravega/controller/store/kvtable/PravegaTablesKVTMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/kvtable/PravegaTablesKVTMetadataStoreTest.java
@@ -21,15 +21,19 @@ import io.pravega.controller.server.SegmentHelper;
 import io.pravega.controller.server.WireCommandFailedException;
 import io.pravega.controller.server.security.auth.GrpcAuthHelper;
 import io.pravega.controller.store.PravegaTablesStoreHelper;
-import io.pravega.controller.store.stream.*;
+import io.pravega.controller.store.stream.StreamMetadataStore;
+import io.pravega.controller.store.stream.StreamStoreFactory;
+import io.pravega.controller.store.stream.OperationContext;
+import io.pravega.controller.store.stream.StoreException;
+import io.pravega.controller.store.stream.TestStreamStoreFactory;
 import io.pravega.controller.stream.api.grpc.v1.Controller;
 import io.pravega.shared.protocol.netty.WireCommandType;
-import io.pravega.test.common.AssertExtensions;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.retry.RetryOneTime;
 
 import org.junit.Assert;
+import io.pravega.test.common.AssertExtensions;
 import org.junit.Test;
 import org.junit.ClassRule;
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/TestStreamStoreFactory.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/TestStreamStoreFactory.java
@@ -11,6 +11,8 @@ package io.pravega.controller.store.stream;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.pravega.controller.store.PravegaTablesStoreHelper;
+import io.pravega.controller.store.kvtable.KVTableMetadataStore;
+import io.pravega.controller.store.kvtable.PravegaTablesKVTMetadataStore;
 import io.pravega.controller.util.Config;
 import org.apache.curator.framework.CuratorFramework;
 
@@ -19,8 +21,15 @@ import java.util.concurrent.ScheduledExecutorService;
 
 public class TestStreamStoreFactory {
     @VisibleForTesting
-    public static StreamMetadataStore createPravegaTablesStore(final CuratorFramework client,
-                                                               final ScheduledExecutorService executor, PravegaTablesStoreHelper helper) {
+    public static StreamMetadataStore createPravegaTablesStreamStore(final CuratorFramework client,
+                                                                     final ScheduledExecutorService executor, PravegaTablesStoreHelper helper) {
         return new PravegaTablesStreamMetadataStore(client, executor, Duration.ofHours(Config.COMPLETED_TRANSACTION_TTL_IN_HOURS), helper);
     }
+
+    @VisibleForTesting
+    public static KVTableMetadataStore createPravegaTablesKVStore(final CuratorFramework client,
+                                                                  final ScheduledExecutorService executor, PravegaTablesStoreHelper helper) {
+        return new PravegaTablesKVTMetadataStore(client, executor, helper);
+    }
+
 }


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description** 
This issue is noticed when deleteScope is invoked on a scope and during this invocation the metadataTable `keyValueTablesInScope-%s` is deleted and later deleteScope is invoked again on the same scope, which causes Client to invoke `listKeyValueTablesInScope` API on Controller, so the scope can be deleted after all KeyValueTables inside this scope have been deleted. However, during the first invocation, since the metadata table storing list of KVTs in this scope is deleted, we get a NullPointerException. This happens becuase we return a null value as token when this table is not found, 
This PR changes the code so that instead of null we now return the same continuation token as was passed by the user along with emptyList of KeyValueTableNames in Scope, so the user gets a valid token and the listKeyValueTablesInScope() call succeeds.

**Purpose of the change**  
Fixes #6205

**What the code does**  
Changed readAll method in PravegaTablesScope to remove the null assignment to token on DATA_NOT_FOUND Exception.
Also included in this PR is a log level change for class ConnectionPoolImpl that helps reduce a lot of spurious connection related logs in production.

**How to verify it**  
Unit, Intergration and System Tests should pass.
