### PR TITLE
Issue 6325: Change pravega version to 0.10.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,7 @@ jjwtVersion=0.9.1
 bouncyCastleVersion=1.69
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.10.0
+pravegaVersion=0.10.1-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
As part of the release process, the version needs to be changed to X.Y.(Z+1)-SNAPSHOT on the release branch. 

**Purpose of the change**  
Fixes #6325

**What the code does**  
Change pravegaVersion in gradle.properties to 0.10.1-SNAPSHOT

**How to verify it**  
All tests should pass