### PR TITLE
Issue 5886: SLTS - Fix several flaky tests. Use multiple threads in tests to uncover more thread/timing related issues.

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
@@ -554,7 +554,10 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
                 if (0 == activeKeys.count(key)) {
                     // Synchronization prevents error when key becomes active between the check and remove.
                     // Move the key to cache
-                    cache.put(key, bufferedTxnData.get(key));
+                    val v = bufferedTxnData.get(key);
+                    if (null != v) {
+                        cache.put(key, v);
+                    }
                     // Remove from buffer.
                     bufferedTxnData.remove(key);
                     count++;

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageTests.java
@@ -42,7 +42,8 @@ import static org.junit.Assert.assertTrue;
  * Unit tests specifically targeted at test {@link ChunkStorage} implementation.
  */
 public class ChunkStorageTests extends ThreadPooledTestSuite {
-    Random rnd = new Random();
+    private static final int THREAD_POOL_SIZE = 10;
+    Random rnd = new Random(0);
 
     @Getter
     ChunkStorage chunkStorage;
@@ -68,6 +69,11 @@ public class ChunkStorageTests extends ThreadPooledTestSuite {
             chunkStorage.close();
         }
         super.before();
+    }
+
+    @Override
+    protected int getThreadPoolSize() {
+        return THREAD_POOL_SIZE;
     }
 
     /**

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageTests.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
  * Unit tests specifically targeted at test {@link ChunkStorage} implementation.
  */
 public class ChunkStorageTests extends ThreadPooledTestSuite {
-    private static final int THREAD_POOL_SIZE = 10;
+    private static final int THREAD_POOL_SIZE = 3;
     Random rnd = new Random(0);
 
     @Getter

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -77,7 +77,7 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
     protected static final Duration TIMEOUT = Duration.ofSeconds(3000);
     private static final int CONTAINER_ID = 42;
     private static final int OWNER_EPOCH = 100;
-    private static final int THREAD_POOL_SIZE = 10;
+    private static final int THREAD_POOL_SIZE = 3;
     protected final Random rnd = new Random(0);
 
     @Rule

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -77,6 +77,7 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
     protected static final Duration TIMEOUT = Duration.ofSeconds(3000);
     private static final int CONTAINER_ID = 42;
     private static final int OWNER_EPOCH = 100;
+    private static final int THREAD_POOL_SIZE = 10;
     protected final Random rnd = new Random(0);
 
     @Rule
@@ -96,7 +97,7 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
 
     @Override
     protected int getThreadPoolSize() {
-        return 1;
+        return THREAD_POOL_SIZE;
     }
 
     public ChunkStorage createChunkStorage() throws Exception {
@@ -1047,7 +1048,7 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
             // Append some data to the last chunk to simulate partial write during failure
             val lastChunkMetadata = TestUtils.getChunkMetadata(testContext.metadataStore,
                     TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName).getLastChunk());
-            testContext.chunkStorage.write(ChunkHandle.writeHandle(lastChunkMetadata.getName()), lastChunkMetadata.getLength(), 1, new ByteArrayInputStream(new byte[1]));
+            testContext.chunkStorage.write(ChunkHandle.writeHandle(lastChunkMetadata.getName()), lastChunkMetadata.getLength(), 1, new ByteArrayInputStream(new byte[1])).join();
             writeAt += i;
         }
 

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -1898,14 +1898,14 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
         // Add some garbage data at the end of last chunk
         val lastChunkMetadata = TestUtils.getChunkMetadata(testContext.metadataStore,
                 TestUtils.getSegmentMetadata(testContext.metadataStore, targetSegmentName).getLastChunk());
-        testContext.chunkStorage.write(ChunkHandle.writeHandle(lastChunkMetadata.getName()), lastChunkMetadata.getLength(), 1, new ByteArrayInputStream(new byte[1]));
+        testContext.chunkStorage.write(ChunkHandle.writeHandle(lastChunkMetadata.getName()), lastChunkMetadata.getLength(), 1, new ByteArrayInputStream(new byte[1])).join();
 
         // Write some garbage at the end.
         val sourceList = TestUtils.getChunkList(testContext.metadataStore, sourceSegmentName);
         for (int i : chunksWithGarbageIndex) {
             // Append some data to the last chunk to simulate partial write during failure
             val chunkMetadata = TestUtils.getChunkMetadata(testContext.metadataStore, sourceList.get(i).getName());
-            testContext.chunkStorage.write(ChunkHandle.writeHandle(chunkMetadata.getName()), chunkMetadata.getLength(), 1, new ByteArrayInputStream(new byte[1]));
+            testContext.chunkStorage.write(ChunkHandle.writeHandle(chunkMetadata.getName()), chunkMetadata.getLength(), 1, new ByteArrayInputStream(new byte[1])).join();
         }
         val hTarget = testContext.chunkedSegmentStorage.openWrite(targetSegmentName).get();
         val concatAt = Arrays.stream(targetLayoutBefore).sum();

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SimpleStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SimpleStorageTests.java
@@ -47,8 +47,15 @@ import static io.pravega.test.common.AssertExtensions.assertMayThrow;
 public abstract class SimpleStorageTests extends StorageTestBase {
     private static final int CONTAINER_ID = 42;
     private static final int WRITE_COUNT = 5;
+    private static final int THREAD_POOL_SIZE = 10;
+
     ChunkStorage chunkStorage;
     ChunkMetadataStore chunkMetadataStore;
+
+    @Override
+    protected int getThreadPoolSize() {
+        return THREAD_POOL_SIZE;
+    }
 
     /**
      * Creates a new instance of the Storage implementation to be tested. This will be cleaned up (via close()) upon

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SimpleStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SimpleStorageTests.java
@@ -47,7 +47,7 @@ import static io.pravega.test.common.AssertExtensions.assertMayThrow;
 public abstract class SimpleStorageTests extends StorageTestBase {
     private static final int CONTAINER_ID = 42;
     private static final int WRITE_COUNT = 5;
-    private static final int THREAD_POOL_SIZE = 10;
+    private static final int THREAD_POOL_SIZE = 3;
 
     ChunkStorage chunkStorage;
     ChunkMetadataStore chunkMetadataStore;

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
@@ -961,7 +961,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
     }
 
     @Test
-    public void testEvictionFromBufferInParallel() throws Exception {
+    public void testEvictionFromBufferInParallel() {
         if (metadataStore instanceof InMemoryMetadataStore) {
             metadataStore.setMaxEntriesInCache(10);
             metadataStore.setMaxEntriesInTxnBuffer(10);
@@ -969,6 +969,21 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
             for (int i = 0; i < 10000; i++) {
                 final int k = i;
                 futures.add(CompletableFuture.runAsync(() -> simpleScenarioForKey("Key" + k)));
+            }
+            Futures.allOf(futures);
+        }
+    }
+
+    @Test
+    public void testEvictAllInParallel() {
+        if (metadataStore instanceof InMemoryMetadataStore) {
+            metadataStore.setMaxEntriesInCache(10);
+            metadataStore.setMaxEntriesInTxnBuffer(10);
+            val futures = new ArrayList<CompletableFuture<Void>>();
+            for (int i = 0; i < 10000; i++) {
+                final int k = i;
+                futures.add(CompletableFuture.runAsync(() -> simpleScenarioForKey("Key" + k)));
+                futures.add(CompletableFuture.runAsync(() -> metadataStore.evictAllEligibleEntriesFromBuffer()));
             }
             Futures.allOf(futures);
         }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStoreTests.java
@@ -54,12 +54,18 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
     protected static final String VALUE5 = "avian";
     protected static final String VALUE6 = "bird";
 
+    private static final int THREAD_POOL_SIZE = 10;
     private static final String[] KEYS = new String[]{ KEY0, KEY1, KEY2, KEY3};
 
     @Rule
     public Timeout globalTimeout = Timeout.seconds(300);
 
     protected BaseMetadataStore metadataStore;
+
+    @Override
+    protected int getThreadPoolSize() {
+        return THREAD_POOL_SIZE;
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -84,7 +90,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
             Assert.assertFalse(txn.isCommitted());
             assertNull(txn.get(null));
 
-            txn.abort();
+            txn.abort().join();
             Assert.assertTrue(txn.isAborted());
 
             AssertExtensions.assertThrows(
@@ -492,7 +498,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
             assertNull(txn2.get(KEY3));
             assertNull(txn2.get(KEY1));
             // abort
-            txn2.abort();
+            txn2.abort().join();
         } catch (Exception e) {
             throw e;
         }
@@ -608,7 +614,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
             assertNull(txn2.get(KEY3));
             assertNull(txn2.get(KEY1));
             // abort
-            txn2.abort();
+            txn2.abort().join();
         } catch (Exception e) {
             throw e;
         }
@@ -1323,7 +1329,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
             assertNull(txn.get(KEY0));
             txn.create(new MockStorageMetadata(KEY0, VALUE0));
             Assert.assertNotNull(txn.get(KEY0));
-            txn.commit();
+            txn.commit().join();
         }
 
         try (MetadataTransaction txn = metadataStore.beginTransaction(true, KEY0, KEY1)) {
@@ -1356,7 +1362,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
             assertNull(txn.get(KEY0));
             txn.create(new MockStorageMetadata(KEY0, VALUE0));
             Assert.assertNotNull(txn.get(KEY0));
-            txn.commit();
+            txn.commit().join();
             AssertExtensions.assertThrows("commit should throw an exception",
                     () -> txn.commit(),
                     ex -> ex instanceof IllegalStateException);
@@ -1373,7 +1379,7 @@ public class ChunkMetadataStoreTests extends ThreadPooledTestSuite {
         try (MetadataTransaction txn = metadataStore.beginTransaction(false, KEY0, KEY1)) {
             txn.update(new MockStorageMetadata(KEY0, VALUE0));
             Assert.assertNotNull(txn.get(KEY0));
-            txn.abort();
+            txn.abort().join();
             AssertExtensions.assertThrows("create should throw an exception",
                     () -> txn.commit(),
                     ex -> ex instanceof IllegalStateException);


### PR DESCRIPTION

Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Issue 5886: SLTS - Fix several flaky tests. Use multiple threads in tests to uncover more thread/timing related issues.

**Purpose of the change**  
Fixes https://github.com/pravega/pravega/issues/5886 , https://github.com/pravega/pravega/issues/6024


**What the code does**  
Fix possible null exception.
Use multiple threads in tests to uncover more thread/timing related issues.
Fix issues where test were not waiting on futures

**How to verify it**  
Tests must pass
