### PR TITLE
Cherry-pick 6200 to r0.9

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -335,17 +335,16 @@ public class SystemJournal {
                     return applyFinalTruncateOffsets(txn, state);
                 }, executor)
                 .thenComposeAsync(v -> {
-                    // Step 5: Create a snapshot record and validate it. However do not save it yet.
-                    return createSystemSnapshotRecord(txn, true, config.isSelfCheckEnabled())
-                            .thenComposeAsync(systemSnapshotRecord -> checkInvariants(systemSnapshotRecord), executor);
-                }, executor)
-                .thenAcceptAsync(v -> {
-                    // Step 6: Check invariants. These should never fail.
+                    // Step 5: Check invariants. These should never fail.
                     if (config.isSelfCheckEnabled()) {
                         Preconditions.checkState(currentFileIndex.get() == 0, "currentFileIndex must be zero");
                         Preconditions.checkState(systemJournalOffset.get() == 0, "systemJournalOffset must be zero");
                         Preconditions.checkState(newChunkRequired.get(), "newChunkRequired must be true");
                     }
+                    // Step 6: Create a snapshot record and validate it. Save it in journals.
+                    return createSystemSnapshotRecord(txn, true, config.isSelfCheckEnabled())
+                            .thenComposeAsync(systemSnapshotRecord -> writeRecordBatch(Collections.singletonList(systemSnapshotRecord)), executor)
+                            .thenRunAsync(() -> newChunkRequired.set(true), executor);
                 }, executor)
                 .thenComposeAsync(v -> {
                     // Step 7: Finally commit all data.
@@ -614,7 +613,17 @@ public class SystemJournal {
     private CompletableFuture<SystemSnapshotRecord> applySystemSnapshotRecord(MetadataTransaction txn,
                                                                               BootstrapState state,
                                                                               SystemSnapshotRecord systemSnapshot) {
+
+        //Now apply
         if (null != systemSnapshot) {
+            // validate
+            systemSnapshot.checkInvariants();
+            // reset all state so far
+            txn.getData().clear();
+            state.finalTruncateOffsets.clear();
+            state.finalFirstChunkStartsAtOffsets.clear();
+            state.chunkStartOffsets.clear();
+
             log.debug("SystemJournal[{}] Applying snapshot that includes journals up to epoch={} journal index={}", containerId,
                     systemSnapshot.epoch, systemSnapshot.fileIndex);
             log.trace("SystemJournal[{}] Processing system log snapshot {}.", containerId, systemSnapshot);
@@ -639,7 +648,6 @@ public class SystemJournal {
 
                     // make sure that the record is marked pinned.
                     txn.markPinned(metadata);
-
                     state.chunkStartOffsets.put(metadata.getName(), offset);
                     offset += metadata.getLength();
                 }
@@ -663,9 +671,7 @@ public class SystemJournal {
         }
 
         // Validate
-        return checkInvariants(systemSnapshot)
-                .thenComposeAsync(v ->
-                        validateSystemSnapshotExistsInTxn(txn, systemSnapshot), executor)
+        return validateSystemSnapshotExistsInTxn(txn, systemSnapshot)
                 .thenApplyAsync(v -> {
                     log.debug("SystemJournal[{}] Done applying snapshots.", containerId);
                     return systemSnapshot;
@@ -722,49 +728,6 @@ public class SystemJournal {
                                     }, executor),
                             executor);
                 }, executor);
-    }
-
-    /**
-     * Check invariants for given {@link SystemSnapshotRecord}.
-     */
-    private CompletableFuture<Void> checkInvariants(SystemSnapshotRecord systemSnapshot) {
-        if (null != systemSnapshot) {
-            for (val segmentSnapshot : systemSnapshot.getSegmentSnapshotRecords()) {
-                segmentSnapshot.segmentMetadata.checkInvariants();
-                Preconditions.checkState(segmentSnapshot.segmentMetadata.isStorageSystemSegment(),
-                        "Segment must be storage segment. Segment snapshot= %s", segmentSnapshot);
-                Preconditions.checkState(segmentSnapshot.segmentMetadata.getChunkCount() == segmentSnapshot.chunkMetadataCollection.size(),
-                        "Chunk count must match. Segment snapshot= %s", segmentSnapshot);
-                if (segmentSnapshot.chunkMetadataCollection.size() == 0) {
-                    Preconditions.checkState(segmentSnapshot.segmentMetadata.getFirstChunk() == null,
-                            "First chunk must be null. Segment snapshot= %s", segmentSnapshot);
-                    Preconditions.checkState(segmentSnapshot.segmentMetadata.getLastChunk() == null,
-                            "Last chunk must be null. Segment snapshot= %s", segmentSnapshot);
-                } else if (segmentSnapshot.chunkMetadataCollection.size() == 1) {
-                    Preconditions.checkState(segmentSnapshot.segmentMetadata.getFirstChunk() != null,
-                            "First chunk must not be null. Segment snapshot= %s", segmentSnapshot);
-                    Preconditions.checkState(segmentSnapshot.segmentMetadata.getFirstChunk().equals(segmentSnapshot.segmentMetadata.getLastChunk()),
-                            "First chunk and last chunk should be same. Segment snapshot= %s", segmentSnapshot);
-                } else {
-                    Preconditions.checkState(segmentSnapshot.segmentMetadata.getFirstChunk() != null,
-                            "First chunk must be not be null. Segment snapshot= %s", segmentSnapshot);
-                    Preconditions.checkState(segmentSnapshot.segmentMetadata.getLastChunk() != null,
-                            "Last chunk must not be null. Segment snapshot= %s", segmentSnapshot);
-                    Preconditions.checkState(!segmentSnapshot.segmentMetadata.getFirstChunk().equals(segmentSnapshot.segmentMetadata.getLastChunk()),
-                            "First chunk and last chunk should not match. Segment snapshot= %s", segmentSnapshot);
-                }
-                ChunkMetadata previous = null;
-                for (val metadata : segmentSnapshot.getChunkMetadataCollection()) {
-                    if (previous != null) {
-                        Preconditions.checkState(previous.getNextChunk().equals(metadata.getName()),
-                                "In correct link . chunk %s must point to chunk %s. Segment snapshot= %s",
-                                previous.getName(), metadata.getName(), segmentSnapshot);
-                    }
-                    previous = metadata;
-                }
-            }
-        }
-        return CompletableFuture.completedFuture(null);
     }
 
     /**
@@ -936,27 +899,30 @@ public class SystemJournal {
         }
         state.visitedRecords.add(record);
         state.recordsProcessedCount.incrementAndGet();
-
+        CompletableFuture<Void> retValue = null;
         // ChunkAddedRecord.
         if (record instanceof ChunkAddedRecord) {
             val chunkAddedRecord = (ChunkAddedRecord) record;
-            return applyChunkAddition(txn, state.chunkStartOffsets,
+            retValue = applyChunkAddition(txn, state.chunkStartOffsets,
                     chunkAddedRecord.getSegmentName(),
                     nullToEmpty(chunkAddedRecord.getOldChunkName()),
                     chunkAddedRecord.getNewChunkName(),
                     chunkAddedRecord.getOffset());
-        }
-
-        // TruncationRecord.
-        if (record instanceof TruncationRecord) {
+        } else if (record instanceof TruncationRecord) {
+            // TruncationRecord.
             val truncationRecord = (TruncationRecord) record;
             state.finalTruncateOffsets.put(truncationRecord.getSegmentName(), truncationRecord.getOffset());
             state.finalFirstChunkStartsAtOffsets.put(truncationRecord.getSegmentName(), truncationRecord.getStartOffset());
-            return CompletableFuture.completedFuture(null);
+            retValue = CompletableFuture.completedFuture(null);
+        } else if (record instanceof SystemSnapshotRecord) {
+            val snapshotRecord = (SystemSnapshotRecord) record;
+            retValue = Futures.toVoid(applySystemSnapshotRecord(txn, state, snapshotRecord));
         }
-
-        // Unknown record.
-        return CompletableFuture.failedFuture(new IllegalStateException(String.format("Unknown record type encountered. record = %s", record)));
+        if (null == retValue) {
+            // Unknown record.
+            retValue = CompletableFuture.failedFuture(new IllegalStateException(String.format("Unknown record type encountered. record = %s", record)));
+        }
+        return retValue;
     }
 
     /**
@@ -1063,8 +1029,9 @@ public class SystemJournal {
                                                     .thenAcceptAsync(mmm -> {
                                                         val chunkToDelete = (ChunkMetadata) mmm;
                                                         txn.delete(toDelete.get());
-                                                        toDelete.set(chunkToDelete.getNextChunk());
                                                         segmentMetadata.setChunkCount(segmentMetadata.getChunkCount() - 1);
+                                                        // move to next chunk in list of now zombie chunks
+                                                        toDelete.set(chunkToDelete.getNextChunk());
                                                     }, executor),
                                             executor)
                                             .thenAcceptAsync(v -> {
@@ -1081,6 +1048,7 @@ public class SystemJournal {
                     } else {
                         segmentMetadata.setFirstChunk(newChunkName);
                         segmentMetadata.setStartOffset(offset);
+                        Preconditions.checkState(segmentMetadata.getChunkCount() == 0, "Chunk count must be 0. %s", segmentMetadata);
                         f = CompletableFuture.completedFuture(null);
                     }
                     return f.thenComposeAsync(v -> {
@@ -1222,7 +1190,10 @@ public class SystemJournal {
             futures.add(future);
         }
         return Futures.allOf(futures)
-                .thenApplyAsync(v -> systemSnapshot, executor);
+                .thenApplyAsync(vv -> {
+                    systemSnapshot.checkInvariants();
+                    return systemSnapshot;
+                }, executor);
     }
 
     /**
@@ -1253,7 +1224,7 @@ public class SystemJournal {
                                                 try {
                                                     val snapshotReadback = SYSTEM_SNAPSHOT_SERIALIZER.deserialize(contents);
                                                     if (config.isSelfCheckEnabled()) {
-                                                        checkInvariants(snapshotReadback);
+                                                        snapshotReadback.checkInvariants();
                                                     }
                                                     Preconditions.checkState(systemSnapshot.equals(snapshotReadback), "Records do not match %s != %s", snapshotReadback, systemSnapshot);
                                                     // Record as successful.
@@ -1606,6 +1577,45 @@ public class SystemJournal {
         private final Collection<ChunkMetadata> chunkMetadataCollection;
 
         /**
+         * Check invariants.
+         */
+        public void checkInvariants() {
+            segmentMetadata.checkInvariants();
+            Preconditions.checkState(segmentMetadata.isStorageSystemSegment(),
+                    "Segment must be storage segment. Segment snapshot= %s", this);
+            Preconditions.checkState(segmentMetadata.getChunkCount() == chunkMetadataCollection.size(),
+                    "Chunk count must match. Segment snapshot= %s", this);
+
+            long dataSize = 0;
+            ChunkMetadata previous = null;
+            ChunkMetadata firstChunk = null;
+            for (val metadata : getChunkMetadataCollection()) {
+                dataSize += metadata.getLength();
+                if (previous != null) {
+                    Preconditions.checkState(previous.getNextChunk().equals(metadata.getName()),
+                            "In correct link . chunk %s must point to chunk %s. Segment snapshot= %s",
+                            previous.getName(), metadata.getName(), this);
+                } else {
+                    firstChunk = metadata;
+                }
+                previous = metadata;
+            }
+            Preconditions.checkState(dataSize == segmentMetadata.getLength() - segmentMetadata.getFirstChunkStartOffset(),
+                    "Data size does not match dataSize (%s). Segment=%s", dataSize, segmentMetadata);
+
+            if (chunkMetadataCollection.size() > 0) {
+                Preconditions.checkState(segmentMetadata.getFirstChunk().equals(firstChunk.getName()),
+                        "First chunk name is wrong. Segment snapshot= %s", this);
+                Preconditions.checkState(segmentMetadata.getLastChunk().equals(previous.getName()),
+                        "Last chunk name is wrong. Segment snapshot= %s", this);
+                Preconditions.checkState(previous.getNextChunk() == null,
+                        "Invalid last chunk Segment snapshot= %s", this);
+                Preconditions.checkState(segmentMetadata.getLength() == segmentMetadata.getLastChunkStartOffset() + previous.getLength(),
+                        "Last chunk start offset is wrong. snapshot= %s", this);
+            }
+        }
+
+        /**
          * Builder that implements {@link ObjectBuilder}.
          */
         public static class SegmentSnapshotRecordBuilder implements ObjectBuilder<SegmentSnapshotRecord> {
@@ -1670,6 +1680,15 @@ public class SystemJournal {
          */
         @NonNull
         private final Collection<SegmentSnapshotRecord> segmentSnapshotRecords;
+
+        /**
+         * Check invariants.
+         */
+        public void checkInvariants() {
+            for (val segmentSnapshot : getSegmentSnapshotRecords()) {
+                segmentSnapshot.checkInvariants();
+            }
+        }
 
         /**
          * Builder that implements {@link ObjectBuilder}.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
@@ -78,17 +78,32 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
                                 // Nothing to do
                                 return CompletableFuture.completedFuture(null);
                             }
+                            val oldChunkCount = segmentMetadata.getChunkCount();
                             val oldStartOffset = segmentMetadata.getStartOffset();
                             return updateFirstChunk(txn)
                                     .thenComposeAsync(v -> deleteChunks(txn)
                                             .thenComposeAsync( vvv -> {
-
                                                 txn.update(segmentMetadata);
 
                                                 // Check invariants.
+                                                segmentMetadata.checkInvariants();
                                                 Preconditions.checkState(segmentMetadata.getLength() == oldLength,
                                                         "truncate should not change segment length. oldLength=%s Segment=%s", oldLength, segmentMetadata);
-                                                segmentMetadata.checkInvariants();
+                                                Preconditions.checkState(oldChunkCount - chunksToDelete.size() == segmentMetadata.getChunkCount(),
+                                                        "Number of chunks do not match. old value (%s) - number of chunks deleted (%s) must match current chunk count(%s)",
+                                                        oldChunkCount, chunksToDelete.size(), segmentMetadata.getChunkCount());
+                                                if (null != currentMetadata && null != segmentMetadata.getFirstChunk()) {
+                                                    Preconditions.checkState(segmentMetadata.getFirstChunk().equals(currentMetadata.getName()),
+                                                            "First chunk name must match current metadata. Expected = %s Actual = %s", segmentMetadata.getFirstChunk(), currentMetadata.getName());
+                                                    Preconditions.checkState(segmentMetadata.getStartOffset() <= segmentMetadata.getFirstChunkStartOffset() + currentMetadata.getLength(),
+                                                            "segment start offset (%s) must be less than or equal to first chunk start offset (%s)+ first chunk length (%s)",
+                                                            segmentMetadata.getStartOffset(), segmentMetadata.getFirstChunkStartOffset(), currentMetadata.getLength());
+                                                    if (segmentMetadata.getChunkCount() == 1) {
+                                                        Preconditions.checkState(segmentMetadata.getLength() - segmentMetadata.getFirstChunkStartOffset() == currentMetadata.getLength(),
+                                                                "Length of first chunk (%s) must match segment length (%s) - first chunk start offset (%s) when there is only one chunk",
+                                                                currentMetadata.getLength(), segmentMetadata.getLength(), segmentMetadata.getFirstChunkStartOffset());
+                                                    }
+                                                }
 
                                                 // Remove read index block entries.
                                                 chunkedSegmentStorage.deleteBlockIndexEntriesForChunk(txn, streamSegmentName, oldStartOffset, segmentMetadata.getStartOffset());

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/WriteOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/WriteOperation.java
@@ -207,6 +207,8 @@ class WriteOperation implements Callable<CompletableFuture<Void>> {
     }
 
     private CompletableFuture<Void> writeData(MetadataTransaction txn) {
+        val oldChunkCount = segmentMetadata.getChunkCount();
+        val oldLength = segmentMetadata.getLength();
         return Futures.loop(
                 () -> bytesRemaining.get() > 0,
                 () -> {
@@ -243,6 +245,17 @@ class WriteOperation implements Callable<CompletableFuture<Void>> {
                 .thenRunAsync(() -> {
                     // Check invariants.
                     segmentMetadata.checkInvariants();
+                    Preconditions.checkState(oldChunkCount + chunksAddedCount.get() == segmentMetadata.getChunkCount(),
+                            "Number of chunks do not match. old value (%s) + number of chunks added (%s) must match current chunk count(%s)",
+                            oldChunkCount, chunksAddedCount.get(), segmentMetadata.getChunkCount());
+                    Preconditions.checkState(oldLength + length == segmentMetadata.getLength(),
+                            "New length must match. old value (%s) + length (%s) must match current chunk count(%s)",
+                            oldLength, length, segmentMetadata.getLength());
+                    if (null != lastChunkMetadata.get()) {
+                        Preconditions.checkState(segmentMetadata.getLastChunkStartOffset() + lastChunkMetadata.get().getLength() == segmentMetadata.getLength(),
+                                "Last chunk start offset (%s) + Last chunk length (%s) must match segment length (%s)",
+                                segmentMetadata.getLastChunkStartOffset(), lastChunkMetadata.get().getLength(), segmentMetadata.getLength());
+                    }
                 }, chunkedSegmentStorage.getExecutor());
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/SegmentMetadata.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/SegmentMetadata.java
@@ -208,7 +208,7 @@ public class SegmentMetadata extends StorageMetadata {
         Preconditions.checkState(lastChunkStartOffset >= 0, "lastChunkStartOffset should be non-negative. %s", this);
         Preconditions.checkState(firstChunkStartOffset <= startOffset, "startOffset must not be smaller than firstChunkStartOffset. %s", this);
         Preconditions.checkState(length >= lastChunkStartOffset, "lastChunkStartOffset must not be greater than length. %s", this);
-        Preconditions.checkState(firstChunkStartOffset <= lastChunkStartOffset, "lastChunkStartOffset must not be greater than firstChunkStartOffset. %s", this);
+        Preconditions.checkState(firstChunkStartOffset <= lastChunkStartOffset, "firstChunkStartOffset must not be greater than lastChunkStartOffset. %s", this);
         Preconditions.checkState(chunkCount >= 0, "chunkCount should be non-negative. %s", this);
         Preconditions.checkState(length >= startOffset, "length must be greater or equal to startOffset. %s", this);
         if (null == firstChunk) {

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalOperationsTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalOperationsTests.java
@@ -120,6 +120,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testSimpleScenario() throws Exception {
+        @Cleanup
         val testContext = new TestContext(CONTAINER_ID);
         val testSegmentName = testContext.segmentNames[0];
         @Cleanup
@@ -183,6 +184,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
      */
     @Test
     public void testSimpleScenarioWithSnapshots() throws Exception {
+        @Cleanup
         val testContext = new TestContext(CONTAINER_ID);
         testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .maxJournalUpdatesPerSnapshot(2)
@@ -261,6 +263,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
 
     @Test
     public void testWithSnapshots() throws Exception {
+        @Cleanup
         val testContext = new TestContext(CONTAINER_ID);
         testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .maxJournalUpdatesPerSnapshot(3)
@@ -274,33 +277,32 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         val instance =  new TestInstance(testContext, 1);
         instance.bootstrap();
         instance.validate();
-        checkJournalsNotExist(testContext, instance, 1, 1, 1);
 
         // Add chunk.
         instance.append(testSegmentName, "A", 0, 1);
-        checkJournalsExist(testContext, instance, 1, 1, 1);
+        checkJournalsExist(testContext, instance, 1, 2, 2);
 
         // Add chunk.
         instance.append(testSegmentName, "B", 1, 2);
-        checkJournalsExist(testContext, instance, 1, 1, 2);
+        checkJournalsExist(testContext, instance, 1, 2, 3);
 
         // Add chunk.
         instance.append(testSegmentName, "C", 3, 3);
-        checkJournalsExist(testContext, instance, 1, 1, 3);
+        checkJournalsExist(testContext, instance, 1, 2, 4);
 
         // Add chunk.
         instance.append(testSegmentName, "D", 6, 4);
-        checkJournalsExist(testContext, instance, 1, 1, 4);
+        checkJournalsExist(testContext, instance, 1, 2, 5);
 
         // Add chunk.
         instance.append(testSegmentName, "E", 10, 5);
         instance.deleteGarbage();
-        checkJournalsExist(testContext, instance, 2, 2, 5);
-        checkJournalsNotExistBefore(testContext, instance.epoch, 2, 2, 5);
+        checkJournalsExist(testContext, instance, 2, 3, 6);
+        checkJournalsNotExistBefore(testContext, instance.epoch, 2, 3, 6);
 
         // Add chunk.
         instance.append(testSegmentName, "F", 15, 6);
-        checkJournalsExist(testContext, instance, 2, 2, 6);
+        checkJournalsExist(testContext, instance, 2, 3, 7);
 
         // Bootstrap new instance.
         @Cleanup
@@ -359,6 +361,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
 
     @Test
     public void testWithSnapshotsAndTime() throws Exception {
+        @Cleanup
         val testContext = new TestContext(CONTAINER_ID);
         testContext.setConfig(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .maxJournalUpdatesPerSnapshot(2)
@@ -372,34 +375,34 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         val instance =  new TestInstance(testContext, 1);
         instance.bootstrap();
         instance.validate();
-        checkJournalsNotExist(testContext, instance, 1, 1, 1);
+        //checkJournalsNotExist(testContext, instance, 1, 1, 1);
         // Add chunk.
         instance.append(testSegmentName, "A", 0, 1);
-        checkJournalsExist(testContext, instance, 1, 1, 1);
+        checkJournalsExist(testContext, instance, 1, 2, 2);
         // Add chunk.
         instance.append(testSegmentName, "B", 1, 2);
-        checkJournalsExist(testContext, instance, 1, 1, 2);
+        checkJournalsExist(testContext, instance, 1, 2, 3);
 
         // Trigger Time and add chunk
         testContext.addTime(testContext.config.getJournalSnapshotInfoUpdateFrequency().toMillis() + 1);
         instance.append(testSegmentName, "C", 3, 3);
         instance.deleteGarbage();
-        checkJournalsExist(testContext, instance, 2, 2, 3);
-        checkJournalsNotExistBefore(testContext, instance.epoch, 2, 2, 3);
+        checkJournalsExist(testContext, instance, 2, 3, 4);
+        checkJournalsNotExistBefore(testContext, instance.epoch, 2, 3, 4);
 
         // Add chunk.
         instance.append(testSegmentName, "D", 6, 4);
-        checkJournalsExist(testContext, instance, 2, 2, 4);
+        checkJournalsExist(testContext, instance, 2, 3, 5);
 
         // Add chunk.
         instance.append(testSegmentName, "E", 10, 5);
-        checkJournalsExist(testContext, instance, 2, 2, 5);
+        checkJournalsExist(testContext, instance, 2, 3, 6);
 
         // Add chunk.
         instance.append(testSegmentName, "F", 15, 6);
         instance.deleteGarbage();
-        checkJournalsExist(testContext, instance, 3, 3, 6);
-        checkJournalsNotExistBefore(testContext, instance.epoch, 3, 3, 6);
+        checkJournalsExist(testContext, instance, 3, 4, 7);
+        checkJournalsNotExistBefore(testContext, instance.epoch, 3, 4, 7);
 
         // Bootstrap new instance.
         @Cleanup
@@ -736,6 +739,229 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
     }
 
     /**
+     * Test basic zombie scenario with truncate.
+     * @throws Exception Exception if any.
+     */
+    @Test
+    public void testZombieScenario() throws Exception {
+        @Cleanup
+        val testContext = new TestContext(CONTAINER_ID);
+        val testSegmentName = testContext.segmentNames[0];
+        @Cleanup
+        val instance =  new TestInstance(testContext, 1);
+        instance.bootstrap();
+        instance.validate();
+        // Add a chunk
+        instance.append(testSegmentName, "A", 0, 10);
+
+        // Bootstrap.
+        @Cleanup
+        val instance2 =  new TestInstance(testContext, 2);
+        instance2.bootstrap();
+
+        // Validate.
+        instance2.validate();
+        TestUtils.checkSegmentBounds(instance2.metadataStore, testSegmentName, 0, 10);
+        TestUtils.checkSegmentLayout(instance2.metadataStore, testSegmentName, new long[] { 10});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance2.metadataStore, testSegmentName);
+        val segmentMetadata2 = TestUtils.getSegmentMetadata(instance2.metadataStore, testSegmentName);
+        Assert.assertEquals("A", segmentMetadata2.getFirstChunk());
+        Assert.assertEquals("A", segmentMetadata2.getLastChunk());
+        Assert.assertEquals(0, segmentMetadata2.getFirstChunkStartOffset());
+        Assert.assertEquals(0, segmentMetadata2.getLastChunkStartOffset());
+
+        // Bootstrap a new instance.
+        @Cleanup
+        val instance3 =  new TestInstance(testContext, 3);
+        instance3.bootstrap();
+        instance3.validate();
+        TestUtils.checkSegmentBounds(instance3.metadataStore, testSegmentName, 0, 10);
+        TestUtils.checkSegmentLayout(instance3.metadataStore, testSegmentName, new long[] { 10});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance3.metadataStore, testSegmentName);
+        val segmentMetadata3 = TestUtils.getSegmentMetadata(instance3.metadataStore, testSegmentName);
+        Assert.assertEquals("A", segmentMetadata3.getFirstChunk());
+        Assert.assertEquals("A", segmentMetadata3.getLastChunk());
+        Assert.assertEquals(0, segmentMetadata3.getFirstChunkStartOffset());
+        Assert.assertEquals(0, segmentMetadata3.getLastChunkStartOffset());
+
+        // Zombie Truncate
+        instance2.writeZombieRecord(SystemJournal.TruncationRecord.builder()
+                .offset(4)
+                .startOffset(0)
+                .segmentName(testSegmentName)
+                .firstChunkName("A")
+                .build());
+
+        // Bootstrap a new instance.
+        @Cleanup
+        val instance4 =  new TestInstance(testContext, 4);
+        instance4.bootstrap();
+        TestUtils.checkSegmentBounds(instance4.metadataStore, testSegmentName, 0, 10);
+        TestUtils.checkSegmentLayout(instance4.metadataStore, testSegmentName, new long[] { 10});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance4.metadataStore, testSegmentName);
+        val segmentMetadata4 = TestUtils.getSegmentMetadata(instance4.metadataStore, testSegmentName);
+        Assert.assertEquals("A", segmentMetadata4.getFirstChunk());
+        Assert.assertEquals("A", segmentMetadata4.getLastChunk());
+        Assert.assertEquals(0, segmentMetadata4.getFirstChunkStartOffset());
+        Assert.assertEquals(0, segmentMetadata4.getLastChunkStartOffset());
+    }
+
+    /**
+     * Test zombie scenario with multiple truncates.
+     * @throws Exception Exception if any.
+     */
+    @Test
+    public void testZombieScenarioMultipleTruncates() throws Exception {
+        @Cleanup
+        val testContext = new TestContext(CONTAINER_ID);
+        val testSegmentName = testContext.segmentNames[0];
+        @Cleanup
+        val instance =  new TestInstance(testContext, 1);
+        instance.bootstrap();
+        instance.validate();
+        // Add a chunk
+        instance.append(testSegmentName, "A", 0, 10);
+        instance.truncate(testSegmentName, 2);
+        // Bootstrap.
+        @Cleanup
+        val instance2 =  new TestInstance(testContext, 2);
+        instance2.bootstrap();
+
+        // Validate.
+        instance2.validate();
+        TestUtils.checkSegmentBounds(instance2.metadataStore, testSegmentName, 2, 10);
+        TestUtils.checkSegmentLayout(instance2.metadataStore, testSegmentName, new long[] { 10});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance2.metadataStore, testSegmentName);
+        val segmentMetadata2 = TestUtils.getSegmentMetadata(instance2.metadataStore, testSegmentName);
+        Assert.assertEquals("A", segmentMetadata2.getFirstChunk());
+        Assert.assertEquals("A", segmentMetadata2.getLastChunk());
+        Assert.assertEquals(0, segmentMetadata2.getFirstChunkStartOffset());
+        Assert.assertEquals(0, segmentMetadata2.getLastChunkStartOffset());
+
+        // Bootstrap a new instance.
+        @Cleanup
+        val instance3 =  new TestInstance(testContext, 3);
+        instance3.bootstrap();
+        instance3.validate();
+        TestUtils.checkSegmentBounds(instance3.metadataStore, testSegmentName, 2, 10);
+        TestUtils.checkSegmentLayout(instance3.metadataStore, testSegmentName, new long[] { 10});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance3.metadataStore, testSegmentName);
+        val segmentMetadata3 = TestUtils.getSegmentMetadata(instance3.metadataStore, testSegmentName);
+        Assert.assertEquals("A", segmentMetadata3.getFirstChunk());
+        Assert.assertEquals("A", segmentMetadata3.getLastChunk());
+        Assert.assertEquals(0, segmentMetadata3.getFirstChunkStartOffset());
+        Assert.assertEquals(0, segmentMetadata3.getLastChunkStartOffset());
+        instance3.truncate(testSegmentName, 3);
+
+        // Zombie Truncate
+        instance2.writeZombieRecord(SystemJournal.TruncationRecord.builder()
+                .offset(4)
+                .startOffset(0)
+                .segmentName(testSegmentName)
+                .firstChunkName("A")
+                .build());
+
+        // Bootstrap a new instance.
+        @Cleanup
+        val instance4 =  new TestInstance(testContext, 4);
+        instance4.bootstrap();
+        TestUtils.checkSegmentBounds(instance4.metadataStore, testSegmentName, 3, 10);
+        TestUtils.checkSegmentLayout(instance4.metadataStore, testSegmentName, new long[] { 10});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance4.metadataStore, testSegmentName);
+        val segmentMetadata4 = TestUtils.getSegmentMetadata(instance4.metadataStore, testSegmentName);
+        Assert.assertEquals("A", segmentMetadata4.getFirstChunk());
+        Assert.assertEquals("A", segmentMetadata4.getLastChunk());
+        Assert.assertEquals(0, segmentMetadata4.getFirstChunkStartOffset());
+        Assert.assertEquals(0, segmentMetadata4.getLastChunkStartOffset());
+    }
+
+    /**
+     * Test zombie scenario with multiple chunks.
+     * @throws Exception Exception if any.
+     */
+    @Test
+    public void testZombieScenarioMultipleChunks() throws Exception {
+        @Cleanup
+        val testContext = new TestContext(CONTAINER_ID);
+        val testSegmentName = testContext.segmentNames[0];
+        @Cleanup
+        val instance =  new TestInstance(testContext, 1);
+        instance.bootstrap();
+        instance.validate();
+        // Add a chunk
+        instance.append(testSegmentName, "A", 0, 10);
+        instance.append(testSegmentName, "B", 10, 20);
+        instance.append(testSegmentName, "C", 30, 30);
+        instance.truncate(testSegmentName, 2);
+        // Bootstrap.
+        @Cleanup
+        val instance2 =  new TestInstance(testContext, 2);
+        instance2.bootstrap();
+
+        // Validate.
+        instance2.validate();
+        TestUtils.checkSegmentBounds(instance2.metadataStore, testSegmentName, 2, 60);
+        TestUtils.checkSegmentLayout(instance2.metadataStore, testSegmentName, new long[] { 10, 20, 30});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance2.metadataStore, testSegmentName);
+        val segmentMetadata2 = TestUtils.getSegmentMetadata(instance2.metadataStore, testSegmentName);
+        Assert.assertEquals("A", segmentMetadata2.getFirstChunk());
+        Assert.assertEquals("C", segmentMetadata2.getLastChunk());
+        Assert.assertEquals(0, segmentMetadata2.getFirstChunkStartOffset());
+        Assert.assertEquals(30, segmentMetadata2.getLastChunkStartOffset());
+
+        // Bootstrap a new instance.
+        @Cleanup
+        val instance3 =  new TestInstance(testContext, 3);
+        instance3.bootstrap();
+        instance3.validate();
+        TestUtils.checkSegmentBounds(instance3.metadataStore, testSegmentName, 2, 60);
+        TestUtils.checkSegmentLayout(instance3.metadataStore, testSegmentName, new long[] { 10, 20, 30});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance3.metadataStore, testSegmentName);
+        val segmentMetadata3 = TestUtils.getSegmentMetadata(instance3.metadataStore, testSegmentName);
+        Assert.assertEquals("A", segmentMetadata3.getFirstChunk());
+        Assert.assertEquals("C", segmentMetadata3.getLastChunk());
+        Assert.assertEquals(0, segmentMetadata3.getFirstChunkStartOffset());
+        Assert.assertEquals(30, segmentMetadata3.getLastChunkStartOffset());
+        instance3.truncate(testSegmentName, 15);
+        instance3.append(testSegmentName, "D", 60, 100);
+
+        // Zombie Truncate
+        instance2.writeZombieRecord(SystemJournal.TruncationRecord.builder()
+                .offset(40)
+                .startOffset(30)
+                .segmentName(testSegmentName)
+                .firstChunkName("C")
+                .build());
+        instance2.writeZombieRecord(SystemJournal.ChunkAddedRecord.builder()
+                .offset(60)
+                .oldChunkName("C")
+                .newChunkName("X")
+                .segmentName(testSegmentName)
+                .build());
+        instance2.writeZombieRecord(SystemJournal.ChunkAddedRecord.builder()
+                .offset(100)
+                .oldChunkName("X")
+                .newChunkName("Y")
+                .segmentName(testSegmentName)
+                .build());
+
+        // Bootstrap a new instance.
+        @Cleanup
+        val instance4 =  new TestInstance(testContext, 4);
+        instance4.bootstrap();
+        TestUtils.checkSegmentBounds(instance4.metadataStore, testSegmentName, 15, 160);
+        TestUtils.checkSegmentLayout(instance4.metadataStore, testSegmentName, new long[] { 20, 30, 100});
+        TestUtils.checkChunksExistInStorage(testContext.chunkStorage, instance4.metadataStore, testSegmentName);
+        val segmentMetadata4 = TestUtils.getSegmentMetadata(instance4.metadataStore, testSegmentName);
+        Assert.assertEquals("B", segmentMetadata4.getFirstChunk());
+        Assert.assertEquals("D", segmentMetadata4.getLastChunk());
+        Assert.assertEquals(10, segmentMetadata4.getFirstChunkStartOffset());
+        Assert.assertEquals(60, segmentMetadata4.getLastChunkStartOffset());
+        // Keep
+        instance2.close();
+    }
+
+    /**
      * Represents a test method.
      */
     interface TestMethod {
@@ -893,6 +1119,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         SystemJournal systemJournal;
         SnapshotInfoStore snapshotInfoStore;
         long epoch;
+        boolean isZombie;
 
         TestInstance(TestContext testContext, long epoch) {
             this.testContext = testContext;
@@ -928,9 +1155,18 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         }
 
         /**
+         * Commit a zombie record.
+         */
+        void writeZombieRecord(SystemJournal.SystemJournalRecord record) throws Exception {
+            isZombie = true;
+            systemJournal.commitRecord(record).join();
+        }
+
+        /**
          * Append a chunk.
          */
         void append(String segmentName, String chunkName, int offset, int length) throws Exception {
+            Assert.assertFalse( "Attempt to use zombie instance", isZombie);
             append(segmentName, chunkName, offset, length, length);
         }
 
@@ -1021,6 +1257,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
          * Truncate.
          */
         synchronized void truncate(String segmentName, int offset) throws Exception {
+            Assert.assertFalse( "Attempt to use zombie instance", isZombie);
             val list = testContext.expectedChunks.get(segmentName);
             val segmentInfo = testContext.expectedSegments.get(segmentName);
 
@@ -1097,7 +1334,6 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
          * Validates the metadata against expected results.
          */
         void validate() throws Exception {
-            Assert.assertEquals(0, systemJournal.getCurrentFileIndex().get());
             for (val expectedSegmentInfo : testContext.expectedSegments.values()) {
                 // Check segment metadata.
                 val expectedChunkInfoList =  testContext.expectedChunks.get(expectedSegmentInfo.name);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalRecordsTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalRecordsTests.java
@@ -1,0 +1,425 @@
+/**
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
+import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
+import io.pravega.test.common.AssertExtensions;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class SystemJournalRecordsTests {
+
+    @Test
+    public void testChunkAddedRecordSerialization() throws Exception {
+        testSystemJournalRecordSerialization(SystemJournal.ChunkAddedRecord.builder()
+                .segmentName("segmentName")
+                .newChunkName("newChunkName")
+                .oldChunkName("oldChunkName")
+                .offset(1)
+                .build());
+
+        // With nullable values
+        testSystemJournalRecordSerialization(SystemJournal.ChunkAddedRecord.builder()
+                .segmentName("segmentName")
+                .newChunkName("newChunkName")
+                .oldChunkName(null)
+                .offset(1)
+                .build());
+    }
+
+    @Test
+    public void testTruncationRecordSerialization() throws Exception {
+        testSystemJournalRecordSerialization(SystemJournal.TruncationRecord.builder()
+                .segmentName("segmentName")
+                .offset(1)
+                .firstChunkName("firstChunkName")
+                .startOffset(2)
+                .build());
+    }
+
+    private void testSystemJournalRecordSerialization(SystemJournal.SystemJournalRecord original) throws Exception {
+        val serializer = new SystemJournal.SystemJournalRecord.SystemJournalRecordSerializer();
+        val bytes = serializer.serialize(original);
+        val obj = serializer.deserialize(bytes);
+        Assert.assertEquals(original, obj);
+    }
+
+    @Test
+    public void testSystemJournalRecordBatchSerialization() throws Exception {
+        ArrayList<SystemJournal.SystemJournalRecord> lst = new ArrayList<SystemJournal.SystemJournalRecord>();
+        testSystemJournalRecordBatchSerialization(
+                SystemJournal.SystemJournalRecordBatch.builder()
+                        .systemJournalRecords(lst)
+                        .build());
+
+        ArrayList<SystemJournal.SystemJournalRecord> lst2 = new ArrayList<SystemJournal.SystemJournalRecord>();
+        lst2.add(SystemJournal.ChunkAddedRecord.builder()
+                .segmentName("segmentName")
+                .newChunkName("newChunkName")
+                .oldChunkName("oldChunkName")
+                .offset(1)
+                .build());
+        lst2.add(SystemJournal.ChunkAddedRecord.builder()
+                .segmentName("segmentName")
+                .newChunkName("newChunkName")
+                .oldChunkName(null)
+                .offset(1)
+                .build());
+        lst2.add(SystemJournal.TruncationRecord.builder()
+                .segmentName("segmentName")
+                .offset(1)
+                .firstChunkName("firstChunkName")
+                .startOffset(2)
+                .build());
+        testSystemJournalRecordBatchSerialization(
+                SystemJournal.SystemJournalRecordBatch.builder()
+                        .systemJournalRecords(lst)
+                        .build());
+    }
+
+    private void testSystemJournalRecordBatchSerialization(SystemJournal.SystemJournalRecordBatch original) throws Exception {
+        val serializer = new SystemJournal.SystemJournalRecordBatch.SystemJournalRecordBatchSerializer();
+        val bytes = serializer.serialize(original);
+        val obj = serializer.deserialize(bytes);
+        Assert.assertEquals(original, obj);
+    }
+
+    @Test
+    public void testSnapshotRecordSerialization() throws Exception {
+
+        ArrayList<ChunkMetadata> list = new ArrayList<>();
+        list.add(ChunkMetadata.builder()
+                .name("name")
+                .nextChunk("nextChunk")
+                .length(1)
+                .status(2)
+                .build());
+        list.add(ChunkMetadata.builder()
+                .name("name")
+                .length(1)
+                .status(2)
+                .build());
+
+        testSegmentSnapshotRecordSerialization(
+                SystemJournal.SegmentSnapshotRecord.builder()
+                        .segmentMetadata(SegmentMetadata.builder()
+                                .name("name")
+                                .length(1)
+                                .chunkCount(2)
+                                .startOffset(3)
+                                .status(5)
+                                .maxRollinglength(6)
+                                .firstChunk("firstChunk")
+                                .lastChunk("lastChunk")
+                                .lastModified(7)
+                                .firstChunkStartOffset(8)
+                                .lastChunkStartOffset(9)
+                                .ownerEpoch(10)
+                                .build())
+                        .chunkMetadataCollection(list)
+                        .build());
+
+        testSegmentSnapshotRecordSerialization(
+                SystemJournal.SegmentSnapshotRecord.builder()
+                        .segmentMetadata(SegmentMetadata.builder()
+                                .name("name")
+                                .length(1)
+                                .chunkCount(2)
+                                .startOffset(3)
+                                .status(5)
+                                .maxRollinglength(6)
+                                .firstChunk(null)
+                                .lastChunk(null)
+                                .lastModified(7)
+                                .firstChunkStartOffset(8)
+                                .lastChunkStartOffset(9)
+                                .ownerEpoch(10)
+                                .build())
+                        .chunkMetadataCollection(list)
+                        .build());
+    }
+
+    private void testSegmentSnapshotRecordSerialization(SystemJournal.SegmentSnapshotRecord original) throws Exception {
+        val serializer = new SystemJournal.SegmentSnapshotRecord.Serializer();
+        val bytes = serializer.serialize(original);
+        val obj = serializer.deserialize(bytes);
+        Assert.assertEquals(original, obj);
+    }
+
+    @Test
+    public void testSystemSnapshotRecordSerialization() throws Exception {
+
+        ArrayList<ChunkMetadata> list1 = new ArrayList<>();
+        list1.add(ChunkMetadata.builder()
+                .name("name1")
+                .nextChunk("nextChunk1")
+                .length(1)
+                .status(2)
+                .build());
+        list1.add(ChunkMetadata.builder()
+                .name("name12")
+                .length(1)
+                .status(2)
+                .build());
+
+        ArrayList<ChunkMetadata> list2 = new ArrayList<>();
+        list2.add(ChunkMetadata.builder()
+                .name("name2")
+                .nextChunk("nextChunk2")
+                .length(1)
+                .status(3)
+                .build());
+        list2.add(ChunkMetadata.builder()
+                .name("name22")
+                .length(1)
+                .status(3)
+                .build());
+
+        ArrayList<SystemJournal.SegmentSnapshotRecord> segmentlist = new ArrayList<>();
+
+        segmentlist.add(
+                SystemJournal.SegmentSnapshotRecord.builder()
+                        .segmentMetadata(SegmentMetadata.builder()
+                                .name("name1")
+                                .length(1)
+                                .chunkCount(2)
+                                .startOffset(3)
+                                .status(5)
+                                .maxRollinglength(6)
+                                .firstChunk("firstChunk111")
+                                .lastChunk("lastChun111k")
+                                .lastModified(7)
+                                .firstChunkStartOffset(8)
+                                .lastChunkStartOffset(9)
+                                .ownerEpoch(10)
+                                .build())
+                        .chunkMetadataCollection(list1)
+                        .build());
+
+        segmentlist.add(
+                SystemJournal.SegmentSnapshotRecord.builder()
+                        .segmentMetadata(SegmentMetadata.builder()
+                                .name("name2")
+                                .length(1)
+                                .chunkCount(2)
+                                .startOffset(3)
+                                .status(5)
+                                .maxRollinglength(6)
+                                .firstChunk(null)
+                                .lastChunk(null)
+                                .lastModified(7)
+                                .firstChunkStartOffset(8)
+                                .lastChunkStartOffset(9)
+                                .ownerEpoch(10)
+                                .build())
+                        .chunkMetadataCollection(list2)
+                        .build());
+        val systemSnapshot = SystemJournal.SystemSnapshotRecord.builder()
+                .epoch(42)
+                .fileIndex(7)
+                .segmentSnapshotRecords(segmentlist)
+                .build();
+        testSystemSnapshotRecordSerialization(systemSnapshot);
+    }
+
+    private void testSystemSnapshotRecordSerialization(SystemJournal.SystemSnapshotRecord original) throws Exception {
+        val serializer = new SystemJournal.SystemSnapshotRecord.Serializer();
+        val bytes = serializer.serialize(original);
+        val obj = serializer.deserialize(bytes);
+        Assert.assertEquals(original, obj);
+    }
+
+    @Test
+    public void testValid() {
+        val valid = SystemJournal.SegmentSnapshotRecord.builder()
+                .segmentMetadata(
+                        SegmentMetadata.builder()
+                                .name("test")
+                                .chunkCount(4)
+                                .firstChunk("A")
+                                .firstChunkStartOffset(1)
+                                .startOffset(2)
+                                .lastChunk("D")
+                                .lastChunkStartOffset(10)
+                                .length(15)
+                                .build()
+                                .setActive(true)
+                                .setStorageSystemSegment(true)
+                )
+                .chunkMetadataCollection(Arrays.asList(
+                        ChunkMetadata.builder()
+                                .name("A")
+                                .length(2)
+                                .nextChunk("B")
+                                .build(),
+                        ChunkMetadata.builder()
+                                .name("B")
+                                .length(3)
+                                .nextChunk("C")
+                                .build(),
+                        ChunkMetadata.builder()
+                                .name("C")
+                                .length(4)
+                                .nextChunk("D")
+                                .build(),
+                        ChunkMetadata.builder()
+                                .name("D")
+                                .length(5)
+                                .nextChunk(null)
+                                .build()
+                ))
+                .build();
+        valid.checkInvariants();
+    }
+
+    @Test
+    public void testInvalidRecords() {
+        // Create mal formed data
+        SystemJournal.SegmentSnapshotRecord[] invalidDataList = new SystemJournal.SegmentSnapshotRecord[] {
+                // Not system segment
+                SystemJournal.SegmentSnapshotRecord.builder()
+                        .segmentMetadata(
+                                SegmentMetadata.builder()
+                                        .name("test")
+                                        .build()
+                                        .setActive(true)
+                        )
+                        .chunkMetadataCollection(Arrays.asList())
+                        .build(),
+                // Incorrect chunk count
+                SystemJournal.SegmentSnapshotRecord.builder()
+                        .segmentMetadata(
+                                SegmentMetadata.builder()
+                                        .name("test")
+                                        .firstChunk("A")
+                                        .lastChunk("A")
+                                        .chunkCount(1)
+                                        .build()
+                                        .setActive(true)
+                                        .setStorageSystemSegment(true)
+                        )
+                        .chunkMetadataCollection(Arrays.asList(
+                                ChunkMetadata.builder()
+                                        .name("A")
+                                        .length(2)
+                                        .nextChunk("B")
+                                        .build(),
+                                ChunkMetadata.builder()
+                                        .name("B")
+                                        .length(3)
+                                        .nextChunk(null)
+                                        .build()
+                        ))
+                        .build(),
+                // Incorrect chunk count.
+                SystemJournal.SegmentSnapshotRecord.builder()
+                        .segmentMetadata(
+                                SegmentMetadata.builder()
+                                        .name("test")
+                                        .firstChunk("A")
+                                        .lastChunk("A")
+                                        .chunkCount(1)
+                                        .build()
+                                        .setActive(true)
+                                        .setStorageSystemSegment(true)
+                        )
+                        .chunkMetadataCollection(Arrays.asList(
+                                ChunkMetadata.builder()
+                                        .name("A")
+                                        .length(2)
+                                        .nextChunk(null)
+                                        .build()
+                        ))
+                        .build(),
+                // Incorrect chunks
+                SystemJournal.SegmentSnapshotRecord.builder()
+                        .segmentMetadata(
+                                SegmentMetadata.builder()
+                                        .name("test")
+                                        .firstChunk("A")
+                                        .lastChunk("A")
+                                        .chunkCount(1)
+                                        .length(2)
+                                        .build()
+                                        .setActive(true)
+                                        .setStorageSystemSegment(true)
+                        )
+                        .chunkMetadataCollection(Arrays.asList(
+                                ChunkMetadata.builder()
+                                        .name("Z")
+                                        .length(2)
+                                        .nextChunk(null)
+                                        .build()
+                        ))
+                        .build(),
+                // Wrong last chunk pointer
+                SystemJournal.SegmentSnapshotRecord.builder()
+                        .segmentMetadata(
+                                SegmentMetadata.builder()
+                                        .name("test")
+                                        .firstChunk("A")
+                                        .lastChunk("A")
+                                        .chunkCount(1)
+                                        .length(2)
+                                        .build()
+                                        .setActive(true)
+                                        .setStorageSystemSegment(true)
+                        )
+                        .chunkMetadataCollection(Arrays.asList(
+                                ChunkMetadata.builder()
+                                        .name("A")
+                                        .length(2)
+                                        .nextChunk("Z")
+                                        .build()
+                        ))
+                        .build(),
+                // Incorrect
+                SystemJournal.SegmentSnapshotRecord.builder()
+                        .segmentMetadata(
+                                SegmentMetadata.builder()
+                                        .name("test")
+                                        .firstChunk("A")
+                                        .lastChunk("B")
+                                        .chunkCount(2)
+                                        .length(10)
+                                        .lastChunkStartOffset(6)
+                                        .build()
+                                        .setActive(true)
+                                        .setStorageSystemSegment(true)
+                        )
+                        .chunkMetadataCollection(Arrays.asList(
+                                ChunkMetadata.builder()
+                                        .name("A")
+                                        .length(5)
+                                        .nextChunk("B")
+                                        .build(),
+                                ChunkMetadata.builder()
+                                        .name("B")
+                                        .length(5)
+                                        .nextChunk(null)
+                                        .build()
+                        ))
+                        .build()
+        };
+
+        for (val invalidData: invalidDataList) {
+            AssertExtensions.assertThrows(invalidData.toString(),
+                    () -> invalidData.checkInvariants(),
+                    ex -> ex instanceof IllegalStateException);
+        }
+    }
+
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -14,9 +14,7 @@ import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.SegmentRollingPolicy;
-import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
 import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
-import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
 import io.pravega.segmentstore.storage.mocks.InMemorySnapshotInfoStore;
 import io.pravega.segmentstore.storage.mocks.InMemoryChunkStorage;
 import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
@@ -484,7 +482,6 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         Assert.assertEquals("Hello World", new String(out));
     }
 
-
     /**
      * Tests a scenario when there are multiple fail overs overs.
      * The test adds a few chunks to the system segments and then fails over.
@@ -498,16 +495,19 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         val containerId = 42;
         @Cleanup
         ChunkStorage chunkStorage = getChunkStorage();
-        testSimpleBootstrapWithMultipleFailovers(containerId, chunkStorage, null);
+        val policy = new SegmentRollingPolicy(100);
+        val config = getDefaultConfigBuilder(policy)
+                .selfCheckEnabled(true)
+                .build();
+
+        testSimpleBootstrapWithMultipleFailovers(containerId, chunkStorage, config, null);
     }
 
-    private void testSimpleBootstrapWithMultipleFailovers(int containerId, ChunkStorage chunkStorage, Consumer<Long> faultInjection) throws Exception {
+    private void testSimpleBootstrapWithMultipleFailovers(int containerId, ChunkStorage chunkStorage, ChunkedSegmentStorageConfig config, Consumer<Long> faultInjection) throws Exception {
         @Cleanup
         CleanupHelper cleanupHelper = new CleanupHelper();
         String systemSegmentName = SystemJournal.getChunkStorageSystemSegments(containerId)[0];
         long epoch = 0;
-        val policy = new SegmentRollingPolicy(100);
-        val config = getDefaultConfigBuilder(policy).build();
         val data = new InMemorySnapshotInfoStore();
         val snapshotInfoStore = new SnapshotInfoStore(containerId,
                 snapshotId -> data.setSnapshotId(containerId, snapshotId),
@@ -577,8 +577,13 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         val containerId = 42;
         @Cleanup
         ChunkStorage chunkStorage = getChunkStorage();
+        val policy = new SegmentRollingPolicy(100);
+        val config = getDefaultConfigBuilder(policy)
+                .selfCheckEnabled(true)
+                .build();
+
         try {
-            testSimpleBootstrapWithMultipleFailovers(containerId, chunkStorage, epoch -> {
+            testSimpleBootstrapWithMultipleFailovers(containerId, chunkStorage, config, epoch -> {
                 val snapShotFile = NameUtils.getSystemJournalSnapshotFileName(containerId, epoch, 1);
                 chunkStorage.delete(ChunkHandle.writeHandle(snapShotFile)).join();
             });
@@ -1063,7 +1068,6 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         TestUtils.checkSegmentLayout(metadataStoreAfterCrash2, systemSegmentName, policy.getMaxLength(), 10);
     }
 
-
     /**
      * Test simple chunk truncation.
      * We failover two times to test correct interaction between snapshot and system logs.
@@ -1124,7 +1128,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
                 metadataStoreAfterCrash,
                 ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
                 executorService());
-        SystemJournal systemJournalAfter = new SystemJournal(containerId, chunkStorage, metadataStoreAfterCrash, garbageCollector2, config, executorService() );
+        SystemJournal systemJournalAfter = new SystemJournal(containerId, chunkStorage, metadataStoreAfterCrash, garbageCollector2, config, executorService());
 
         systemJournalAfter.bootstrap(2, snapshotInfoStore).join();
 
@@ -1184,7 +1188,6 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
 
         TestUtils.checkSegmentBounds(metadataStoreAfterCrash3, systemSegmentName, 20, 20);
     }
-
 
     /**
      * Test concurrent writes to storage system segments by simulating concurrent writes.
@@ -1285,226 +1288,6 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         for (String systemSegment : segmentStorage.getSystemJournal().getSystemSegments()) {
             TestUtils.checkChunksExistInStorage(segmentStorage.getChunkStorage(), segmentStorage.getMetadataStore(), systemSegment);
         }
-    }
-
-    @Test
-    public void testChunkAddedRecordSerialization() throws Exception {
-        testSystemJournalRecordSerialization(SystemJournal.ChunkAddedRecord.builder()
-                .segmentName("segmentName")
-                .newChunkName("newChunkName")
-                .oldChunkName("oldChunkName")
-                .offset(1)
-                .build());
-
-        // With nullable values
-        testSystemJournalRecordSerialization(SystemJournal.ChunkAddedRecord.builder()
-                .segmentName("segmentName")
-                .newChunkName("newChunkName")
-                .oldChunkName(null)
-                .offset(1)
-                .build());
-    }
-
-    @Test
-    public void testTruncationRecordSerialization() throws Exception {
-        testSystemJournalRecordSerialization(SystemJournal.TruncationRecord.builder()
-                .segmentName("segmentName")
-                .offset(1)
-                .firstChunkName("firstChunkName")
-                .startOffset(2)
-                .build());
-    }
-
-    private void testSystemJournalRecordSerialization(SystemJournal.SystemJournalRecord original) throws Exception {
-        val serializer = new SystemJournal.SystemJournalRecord.SystemJournalRecordSerializer();
-        val bytes = serializer.serialize(original);
-        val obj = serializer.deserialize(bytes);
-        Assert.assertEquals(original, obj);
-    }
-
-    @Test
-    public void testSystemJournalRecordBatchSerialization() throws Exception {
-        ArrayList<SystemJournal.SystemJournalRecord> lst = new ArrayList<SystemJournal.SystemJournalRecord>();
-        testSystemJournalRecordBatchSerialization(
-                SystemJournal.SystemJournalRecordBatch.builder()
-                        .systemJournalRecords(lst)
-                        .build());
-
-        ArrayList<SystemJournal.SystemJournalRecord> lst2 = new ArrayList<SystemJournal.SystemJournalRecord>();
-        lst2.add(SystemJournal.ChunkAddedRecord.builder()
-                .segmentName("segmentName")
-                .newChunkName("newChunkName")
-                .oldChunkName("oldChunkName")
-                .offset(1)
-                .build());
-        lst2.add(SystemJournal.ChunkAddedRecord.builder()
-                .segmentName("segmentName")
-                .newChunkName("newChunkName")
-                .oldChunkName(null)
-                .offset(1)
-                .build());
-        lst2.add(SystemJournal.TruncationRecord.builder()
-                .segmentName("segmentName")
-                .offset(1)
-                .firstChunkName("firstChunkName")
-                .startOffset(2)
-                .build());
-        testSystemJournalRecordBatchSerialization(
-                SystemJournal.SystemJournalRecordBatch.builder()
-                        .systemJournalRecords(lst)
-                        .build());
-    }
-
-    private void testSystemJournalRecordBatchSerialization(SystemJournal.SystemJournalRecordBatch original) throws Exception {
-        val serializer = new SystemJournal.SystemJournalRecordBatch.SystemJournalRecordBatchSerializer();
-        val bytes = serializer.serialize(original);
-        val obj = serializer.deserialize(bytes);
-        Assert.assertEquals(original, obj);
-    }
-
-    @Test
-    public void testSnapshotRecordSerialization() throws Exception {
-
-        ArrayList<ChunkMetadata> list = new ArrayList<>();
-        list.add(ChunkMetadata.builder()
-                .name("name")
-                .nextChunk("nextChunk")
-                .length(1)
-                .status(2)
-                .build());
-        list.add(ChunkMetadata.builder()
-                .name("name")
-                .length(1)
-                .status(2)
-                .build());
-
-        testSegmentSnapshotRecordSerialization(
-                SystemJournal.SegmentSnapshotRecord.builder()
-                        .segmentMetadata(SegmentMetadata.builder()
-                                .name("name")
-                                .length(1)
-                                .chunkCount(2)
-                                .startOffset(3)
-                                .status(5)
-                                .maxRollinglength(6)
-                                .firstChunk("firstChunk")
-                                .lastChunk("lastChunk")
-                                .lastModified(7)
-                                .firstChunkStartOffset(8)
-                                .lastChunkStartOffset(9)
-                                .ownerEpoch(10)
-                                .build())
-                        .chunkMetadataCollection(list)
-                        .build());
-
-        testSegmentSnapshotRecordSerialization(
-                SystemJournal.SegmentSnapshotRecord.builder()
-                        .segmentMetadata(SegmentMetadata.builder()
-                                .name("name")
-                                .length(1)
-                                .chunkCount(2)
-                                .startOffset(3)
-                                .status(5)
-                                .maxRollinglength(6)
-                                .firstChunk(null)
-                                .lastChunk(null)
-                                .lastModified(7)
-                                .firstChunkStartOffset(8)
-                                .lastChunkStartOffset(9)
-                                .ownerEpoch(10)
-                                .build())
-                        .chunkMetadataCollection(list)
-                        .build());
-    }
-
-    private void testSegmentSnapshotRecordSerialization(SystemJournal.SegmentSnapshotRecord original) throws Exception {
-        val serializer = new SystemJournal.SegmentSnapshotRecord.Serializer();
-        val bytes = serializer.serialize(original);
-        val obj = serializer.deserialize(bytes);
-        Assert.assertEquals(original, obj);
-    }
-
-    @Test
-    public void testSystemSnapshotRecordSerialization() throws Exception {
-
-        ArrayList<ChunkMetadata> list1 = new ArrayList<>();
-        list1.add(ChunkMetadata.builder()
-                .name("name1")
-                .nextChunk("nextChunk1")
-                .length(1)
-                .status(2)
-                .build());
-        list1.add(ChunkMetadata.builder()
-                .name("name12")
-                .length(1)
-                .status(2)
-                .build());
-
-        ArrayList<ChunkMetadata> list2 = new ArrayList<>();
-        list2.add(ChunkMetadata.builder()
-                .name("name2")
-                .nextChunk("nextChunk2")
-                .length(1)
-                .status(3)
-                .build());
-        list2.add(ChunkMetadata.builder()
-                .name("name22")
-                .length(1)
-                .status(3)
-                .build());
-
-        ArrayList<SystemJournal.SegmentSnapshotRecord> segmentlist = new ArrayList<>();
-
-        segmentlist.add(
-                SystemJournal.SegmentSnapshotRecord.builder()
-                        .segmentMetadata(SegmentMetadata.builder()
-                                .name("name1")
-                                .length(1)
-                                .chunkCount(2)
-                                .startOffset(3)
-                                .status(5)
-                                .maxRollinglength(6)
-                                .firstChunk("firstChunk111")
-                                .lastChunk("lastChun111k")
-                                .lastModified(7)
-                                .firstChunkStartOffset(8)
-                                .lastChunkStartOffset(9)
-                                .ownerEpoch(10)
-                                .build())
-                        .chunkMetadataCollection(list1)
-                        .build());
-
-        segmentlist.add(
-                SystemJournal.SegmentSnapshotRecord.builder()
-                        .segmentMetadata(SegmentMetadata.builder()
-                                .name("name2")
-                                .length(1)
-                                .chunkCount(2)
-                                .startOffset(3)
-                                .status(5)
-                                .maxRollinglength(6)
-                                .firstChunk(null)
-                                .lastChunk(null)
-                                .lastModified(7)
-                                .firstChunkStartOffset(8)
-                                .lastChunkStartOffset(9)
-                                .ownerEpoch(10)
-                                .build())
-                        .chunkMetadataCollection(list2)
-                        .build());
-        val systemSnapshot = SystemJournal.SystemSnapshotRecord.builder()
-                .epoch(42)
-                .fileIndex(7)
-                .segmentSnapshotRecords(segmentlist)
-                .build();
-        testSystemSnapshotRecordSerialization(systemSnapshot);
-    }
-
-    private void testSystemSnapshotRecordSerialization(SystemJournal.SystemSnapshotRecord original) throws Exception {
-        val serializer = new SystemJournal.SystemSnapshotRecord.Serializer();
-        val bytes = serializer.serialize(original);
-        val obj = serializer.deserialize(bytes);
-        Assert.assertEquals(original, obj);
     }
 
     /**

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/TestUtils.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/TestUtils.java
@@ -95,7 +95,7 @@ public class TestUtils {
         // Assert
         Assert.assertNotNull(segmentMetadata.getFirstChunk());
         Assert.assertNotNull(segmentMetadata.getLastChunk());
-        long expectedLength = 0;
+        long expectedLength = segmentMetadata.getFirstChunkStartOffset();
         int i = 0;
         val chunks = getChunkList(metadataStore, segmentName);
         for (val chunk : chunks) {


### PR DESCRIPTION
Immediately after bootstrap, persist extra snapshot to journals and use it for identification/elimination of zombie journal records.

Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Cherry pick #6200 

**Purpose of the change**  
Cherry pick #6200 

**What the code does**  
Cherry pick #6200 

**How to verify it**  
Test should pass.
