### PR TITLE
Issue 6306 : SLTS - avoid deadlock in truncate

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
@@ -179,6 +179,7 @@ class ConcatOperation implements Callable<CompletableFuture<Void>> {
                                 targetSegmentMetadata.setChunkCount(targetSegmentMetadata.getChunkCount() + sourceSegmentMetadata.getChunkCount());
 
                                 // Delete read index block entries for source.
+                                // To avoid possibility of unintentional deadlock, skip this step for storage system segments.
                                 if (!sourceSegmentMetadata.isStorageSystemSegment()) {
                                     chunkedSegmentStorage.deleteBlockIndexEntriesForChunk(txn, sourceSegment, sourceSegmentMetadata.getStartOffset(), sourceSegmentMetadata.getLength());
                                 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
@@ -179,8 +179,9 @@ class ConcatOperation implements Callable<CompletableFuture<Void>> {
                                 targetSegmentMetadata.setChunkCount(targetSegmentMetadata.getChunkCount() + sourceSegmentMetadata.getChunkCount());
 
                                 // Delete read index block entries for source.
-                                chunkedSegmentStorage.deleteBlockIndexEntriesForChunk(txn, sourceSegment, sourceSegmentMetadata.getStartOffset(), sourceSegmentMetadata.getLength());
-
+                                if (!sourceSegmentMetadata.isStorageSystemSegment()) {
+                                    chunkedSegmentStorage.deleteBlockIndexEntriesForChunk(txn, sourceSegment, sourceSegmentMetadata.getStartOffset(), sourceSegmentMetadata.getLength());
+                                }
                                 txn.update(targetSegmentMetadata);
                                 txn.delete(sourceSegment);
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -783,7 +783,7 @@ public class SystemJournal {
                 executor)
                 .handleAsync((v, e) -> {
                     // If read is not done and we have exception then throw.
-                    if ((!supressExceptionWarning && shouldBreak.get()) || (!isReadDone.get() && lastException.get() != null)) {
+                    if (shouldBreak.get() || (!isReadDone.get() && lastException.get() != null)) {
                         throw new CompletionException(lastException.get());
                     }
                     return v;

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -749,7 +749,7 @@ public class SystemJournal {
     /**
      * Read contents from file.
      */
-    private CompletableFuture<byte[]> getContents(String chunkPath, boolean shouldIgnore) {
+    private CompletableFuture<byte[]> getContents(String chunkPath, boolean supressExceptionWarning) {
         val isReadDone = new AtomicBoolean();
         val shouldBreak = new AtomicBoolean();
         val attempt = new AtomicInteger();
@@ -768,7 +768,7 @@ public class SystemJournal {
                                 boolean shouldLog = true;
                                 if (!shouldRetry(ex)) {
                                     shouldBreak.set(true);
-                                    shouldLog = shouldIgnore;
+                                    shouldLog = !supressExceptionWarning;
                                 }
                                 if (shouldLog) {
                                     log.warn("SystemJournal[{}] Error while reading journal {}. Attempt#{}", containerId, chunkPath, attempt.get(), lastException.get());
@@ -783,7 +783,7 @@ public class SystemJournal {
                 executor)
                 .handleAsync((v, e) -> {
                     // If read is not done and we have exception then throw.
-                    if ((!shouldIgnore && shouldBreak.get()) || (!isReadDone.get() && lastException.get() != null)) {
+                    if ((!supressExceptionWarning && shouldBreak.get()) || (!isReadDone.get() && lastException.get() != null)) {
                         throw new CompletionException(lastException.get());
                     }
                     return v;

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -743,6 +743,13 @@ public class SystemJournal {
      * Read contents from file.
      */
     private CompletableFuture<byte[]> getContents(String chunkPath) {
+        return getContents(chunkPath, false);
+    }
+
+    /**
+     * Read contents from file.
+     */
+    private CompletableFuture<byte[]> getContents(String chunkPath, boolean shouldIgnore) {
         val isReadDone = new AtomicBoolean();
         val shouldBreak = new AtomicBoolean();
         val attempt = new AtomicInteger();
@@ -757,10 +764,14 @@ public class SystemJournal {
                             if (e != null) {
                                 // record the exception
                                 lastException.set(e);
-                                log.warn("SystemJournal[{}] Error while reading journal {}. Attempt#{}", containerId, chunkPath, attempt.get(), lastException.get());
                                 val ex = Exceptions.unwrap(e);
+                                boolean shouldLog = true;
                                 if (!shouldRetry(ex)) {
                                     shouldBreak.set(true);
+                                    shouldLog = shouldIgnore;
+                                }
+                                if (shouldLog) {
+                                    log.warn("SystemJournal[{}] Error while reading journal {}. Attempt#{}", containerId, chunkPath, attempt.get(), lastException.get());
                                 }
                                 return null;
                             } else {
@@ -772,7 +783,7 @@ public class SystemJournal {
                 executor)
                 .handleAsync((v, e) -> {
                     // If read is not done and we have exception then throw.
-                    if (shouldBreak.get() || (!isReadDone.get() && lastException.get() != null)) {
+                    if ((!shouldIgnore && shouldBreak.get()) || (!isReadDone.get() && lastException.get() != null)) {
                         throw new CompletionException(lastException.get());
                     }
                     return v;
@@ -852,7 +863,7 @@ public class SystemJournal {
                             () -> !isScanDone.get(),
                             () -> {
                                 val systemLogName = getSystemJournalChunkName(containerId, epochToRecover.get(), fileIndexToRecover.get());
-                                return getContents(systemLogName)
+                                return getContents(systemLogName, true)
                                         .thenApplyAsync(contents -> {
                                             // We successfully read the contents.
                                             journalsProcessed.add(systemLogName);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
@@ -83,6 +83,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
 
                             if (segmentMetadata.getStartOffset() >= offset) {
                                 // Nothing to do
+                                logEnd();
                                 return CompletableFuture.completedFuture(null);
                             }
                             val oldChunkCount = segmentMetadata.getChunkCount();
@@ -113,7 +114,9 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
                                                 }
 
                                                 // Remove read index block entries.
-                                                chunkedSegmentStorage.deleteBlockIndexEntriesForChunk(txn, streamSegmentName, oldStartOffset, segmentMetadata.getStartOffset());
+                                                if (!segmentMetadata.isStorageSystemSegment()) {
+                                                    chunkedSegmentStorage.deleteBlockIndexEntriesForChunk(txn, streamSegmentName, oldStartOffset, segmentMetadata.getStartOffset());
+                                                }
 
                                                 // Collect garbage.
                                                 return chunkedSegmentStorage.getGarbageCollector().addChunksToGarbage(txn.getVersion(), chunksToDelete)

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
@@ -114,6 +114,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
                                                 }
 
                                                 // Remove read index block entries.
+                                                // To avoid possibility of unintentional deadlock, skip this step for storage system segments.
                                                 if (!segmentMetadata.isStorageSystemSegment()) {
                                                     chunkedSegmentStorage.deleteBlockIndexEntriesForChunk(txn, streamSegmentName, oldStartOffset, segmentMetadata.getStartOffset());
                                                 }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -72,7 +72,12 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
     }
 
     protected ChunkMetadataStore getMetadataStore() throws Exception {
-        return new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
+        val metadataStore = new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
+        metadataStore.setReadCallback( transactionData -> {
+            Assert.assertFalse("Attempt to read pinned metadata from store", transactionData.getKey().contains("_system/containers"));
+            return CompletableFuture.completedFuture(null);
+        });
+        return metadataStore;
     }
 
     protected ChunkStorage getChunkStorage() throws Exception {


### PR DESCRIPTION
**Change log description**  
Issue 6306 : SLTS - avoid deadlock in truncate on system segments and improve logs.

**Purpose of the change**  
Fixes #6306 and #6297

**What the code does**  

- In case of system segments do not attempt to delete block read index entries.
- Add debug logs for openRead, openWrite and getStreamSegmentInfo methods.
- reduce log noise in system journals

**How to verify it**  
Tests must pass
