### PR TITLE
Issue 6129: Bookkeeper upgrade causes API mismatch from its transitive dependencies in pravega-standalone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -458,8 +458,6 @@ project('segmentstore:storage:impl') {
         testCompile project(':test:testcommon')
         testCompile project(path:':segmentstore:storage', configuration:'testRuntime')
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
-        testCompile group: 'io.dropwizard.metrics', name: 'metrics-core', version: dropWizardVersion
-        testCompile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyJavaVersion
     }
     javadoc {
         dependsOn delombok

--- a/build.gradle
+++ b/build.gradle
@@ -458,6 +458,8 @@ project('segmentstore:storage:impl') {
         testCompile project(':test:testcommon')
         testCompile project(path:':segmentstore:storage', configuration:'testRuntime')
         testCompile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
+        testCompile group: 'io.dropwizard.metrics', name: 'metrics-core', version: dropWizardVersion
+        testCompile group: 'org.xerial.snappy', name: 'snappy-java', version: snappyJavaVersion
     }
     javadoc {
         dependsOn delombok

--- a/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketManager.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
+@SuppressWarnings("deprecation")
 @Slf4j
 public class ZooKeeperBucketManager extends BucketManager {
     private final ZookeeperBucketStore bucketStore;

--- a/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketService.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketService.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
+@SuppressWarnings("deprecation")
 @Slf4j
 public class ZooKeeperBucketService extends BucketService {
     private final ZookeeperBucketStore bucketStore;

--- a/controller/src/main/java/io/pravega/controller/store/ZKStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/ZKStoreHelper.java
@@ -40,6 +40,7 @@ import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 
+@SuppressWarnings("deprecation")
 @Slf4j
 public class ZKStoreHelper {
     @Getter(AccessLevel.PUBLIC)

--- a/controller/src/main/java/io/pravega/controller/store/host/ZKHostStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/ZKHostStore.java
@@ -38,6 +38,7 @@ import javax.annotation.concurrent.GuardedBy;
 /**
  * Zookeeper based implementation of the HostControllerStore.
  */
+@SuppressWarnings("deprecation")
 @Slf4j
 public class ZKHostStore implements HostControllerStore {
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKGarbageCollector.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKGarbageCollector.java
@@ -50,6 +50,7 @@ import org.apache.curator.framework.recipes.cache.NodeCacheListener;
  * The current batch is identified by a znode. All controller instances register a watch on this znode. And whenever batch
  * is updated, all watchers receive the latest update.
  */
+@SuppressWarnings("deprecation")
 @Slf4j
 class ZKGarbageCollector extends AbstractService {
     private static final String GC_ROOT = "/garbagecollection/%s";

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZookeeperBucketStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZookeeperBucketStore.java
@@ -34,6 +34,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("deprecation")
 @Slf4j
 public class ZookeeperBucketStore implements BucketStore {
     private static final String ROOT_PATH = "/";

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,8 +22,8 @@ org.gradle.jvmargs=-Xms1g
 #3rd party Versions
 apacheCommonsCsvVersion=1.5
 apacheCommonsCompressVersion=1.21
-apacheCuratorVersion=4.0.1
-apacheZookeeperVersion=3.5.9
+apacheCuratorVersion=4.3.0
+apacheZookeeperVersion=3.6.3
 awsSdkVersion=2.17.43
 checkstyleToolVersion=8.23
 bookKeeperVersion=4.14.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,6 +55,7 @@ junitVersion=4.12
 lombokVersion=1.18.12
 marathonClientVersion=0.6.2
 micrometerVersion=1.2.0
+dropWizardVersion=4.2.3
 mockitoVersion=3.3.3
 jacocoVersion=0.8.5
 nettyVersion=4.1.65.Final
@@ -68,6 +69,7 @@ gradleGitPluginVersion=4.1.0
 k8ClientVersion=8.0.0
 jjwtVersion=0.9.1
 bouncyCastleVersion=1.69
+snappyJavaVersion=1.1.8.4
 
 # Version and base tags can be overridden at build time
 pravegaVersion=0.11.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.jvmargs=-Xms1g
 #3rd party Versions
 apacheCommonsCsvVersion=1.5
 apacheCommonsCompressVersion=1.21
-apacheCuratorVersion=4.3.0
+apacheCuratorVersion=5.2.0
 apacheZookeeperVersion=3.6.3
 awsSdkVersion=2.17.43
 checkstyleToolVersion=8.23

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,6 @@ junitVersion=4.12
 lombokVersion=1.18.12
 marathonClientVersion=0.6.2
 micrometerVersion=1.2.0
-dropWizardVersion=4.2.3
 mockitoVersion=3.3.3
 jacocoVersion=0.8.5
 nettyVersion=4.1.65.Final
@@ -69,7 +68,6 @@ gradleGitPluginVersion=4.1.0
 k8ClientVersion=8.0.0
 jjwtVersion=0.9.1
 bouncyCastleVersion=1.69
-snappyJavaVersion=1.1.8.4
 
 # Version and base tags can be overridden at build time
 pravegaVersion=0.11.0-SNAPSHOT

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
@@ -58,6 +58,7 @@ import org.apache.curator.utils.ZKPaths;
  * and starts or stops appropriate segment containers locally. Any start failures are periodically retried until
  * the desired ownership state is achieved.
  */
+@SuppressWarnings("deprecation")
 @Slf4j
 public class ZKSegmentContainerMonitor implements AutoCloseable {
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
@@ -47,6 +47,7 @@ import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.LocalBookKeeper;
 import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.server.NettyServerCnxnFactory;
+import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
@@ -109,7 +110,7 @@ public class ZooKeeperServiceRunner implements AutoCloseable {
         this.serverFactory.set(NettyServerCnxnFactory.createFactory());
         val address = LOOPBACK_ADDRESS + ":" + this.zkPort;
         log.info("Starting Zookeeper server at " + address + " ...");
-        this.serverFactory.get().configure(new InetSocketAddress(LOOPBACK_ADDRESS, this.zkPort), 1000, secureZK);
+        this.serverFactory.get().configure(new InetSocketAddress(LOOPBACK_ADDRESS, this.zkPort), 1000, 1000, secureZK);
         this.serverFactory.get().startup(s);
 
         if (!waitForServerUp(this.zkPort, this.secureZK, this.keyStore, this.keyStorePasswordPath, this.trustStore,
@@ -122,7 +123,7 @@ public class ZooKeeperServiceRunner implements AutoCloseable {
         try {
             ServerCnxnFactory sf = this.serverFactory.getAndSet(null);
             if (sf != null) {
-                sf.closeAll();
+                sf.closeAll(ServerCnxn.DisconnectReason.CLOSE_ALL_CONNECTIONS_FORCED);
                 sf.shutdown();
             }
         } catch (Throwable e) {

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/zkImpl/ClusterZKImpl.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/zkImpl/ClusterZKImpl.java
@@ -55,6 +55,7 @@ import static io.pravega.common.cluster.ClusterListener.EventType.HOST_REMOVED;
  * - Ephemeral Node is valid until a session timeout, default session timeout is 60 seconds.
  * System property "curator-default-session-timeout" can be used to change it.
  */
+@SuppressWarnings("deprecation")
 @Slf4j
 public class ClusterZKImpl implements Cluster {
 


### PR DESCRIPTION
**Change log description**  
Upgraded Zookeeper (3.6.3) and Curator (4.3.0) dependencies.

**Purpose of the change**  
Fixes #6129.

**What the code does**  
Upgrades Zookeeper (3.6.3) dependency to the same major version as Bookkeeper 4.14. Adapted a couple of calls in `ZooKeeperServiceRunner` to the new API.
Upgraded Curator (4.3.0) version as well.

**How to verify it**  
All tests should be passing as before.