### PR TITLE
Issue 6272: Removing JAVA_HOME from entrypoint.sh and adding it to Dockerfile

### DIFF
--- a/docker/bookkeeper/Dockerfile
+++ b/docker/bookkeeper/Dockerfile
@@ -27,6 +27,7 @@ FROM apache/bookkeeper:4.14.1
 
 ARG BK_VERSION=4.14.1
 ARG DISTRO_NAME=bookkeeper-all-${BK_VERSION}-bin
+ENV JAVA_HOME=/usr/lib/jvm/java-11
 
 RUN set -x \
     && yum install -y iproute wget \

--- a/docker/bookkeeper/entrypoint.sh
+++ b/docker/bookkeeper/entrypoint.sh
@@ -42,7 +42,6 @@ BOOKKEEPER=${BINDIR}/bookkeeper
 SCRIPTS_DIR=${BK_HOME}/scripts
 
 export PATH=$PATH:/opt/bookkeeper/bin
-export JAVA_HOME=/usr/lib/jvm/java-11
 export BK_zkLedgersRootPath=${BK_LEDGERS_PATH}
 export BOOKIE_PORT=${BOOKIE_PORT}
 export SERVICE_PORT=${BOOKIE_PORT}


### PR DESCRIPTION
**Change log description**  
Removing JAVA_HOME from entrypoint.sh and adding it to Dockerfile, so that bookkeeper OSS and branch builds can use different java runtime.
Previously thought of bundling this change with another issue, but as it is taking time to review it committing this separately.

**Purpose of the change**  
Fixes #6272 

**What the code does**  
sets JAVA_HOME

**How to verify it**  
We should be able to substitute bookkeeper image (either bookkeeper OSS or branch build)
