### PR TITLE
Issue 6294: Need for setting memory limits in Kubernetes system test pods

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -224,7 +224,7 @@ public abstract class AbstractService implements Service {
     // Removal of the JVM option 'UseCGroupMemoryLimitForHeap' is required with JVM environments >= 10. This option
     // is supplied by default by the operators. We cannot 'deactivate' it using the XX:- counterpart as it is unrecognized.
     private String[] getSegmentStoreJVMOptions() {
-        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:MaxDirectMemorySize=5Gi", "-Xmx1024m"};
+        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:MaxDirectMemorySize=5g", "-Xmx1024m"};
     }
 
     private String[] getControllerJVMOptions() {

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -130,8 +130,8 @@ public abstract class AbstractService implements Service {
                 .put("segmentStoreReplicas", segmentStoreCount)
                 .put("debugLogging", true)
                 .put("cacheVolumeClaimTemplate", pravegaPersistentVolumeSpec)
-                .put("controllerResources", getResources("2000m", "3Gi", "1000m", "1Gi"))
-                .put("segmentStoreResources", getResources("2000m", "5Gi", "1000m", "3Gi"))
+                .put("controllerResources", getResources("2000m", "2Gi", "1000m", "2Gi"))
+                .put("segmentStoreResources", getResources("2000m", "6Gi", "1000m", "6Gi"))
                 .put("options", props)
                 .put("image", pravegaImgSpec)
                 .put("longtermStorage", tier2Spec())
@@ -224,15 +224,15 @@ public abstract class AbstractService implements Service {
     // Removal of the JVM option 'UseCGroupMemoryLimitForHeap' is required with JVM environments >= 10. This option
     // is supplied by default by the operators. We cannot 'deactivate' it using the XX:- counterpart as it is unrecognized.
     private String[] getSegmentStoreJVMOptions() {
-        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions"};
+        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:MaxDirectMemorySize=5Gi", "-Xmx1024m"};
     }
 
     private String[] getControllerJVMOptions() {
-        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions"};
+        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions", "-Xmx1024m"};
     }
 
     private String[] getBookkeeperMemoryOptions() {
-        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions"};
+        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions", "-Xmx1024m"};
     }
 
 


### PR DESCRIPTION
**Change log description**  
Added memory limits for JVM heap size and Direct Memory in Kubernetes system test pods.

**Purpose of the change**  
Fixes #6294.

**What the code does**  
Sets some reasonable memory limits to pods, specially to Segment Store pods which could go OOM in some situations as no heap or direct memory limits are set. Specifically, the Segment Store defines a 4GB cache size by default and 5GB of direct memory are allocated. The pod size is 6GB and the JVM heap size is set to 1GB. Given the load in our system tests, this should me more than sufficient.

**How to verify it**  
Have not found OOM issues with this change.