### PR TITLE
Issue : EventStreamWriter.flush() should throw RetriesExhaustedException in presense of connectivity failures consistently.

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentOutputStreamImpl.java
@@ -211,7 +211,7 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                 }
                 log.info("Handling exception {} for connection {} on writer {}. SetupCompleted: {}, Closed: {}",
                          throwable, connection, writerId, connectionSetupCompleted == null ? null : connectionSetupCompleted.isDone(), closed);
-                if (exception == null) {
+                if (exception == null || throwable instanceof RetriesExhaustedException) {
                     exception = throwable;
                 }
                 connection = null;
@@ -587,6 +587,8 @@ class SegmentOutputStreamImpl implements SegmentOutputStream {
                 throw new SegmentSealedException(segmentName + " sealed for writer " + writerId);
             }
 
+        } else if (state.exception instanceof RetriesExhaustedException) {
+            throw Exceptions.sneakyThrow(state.exception);
         }
     }
 

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentOutputStreamTest.java
@@ -248,7 +248,6 @@ public class SegmentOutputStreamTest extends LeakDetectorTestSuite {
         ClientConnection connection = mock(ClientConnection.class);
         InOrder verify = inOrder(connection);
         cf.provideConnection(uri, connection);
-        @Cleanup
         SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
                 retryConfig, DelegationTokenProviderFactory.createWithEmptyToken());
         output.reconnect();
@@ -271,6 +270,8 @@ public class SegmentOutputStreamTest extends LeakDetectorTestSuite {
         AssertExtensions.assertThrows(RetriesExhaustedException.class, () -> Futures.getThrowingException(output.getConnection()));
         verify.verify(connection).close();
         verifyNoMoreInteractions(connection);
+        // Verify that a close on the SegmentOutputStream does throw a RetriesExhaustedException.
+        AssertExtensions.assertThrows(RetriesExhaustedException.class, output::close);
     }
 
     @Test(timeout = 10000)
@@ -336,7 +337,6 @@ public class SegmentOutputStreamTest extends LeakDetectorTestSuite {
         MockController controller = new MockController(uri.getEndpoint(), uri.getPort(), cf, true);
         ClientConnection connection = mock(ClientConnection.class);
         cf.provideConnection(uri, connection);
-        @Cleanup
         SegmentOutputStreamImpl output = new SegmentOutputStreamImpl(SEGMENT, true, controller, cf, cid, segmentSealedCallback,
                 retryConfig, DelegationTokenProviderFactory.createWithEmptyToken());
         output.reconnect();
@@ -364,6 +364,8 @@ public class SegmentOutputStreamTest extends LeakDetectorTestSuite {
         AssertExtensions.assertThrows(RetriesExhaustedException.class, () -> Futures.getThrowingException(output.getConnection()));
         // Verify that the inflight event future is completed exceptionally.
         AssertExtensions.assertThrows(RetriesExhaustedException.class, () -> Futures.getThrowingException(acked));
+        // Verify that a close on the SegmentOutputStream does throw a RetriesExhaustedException.
+        AssertExtensions.assertThrows(RetriesExhaustedException.class, output::close);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
**Change log description**  
Ensure EventStreamWriter.flush() throws RetriesExhaustedException incase of all retries to establish connection fails.

**Purpose of the change**  
Fixes #

**What the code does**  
Ensure the writer checks the connectivity state even in the case of zero inflight events.

**How to verify it**  
All the existing and newly added tests should pass.
