### PR TITLE
improve user cli master

### DIFF
--- a/cli/user/README.md
+++ b/cli/user/README.md
@@ -98,7 +98,7 @@ All available commands:
 	stream create scoped-stream-names: Creates one or more Streams.
 	stream delete scoped-stream-names: Deletes one or more Streams.
 	stream list scope-name: Lists all Streams in a Scope.
-	stream read scoped-stream-name [group-similar] [timeout-in-seconds]: Reads all Events from a Stream and then tails the Stream.
+	stream read scoped-stream-name [group-similar] [max-list-items]: Reads all Events from a Stream and then tails the Stream until reach max-list-items.
 ```
 
 You can try out commands such as:

--- a/cli/user/src/main/java/io/pravega/cli/user/stream/StreamCommand.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/stream/StreamCommand.java
@@ -234,12 +234,12 @@ public abstract class StreamCommand extends Command {
             long maxListItems = getConfig().getMaxListItems();
             if (getCommandArgs().getArgs().size() == 3) {
                 group = getBooleanArg(1);
-                maxListItems = Long.parseLong(getArg(2)) * 1000;
+                maxListItems = Long.parseLong(getArg(2));
             } else if (getCommandArgs().getArgs().size() == 2) {
                 if (isBooleanArg(1)) {
                     group = getBooleanArg(1);
                 } else {
-                    maxListItems = getLongArg(1) * 1000;
+                    maxListItems = getLongArg(1);
                 }
             }
             final Aggregator aggregator = group ? new GroupedItems() : new SingleItem();


### PR DESCRIPTION
**Change log description**  
(2-3 concise points about the changes in this PR. When committing this PR, the committer is expected to copy the content of this section to the merge description box)
Use max-list-items instead of timeout seconds in stream event list command arguments for more handy list cli. In that way users can list events as many as they wish without set the config everytime in the same session.

**Purpose of the change**  
(_e.g._, Fixes #666, Closes #1234)
Use max-list-items instead of timeout seconds in stream event list command arguments.
**What the code does**  
(Detailed description of the code changes)
Replace timeout-in-seconds with max-list-items.
**How to verify it**  
(Optional: steps to verify that the changes are effective)
