### PR TITLE
Issue 6204: make InProcPravegaCluster listen on all IPv4 interfaces

### DIFF
--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -306,7 +306,7 @@ public class InProcPravegaCluster implements AutoCloseable {
                         .with(ServiceConfig.REST_KEYSTORE_PASSWORD_FILE, this.keyPasswordFile)
                         .with(ServiceConfig.CERT_FILE, this.certFile)
                         .with(ServiceConfig.ENABLE_TLS_RELOAD, this.enableTlsReload)
-                        .with(ServiceConfig.LISTENING_IP_ADDRESS, LOCALHOST)
+                        .with(ServiceConfig.LISTENING_IP_ADDRESS, "0.0.0.0")
                         .with(ServiceConfig.PUBLISHED_IP_ADDRESS, LOCALHOST)
                         .with(ServiceConfig.CACHE_POLICY_MAX_TIME, 60)
                         .with(ServiceConfig.CACHE_POLICY_MAX_SIZE, 128 * 1024 * 1024L)


### PR DESCRIPTION
**Change log description**  
Make InProcPravegaCluster listen on all IPv4 interfaces instead of just localhost, so that Docker can redirect traffic to segment store.

**Purpose of the change**  
Fixes #6204

**What the code does**  
Allows segment store to listen on all IPv4 interfaces.

**How to verify it**  
Start standalone via docker as according to: https://github.com/pravega/pravega/blob/master/documentation/src/docs/deployment/run-local.md#from-docker-image
and confirm that you are able to write and read to/from a stream.