### PR TITLE
Issue 6314: ContainerEventProcessor close method may exhaust threads if executed in bursts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,7 @@ jjwtVersion=0.9.1
 bouncyCastleVersion=1.69
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.10.0-SNAPSHOT
+pravegaVersion=0.11.0-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -329,14 +329,14 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
         //region AutoCloseable implementation
 
         /**
-         * This method stop the service (superclass), auto-unregisters from the existing set of active
+         * This method stops the service (superclass), auto-unregisters from the existing set of active
          * {@link EventProcessor} instances (via onClose callback), and closes the metrics.
          */
         @Override
         public void close() {
             if (!this.closed.getAndSet(true)) {
                 log.info("{}: Closing EventProcessor.", this.traceObjectId);
-                super.close();
+                super.stopAsync();
                 this.metrics.close();
                 this.onClose.run();
             }
@@ -372,6 +372,7 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
                            } else {
                                log.info("{}: Terminated.", this.traceObjectId);
                            }
+                           System.err.println("Exiting");
                            return null;
                        });
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -22,6 +22,7 @@ import io.pravega.common.ObjectBuilder;
 import io.pravega.common.Timer;
 import io.pravega.common.concurrent.AbstractThreadPoolService;
 import io.pravega.common.concurrent.Futures;
+import io.pravega.common.concurrent.Services;
 import io.pravega.common.io.BoundedInputStream;
 import io.pravega.common.io.serialization.RevisionDataInput;
 import io.pravega.common.io.serialization.RevisionDataOutput;
@@ -336,7 +337,10 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
         public void close() {
             if (!this.closed.getAndSet(true)) {
                 log.info("{}: Closing EventProcessor.", this.traceObjectId);
-                super.stopAsync();
+                Services.onStop(super.stopAsync(),
+                        () -> log.info("{}: EventProcessor service shutdown complete.", this.traceObjectId),
+                        ex -> log.warn("{}: Problem shutting down EventProcessor service.", this.traceObjectId, ex),
+                        this.executor);
                 this.metrics.close();
                 this.onClose.run();
             }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -339,16 +339,21 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
                 log.info("{}: Closing EventProcessor.", this.traceObjectId);
                 Services.onStop(super.stopAsync(),
                         () -> log.info("{}: EventProcessor service shutdown complete.", this.traceObjectId),
-                        ex -> log.warn("{}: Problem shutting down EventProcessor service.", this.traceObjectId, ex),
+                        this::failureCallback,
                         this.executor);
                 this.metrics.close();
                 this.onClose.run();
             }
         }
 
+        @VisibleForTesting
+        void failureCallback(Throwable ex) {
+            log.warn("{}: Problem shutting down EventProcessor service.", this.traceObjectId, ex);
+        }
+
         //endregion
 
-        //region Runnable implementation
+        //region AbstractThreadPoolService implementation
 
         @Override
         protected Duration getShutdownTimeout() {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -372,7 +372,6 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
                            } else {
                                log.info("{}: Terminated.", this.traceObjectId);
                            }
-                           System.err.println("Exiting");
                            return null;
                        });
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -2446,6 +2446,8 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
                 .get(TIMEOUT_FUTURE.toSeconds(), TimeUnit.SECONDS));
         // Close the processor and unregister it.
         processor.close();
+        // Make sure that EventProcessor eventually terminates.
+        ((ContainerEventProcessorImpl.EventProcessorImpl) processor).awaitTerminated();
 
         // Now, re-create the Event Processor with a handler to consume the events.
         ContainerEventProcessor.EventProcessorConfig eventProcessorConfig =

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -2388,7 +2388,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
      * @throws Exception
      */
     @Test(timeout = 10000)
-    public void testEventProcessorMultiplePConsumers() throws Exception {
+    public void testEventProcessorMultipleConsumers() throws Exception {
         @Cleanup
         TestContext context = createContext();
         val container = (StreamSegmentContainer) context.container;
@@ -2468,6 +2468,12 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
         // Wait for all items to be processed.
         AssertExtensions.assertEventuallyEquals(true, () -> processorResults.size() == allEventsToProcess, 10000);
         Assert.assertArrayEquals(processorResults.toArray(), IntStream.iterate(0, v -> v + 1).limit(allEventsToProcess).boxed().toArray());
+        // Just check failure callback.
+        ((ContainerEventProcessorImpl.EventProcessorImpl) processor).failureCallback(new IntentionalException());
+        // Close the processor and unregister it.
+        processor.close();
+        // Make sure that EventProcessor eventually terminates.
+        ((ContainerEventProcessorImpl.EventProcessorImpl) processor).awaitTerminated();
     }
 
     /**


### PR DESCRIPTION
**Change log description**  
Replace call to `super.close()` by `super.stopAsync()` in `EventProcessorImpl.close()` method to avoid locking threads until the service is stopped.

**Purpose of the change**  
Fixes #6314.

**What the code does**  
Use `super.stopAsync()` in `EventProcessorImpl.close()` to stop the `EventProcessorImpl` service. Before, the `close()` method in `EventProcessorImpl` called `super.close()`, which contains a `Futures.await()` call that blocks a thread until the service is stopped. Now, there are no blocking calls in the `close()` call of `EventProcessorImpl`.

**How to verify it**  
Modified test to validate that the `EventProcessorImpl` service is actually stopped. All other tests should pass.