### PR TITLE
Issue 6265:  Enforce junit version 4.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ allprojects {
             force "io.netty:netty-handler-proxy:" + nettyVersion
             force "io.netty:netty-transport-native-epoll:" + nettyVersion
             force "io.netty:netty-tcnative-boringssl-static:" + nettyBoringSSLVersion
-            force "junit:junit:4.12:" + junitVersion
+            force "junit:junit:" + junitVersion
             // Netty 4 uber jar
             exclude group: 'io.netty', module: 'netty-all'
             // Netty 3

--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,7 @@ allprojects {
             force "io.netty:netty-handler-proxy:" + nettyVersion
             force "io.netty:netty-transport-native-epoll:" + nettyVersion
             force "io.netty:netty-tcnative-boringssl-static:" + nettyBoringSSLVersion
+            force "junit:junit:4.12:" + junitVersion
             // Netty 4 uber jar
             exclude group: 'io.netty', module: 'netty-all'
             // Netty 3


### PR DESCRIPTION
**Change log description**  
Enforce junit version 4.12

**Purpose of the change**  
Fixes #6265 .

**What the code does**  
Enforce junit version to 4.12.

A recent upgrade of fasterxml.jackson caused an upgrade of junit dependency to 4.13.1. This causes multiple test failures.

```
+--- com.fasterxml.jackson.core:jackson-databind:2.10.5.1 -> 2.12.4
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.12.4
|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.12.4
|    |    |         +--- junit:junit:4.13.1 (c)
```


**How to verify it**  
All the existing tests hould pass reliably.
