### PR TITLE
Issue 6278: Add missing jq tool

### DIFF
--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -15,7 +15,14 @@
 #
 FROM adoptopenjdk/openjdk11:jre-11.0.11_9-alpine
 
-RUN apk --update --no-cache add curl python3 && ln -sf python3 /usr/bin/python
+RUN apk --update --no-cache add \
+    #used in readiness and liveness probes
+    curl \
+    #used in wait_for function
+    python3 \
+    #used in init_kubernetes
+    jq \
+    && ln -sf python3 /usr/bin/python
 
 EXPOSE 9090 9091 10000 12345
 

--- a/docker/pravega/scripts/init_kubernetes.sh
+++ b/docker/pravega/scripts/init_kubernetes.sh
@@ -55,7 +55,7 @@ init_kubernetes() {
         export PUBLISHED_PORT=""
         local service=$( k8 "${ns}" "services" "${podname}" .kind )
 
-        if [[  "$service" != "Service" ]];
+        if [[  "${service}" != "Service" ]];
         then 
             echo "Failed to get External Service. Exiting..."
             exit 1     


### PR DESCRIPTION
Signed-off-by: Igor Medvedev <medvedevigorek@gmail.com>

**Change log description**  
Added installation of `jq` tool 

**Purpose of the change**  
Fixes #6278 

**What the code does**  
Modified Pravega Dockerfile to include installation of `jq` tool on top of the base image 

**How to verify it**  
Run the docker image in K8s environment and have External Access enabled 
