### PR TITLE
Issue 6198: (Bugfix) Fix incorrect handling of empty value during listStreams

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/PravegaTablesScope.java
+++ b/controller/src/main/java/io/pravega/controller/store/PravegaTablesScope.java
@@ -283,13 +283,7 @@ public class PravegaTablesScope implements Scope {
                         }
                     }
             ).thenCompose(table -> storeHelper.expectingDataNotFound(
-                    storeHelper.getEntry(table, tag, bytes -> {
-                                    if (bytes.length == 0) {
-                                        throw StoreException.create(StoreException.Type.DATA_NOT_FOUND, "Empty value returned");
-                                    } else {
-                                        return TagRecord.fromBytes(bytes);
-                                    }
-                               }, context.getRequestId())
+                    storeHelper.getEntry(table, tag, TagRecord::fromBytes, context.getRequestId())
                                .thenApply(ver -> new ImmutablePair<>(new ArrayList<>(ver.getObject().getStreams()), table)),
                     new ImmutablePair<>(Collections.emptyList(), table)));
         }
@@ -392,7 +386,7 @@ public class PravegaTablesScope implements Scope {
 
     private boolean isEmptyTagRecord(TableSegmentEntry entry) {
         byte[] array = storeHelper.getArray(entry.getValue());
-        return array.length != 0 && TagRecord.fromBytes(array).getStreams().isEmpty();
+        return array.length == 0 || TagRecord.fromBytes(array).getStreams().isEmpty();
     }
 
     public CompletableFuture<Void> removeStreamFromScope(String stream, OperationContext context) {

--- a/controller/src/main/java/io/pravega/controller/store/PravegaTablesStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/PravegaTablesStoreHelper.java
@@ -284,6 +284,7 @@ public class PravegaTablesStoreHelper {
                                                   return segmentHelper.updateTableEntries(tableName, Collections.singletonList(updatedEntry), authToken.get(), requestId)
                                                                       .thenCompose(keyVersions -> {
                                                                           if (shouldAttemptCleanup) {
+                                                                              log.debug(requestId, "Delete of table key {} on table {}", tableKey, tableName);
                                                                               // attempt a conditional delete of the entry since there are zero entries.
                                                                               return conditionalDeleteOfKey(tableName, requestId, tableKey, keyVersions.get(0));
                                                                           } else {

--- a/controller/src/test/java/io/pravega/controller/store/PravegaTablesScopeTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/PravegaTablesScopeTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.controller.store;
+
+import io.pravega.client.tables.impl.TableSegmentEntry;
+import io.pravega.client.tables.impl.TableSegmentKey;
+import io.pravega.client.tables.impl.TableSegmentKeyVersion;
+import io.pravega.controller.server.SegmentHelper;
+import io.pravega.controller.server.security.auth.GrpcAuthHelper;
+import io.pravega.controller.store.stream.OperationContext;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PravegaTablesScopeTest extends ThreadPooledTestSuite {
+    private final String scope = "scope";
+    private final String stream = "stream";
+    private final String indexTable = "table";
+    private final String tag = "tag";
+    private final byte[] tagBytes = tag.getBytes(StandardCharsets.UTF_8);
+    private final OperationContext context = new TestOperationContext();
+    private List<TableSegmentKey> keySnapshot;
+
+    @Test(timeout = 5000)
+    @SuppressWarnings("unchecked")
+    public void testRemoveTagsUnderScope() {
+        // Setup Mocks.
+        GrpcAuthHelper authHelper = mock(GrpcAuthHelper.class);
+        when(authHelper.retrieveMasterToken()).thenReturn("");
+        SegmentHelper segmentHelper = mock(SegmentHelper.class);
+        PravegaTablesStoreHelper storeHelper = new PravegaTablesStoreHelper(segmentHelper, authHelper, executorService());
+        PravegaTablesScope tablesScope = spy(new PravegaTablesScope(scope, storeHelper));
+        doReturn(CompletableFuture.completedFuture(indexTable)).when(tablesScope)
+                                                               .getAllStreamTagsInScopeTableNames(stream, context);
+        // Simulate an empty value being returned.
+        TableSegmentEntry entry = TableSegmentEntry.versioned(tagBytes, new byte[0], 1L);
+        when(segmentHelper.readTable(eq(indexTable), any(), anyString(), anyLong()))
+                .thenReturn(CompletableFuture.completedFuture(singletonList(entry)));
+        when(segmentHelper.updateTableEntries(eq(indexTable), any(), anyString(), anyLong()))
+                .thenReturn(CompletableFuture.completedFuture(singletonList(TableSegmentKeyVersion.from(2L))));
+        when(segmentHelper.removeTableKeys(eq(indexTable), any(), anyString(), anyLong()))
+                .thenAnswer(invocation -> {
+                    //Capture the key value sent during removeTableKeys.
+                    keySnapshot = (List<TableSegmentKey>) invocation.getArguments()[1];
+                    return CompletableFuture.completedFuture(null);
+                });
+
+        // Invoke the removeTags method.
+        tablesScope.removeTagsUnderScope(stream, Set.of(tag), context).join();
+        // Verify if correctly detect that the data is empty and the entry is cleaned up.
+        verify(segmentHelper, times(1)).removeTableKeys(eq(indexTable), eq(keySnapshot), anyString(), anyLong());
+        // Verify if the version number is as expected.
+        assertEquals(2L, keySnapshot.get(0).getVersion().getSegmentVersion());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Sandeep <sandeep.shridhar@emc.com>

**Change log description**  
Fix incorrect handling of empty value during listStreams

**Purpose of the change**  
Fixes #6198 

**What the code does**  
The code fixes the following
* Due to the incorrect isEmptyRecord condition an empty value is being written into the KVT.  This caused the EOFException while attempting to read from this empty record.  
* Improve the robustness of check for last tag index chunk.

**How to verify it**  
The system tests should pass reliably.
