### PR TITLE
Issue 6223: SLTS - GC deleteSegment delete/update metadata in small batches.

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
@@ -50,6 +50,7 @@ public class ChunkedSegmentStorageConfig {
     public static final Property<Integer> GARBAGE_COLLECTION_MAX_QUEUE_SIZE = Property.named("garbage.collection.queue.size.max", 16 * 1024);
     public static final Property<Integer> GARBAGE_COLLECTION_SLEEP = Property.named("garbage.collection.sleep.millis", 10);
     public static final Property<Integer> GARBAGE_COLLECTION_MAX_ATTEMPTS = Property.named("garbage.collection.attempts.max", 3);
+    public static final Property<Integer> GARBAGE_COLLECTION_MAX_TXN_BATCH_SIZE = Property.named("garbage.collection.txn.batch.size.max", 5000);
     public static final Property<Integer> MAX_METADATA_ENTRIES_IN_BUFFER = Property.named("metadata.buffer.size.max", 1024);
     public static final Property<Integer> MAX_METADATA_ENTRIES_IN_CACHE = Property.named("metadata.cache.size.max", 5000);
 
@@ -79,6 +80,7 @@ public class ChunkedSegmentStorageConfig {
             .garbageCollectionMaxQueueSize(16 * 1024)
             .garbageCollectionSleep(Duration.ofMillis(10))
             .garbageCollectionMaxAttempts(3)
+            .garbageCollectionTransactionBatchSize(5000)
             .indexBlockSize(1024 * 1024)
             .maxEntriesInCache(5000)
             .maxEntriesInTxnBuffer(1024)
@@ -198,6 +200,12 @@ public class ChunkedSegmentStorageConfig {
     final private int garbageCollectionMaxAttempts;
 
     /**
+     * Max number of metadata entries to update in a single transaction during garbage collection.
+     */
+    @Getter
+    final private int garbageCollectionTransactionBatchSize;
+
+    /**
      * Maximum number of metadata entries to keep in recent transaction buffer.
      */
     @Getter
@@ -262,6 +270,7 @@ public class ChunkedSegmentStorageConfig {
         this.garbageCollectionMaxQueueSize = properties.getInt(GARBAGE_COLLECTION_MAX_QUEUE_SIZE);
         this.garbageCollectionSleep = Duration.ofMillis(properties.getInt(GARBAGE_COLLECTION_SLEEP));
         this.garbageCollectionMaxAttempts = properties.getInt(GARBAGE_COLLECTION_MAX_ATTEMPTS);
+        this.garbageCollectionTransactionBatchSize = properties.getInt(GARBAGE_COLLECTION_MAX_TXN_BATCH_SIZE);
         this.journalSnapshotInfoUpdateFrequency = Duration.ofMinutes(properties.getInt(JOURNAL_SNAPSHOT_UPDATE_FREQUENCY));
         this.maxJournalUpdatesPerSnapshot =  properties.getInt(MAX_PER_SNAPSHOT_UPDATE_COUNT);
         this.maxJournalReadAttempts = properties.getInt(MAX_JOURNAL_READ_ATTEMPTS);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
@@ -270,7 +270,7 @@ public class ChunkedSegmentStorageConfig {
         this.garbageCollectionMaxQueueSize = properties.getInt(GARBAGE_COLLECTION_MAX_QUEUE_SIZE);
         this.garbageCollectionSleep = Duration.ofMillis(properties.getInt(GARBAGE_COLLECTION_SLEEP));
         this.garbageCollectionMaxAttempts = properties.getInt(GARBAGE_COLLECTION_MAX_ATTEMPTS);
-        this.garbageCollectionTransactionBatchSize = properties.getInt(GARBAGE_COLLECTION_MAX_TXN_BATCH_SIZE);
+        this.garbageCollectionTransactionBatchSize = properties.getPositiveInt(GARBAGE_COLLECTION_MAX_TXN_BATCH_SIZE);
         this.journalSnapshotInfoUpdateFrequency = Duration.ofMinutes(properties.getInt(JOURNAL_SNAPSHOT_UPDATE_FREQUENCY));
         this.maxJournalUpdatesPerSnapshot =  properties.getInt(MAX_PER_SNAPSHOT_UPDATE_COUNT);
         this.maxJournalReadAttempts = properties.getInt(MAX_JOURNAL_READ_ATTEMPTS);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
@@ -47,6 +47,7 @@ public class ChunkedSegmentStorageConfigTests {
         props.setProperty(ChunkedSegmentStorageConfig.READ_INDEX_BLOCK_SIZE.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "14");
         props.setProperty(ChunkedSegmentStorageConfig.MAX_METADATA_ENTRIES_IN_BUFFER.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "15");
         props.setProperty(ChunkedSegmentStorageConfig.MAX_METADATA_ENTRIES_IN_CACHE.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "16");
+        props.setProperty(ChunkedSegmentStorageConfig.GARBAGE_COLLECTION_MAX_TXN_BATCH_SIZE.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "17");
 
         TypedProperties typedProperties = new TypedProperties(props, "storage");
         ChunkedSegmentStorageConfig config = new ChunkedSegmentStorageConfig(typedProperties);
@@ -69,6 +70,7 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertEquals(config.getIndexBlockSize(), 14);
         Assert.assertEquals(config.getMaxEntriesInTxnBuffer(), 15);
         Assert.assertEquals(config.getMaxEntriesInCache(), 16);
+        Assert.assertEquals(config.getGarbageCollectionTransactionBatchSize(), 17);
     }
 
     @Test
@@ -100,6 +102,7 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertEquals(config.getIndexBlockSize(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getIndexBlockSize());
         Assert.assertEquals(config.getMaxEntriesInTxnBuffer(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxEntriesInTxnBuffer());
         Assert.assertEquals(config.getMaxEntriesInCache(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxEntriesInCache());
+        Assert.assertEquals(config.getGarbageCollectionTransactionBatchSize(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getGarbageCollectionTransactionBatchSize());
     }
 
     @Test

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollectorTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollectorTests.java
@@ -792,7 +792,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
         Assert.assertEquals(1, testTaskQueue.getTaskQueueMap().get(garbageCollector.getTaskQueueName()).size());
         Assert.assertEquals("testSegment", testTaskQueue.getTaskQueueMap().get(garbageCollector.getTaskQueueName()).peek().getName());
 
-        garbageCollector.processBatch(testTaskQueue.drain(garbageCollector.getTaskQueueName(), 10)).join();
+        garbageCollector.processBatch(testTaskQueue.drain(garbageCollector.getTaskQueueName(), 1)).join();
 
         // Validate state after
         Assert.assertEquals(4, testTaskQueue.getTaskQueueMap().get(garbageCollector.getTaskQueueName()).size());

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollectorTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollectorTests.java
@@ -259,6 +259,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
         Assert.assertEquals(0, garbageCollector.getQueueSize().get());
         Assert.assertTrue(chunkStorage.exists("activeChunk").get());
         Assert.assertNotNull(getChunkMetadata(metadataStore, "activeChunk"));
+        Assert.assertTrue(chunkStorage.exists("activeChunk").join());
     }
 
     /**
@@ -350,6 +351,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
 
         Assert.assertNotNull(garbageCollector.getTaskQueue());
         Assert.assertEquals(0, garbageCollector.getQueueSize().get());
+        Assert.assertFalse(chunkStorage.exists("deletedChunk").join());
 
         // Add some garbage
         garbageCollector.addChunksToGarbage(TXN_ID, Collections.singleton("deletedChunk")).join();
@@ -402,6 +404,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
 
         Assert.assertNotNull(garbageCollector.getTaskQueue());
         Assert.assertEquals(0, garbageCollector.getQueueSize().get());
+        Assert.assertFalse(chunkStorage.exists("nonExistingChunk").join());
 
         // Add some garbage
         garbageCollector.addChunksToGarbage(TXN_ID, Collections.singleton("nonExistingChunk")).join();
@@ -639,6 +642,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
 
         // Validate state after
         assertQueueEquals(garbageCollector.getTaskQueueName(), testTaskQueue, new String[]{"deletedChunk"});
+        Assert.assertTrue(chunkStorage.exists("deletedChunk").get());
     }
 
     /**
@@ -654,6 +658,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
 
         int dataSize = 1;
         insertChunkMetadata(metadataStore, "missingChunk", dataSize, 0);
+        Assert.assertFalse(chunkStorage.exists("missingChunk").get());
 
         Function<Duration, CompletableFuture<Void>> noDelay = d -> CompletableFuture.completedFuture(null);
         val testTaskQueue = new InMemoryTaskQueueManager();
@@ -746,6 +751,8 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
 
         // Validate state after
         assertQueueEquals(garbageCollector.getTaskQueueName(), testTaskQueue, new String[]{"deletedChunk"});
+        // The chunk is deleted, but we have failure while deleting metadata.
+        Assert.assertFalse(chunkStorage.exists("deletedChunk").get());
     }
 
     /**
@@ -783,6 +790,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
 
         insertSegment(metadataStore, chunkStorage, config, "testSegment", 10, 1,
                 new long[] {1, 2, 3, 4},  false, 0);
+        val chunkNames = TestUtils.getChunkNameList(metadataStore, "testSegment");
 
         // Add some garbage
         garbageCollector.addSegmentToGarbage(TXN_ID, "testSegment").join();
@@ -802,6 +810,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
         garbageCollector.processBatch(testTaskQueue.drain(garbageCollector.getTaskQueueName(), 10)).join();
         Assert.assertEquals(0, testTaskQueue.getTaskQueueMap().get(garbageCollector.getTaskQueueName()).size());
         Assert.assertEquals(0, garbageCollector.getQueueSize().get());
+        chunkNames.stream().forEach( chunkName -> Assert.assertFalse(chunkName + " should not exist", chunkStorage.exists(chunkName).join()));
     }
 
     /**
@@ -923,7 +932,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
 
         insertSegment(metadataStore, chunkStorage, config, "testSegment", 10, 1,
                 new long[] {1, 2, 3, 4},  false, 1);
-
+        val chunkNames = TestUtils.getChunkNameList(metadataStore, "testSegment");
         // Add some garbage
         garbageCollector.addSegmentToGarbage(TXN_ID, "testSegment").join();
 
@@ -942,6 +951,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
         Assert.assertEquals(0, garbageCollector.getQueueSize().get());
 
         Assert.assertNotNull(getSegmentMetadata(metadataStore, "testSegment"));
+        chunkNames.stream().forEach( chunkName -> Assert.assertTrue(chunkStorage.exists(chunkName).join()));
     }
 
     /**
@@ -980,6 +990,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
 
         insertSegment(metadataStore, chunkStorage, config, "testSegment", 10, 1,
                 new long[] {1, 2, 3, 4},  false, 0);
+        val chunkNames = TestUtils.getChunkNameList(metadataStore, "testSegment");
 
         // Add some garbage
         garbageCollector.addSegmentToGarbage(TXN_ID, "testSegment").join();
@@ -1003,6 +1014,75 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
         Assert.assertEquals(1, garbageCollector.getQueueSize().get());
 
         Assert.assertNotNull(getSegmentMetadata(metadataStore, "testSegment"));
+        chunkNames.stream().forEach( chunkName -> Assert.assertTrue(chunkStorage.exists(chunkName).join()));
+    }
+
+    /**
+     * Test for segment that for which metadata is partially updated already in previous attempt.
+     */
+    @Test
+    public void testMetadataExceptionForSegmentPartialMetadataUpdate() throws Exception {
+        @Cleanup
+        ChunkStorage chunkStorage = getChunkStorage();
+        @Cleanup
+        ChunkMetadataStore metadataStore = spy(getMetadataStore());
+        int containerId = CONTAINER_ID;
+
+        int dataSize = 1;
+        Function<Duration, CompletableFuture<Void>> noDelay = d -> CompletableFuture.completedFuture(null);
+        val testTaskQueue = new InMemoryTaskQueueManager();
+
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .garbageCollectionDelay(Duration.ofMillis(1))
+                .garbageCollectionSleep(Duration.ofMillis(1))
+                .build();
+        @Cleanup
+        GarbageCollector garbageCollector = new GarbageCollector(containerId,
+                chunkStorage,
+                metadataStore,
+                config,
+                executorService(),
+                System::currentTimeMillis,
+                noDelay);
+
+        // Now actually start run
+        garbageCollector.initialize(testTaskQueue).join();
+
+        Assert.assertNotNull(garbageCollector.getTaskQueue());
+        Assert.assertEquals(0, garbageCollector.getQueueSize().get());
+
+        insertSegment(metadataStore, chunkStorage, config, "testSegment", 10, 1,
+                new long[] {1, 2, 3, 4},  false, 0);
+        val chunkNames = TestUtils.getChunkNameList(metadataStore, "testSegment");
+
+        // Simulate partial update of metadata.
+        @Cleanup
+        val txn = metadataStore.beginTransaction(false, "testSegment");
+        val metadata = (ChunkMetadata) txn.get(chunkNames.stream().findFirst().get()).join();
+        metadata.setActive(false);
+        txn.update(metadata);
+        txn.commit().join();
+
+        // Add some garbage
+        garbageCollector.addSegmentToGarbage(TXN_ID, "testSegment").join();
+
+        // Validate state before
+        Assert.assertEquals(1, garbageCollector.getQueueSize().get());
+        Assert.assertEquals("testSegment", testTaskQueue.getTaskQueueMap().get(garbageCollector.getTaskQueueName()).peek().getName());
+
+        val list = testTaskQueue.drain(garbageCollector.getTaskQueueName(), 1);
+        Assert.assertEquals(0, testTaskQueue.getTaskQueueMap().get(garbageCollector.getTaskQueueName()).size());
+        Assert.assertEquals(1, garbageCollector.getQueueSize().get());
+        garbageCollector.processBatch(list).join();
+
+        // Validate state after
+        Assert.assertEquals(4, testTaskQueue.getTaskQueueMap().get(garbageCollector.getTaskQueueName()).size());
+        Assert.assertEquals(4, garbageCollector.getQueueSize().get());
+
+        garbageCollector.processBatch(testTaskQueue.drain(garbageCollector.getTaskQueueName(), 4)).join();
+        Assert.assertEquals(0, testTaskQueue.getTaskQueueMap().get(garbageCollector.getTaskQueueName()).size());
+        Assert.assertEquals(0, garbageCollector.getQueueSize().get());
+        chunkNames.stream().forEach( chunkName -> Assert.assertFalse(chunkName + " should not exist", chunkStorage.exists(chunkName).join()));
     }
 
     /**


### PR DESCRIPTION


Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Issue 6223: SLTS - GC deleteSegment delete/update metadata in small batches.

**Purpose of the change**  
Fixes #6223 

**What the code does**  
Instead of modifying all metadata for deleted segment in a single transaction, break the delete/update into multiple small batches.

**How to verify it**  
All tests should pass
