### PR TITLE
Issue 6232: (Bugfix) Ensure StateSyncrhonizer handles stale updates from RevisionedStreamClient.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentMetadataClientImpl.java
@@ -187,7 +187,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
 
     private CompletableFuture<SegmentTruncated> truncateSegmentAsync(Segment segment, long offset,
                                                                      DelegationTokenProvider tokenProvider) {
-        log.trace("Truncating segment: {}", segment);
+        log.debug("Truncating segment: {} at offset {}", segment, offset);
         RawClient connection = getConnection();
         long requestId = connection.getFlow().getNextSequenceNumber();
 
@@ -264,7 +264,7 @@ class SegmentMetadataClientImpl implements SegmentMetadataClient {
             .runAsync(() -> truncateSegmentAsync(segmentId, offset, tokenProvider).exceptionally(t -> {
                 final Throwable ex = Exceptions.unwrap(t);
                 if (ex.getCause() instanceof SegmentTruncatedException) {
-                    log.debug("Segment already truncated at offset {}. Details: {}",
+                    log.debug("Segment {} already truncated at offset {}. Details: {}", segmentId,
                               offset,
                               ex.getCause().getMessage());
                     return null;

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -235,6 +235,7 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
     @Override
     public void truncateToRevision(Revision newStart) {
         Futures.getThrowingException(meta.truncateSegment(newStart.asImpl().getOffsetInSegment()));
+        log.info("Truncate segment {} to revision {}", newStart.asImpl().getSegment(), newStart);
     }
 
     @Override


### PR DESCRIPTION
**Change log description**  
Ensure StateSyncrhonizer handles a scenario where its in-memory state is newer than the update received from the RevisionedStreamClient.

**Purpose of the change**  
Fixes #6232 

**What the code does**  
In a scenario where there concurrent `StateSyncrhonizer.fetchUpdates()` API invocations post a truncation(due to compaction) it can so happen that the in-memory state of the StateSyncrhonizer is newer than the update received from the Revisioned Stream client.
In such a scneario the StateSyncrhonizer should not throw an `IllegalStateExeption` since not `InitialUpdate ` is an older one.
The `IllegalStateException` should be thrown only in a scneario if no `InitialUpdate ` is observed.

**How to verify it**  
All the existing and newly added tests should pass.
