### PR TITLE
Issue 6332: Cherry pick for PR #6316 to r0.10

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -105,6 +105,7 @@ public class SegmentHelper implements AutoCloseable {
             .put(WireCommands.ReadTable.class, ImmutableSet.of(WireCommands.TableRead.class))
             .put(WireCommands.ReadTableKeys.class, ImmutableSet.of(WireCommands.TableKeysRead.class))
             .put(WireCommands.ReadTableEntries.class, ImmutableSet.of(WireCommands.TableEntriesRead.class))
+            .put(WireCommands.GetTableSegmentInfo.class, ImmutableSet.of(WireCommands.TableSegmentInfo.class))
             .build();
 
     private static final Map<Class<? extends Request>, Set<Class<? extends Reply>>> EXPECTED_FAILING_REPLIES =
@@ -120,6 +121,7 @@ public class SegmentHelper implements AutoCloseable {
             .put(WireCommands.ReadTable.class, ImmutableSet.of(WireCommands.NoSuchSegment.class))
             .put(WireCommands.ReadTableKeys.class, ImmutableSet.of(WireCommands.NoSuchSegment.class))
             .put(WireCommands.ReadTableEntries.class, ImmutableSet.of(WireCommands.NoSuchSegment.class))
+            .put(WireCommands.GetTableSegmentInfo.class, ImmutableSet.of(WireCommands.NoSuchSegment.class))
             .build();
 
     protected final ConnectionPool connectionPool;

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -392,6 +392,37 @@ public class SegmentHelperTest extends ThreadPooledTestSuite {
     }
 
     @Test
+    public void testGetTableSegmentInfo() {
+        MockConnectionFactory factory = new MockConnectionFactory();
+        @Cleanup
+        SegmentHelper helper = new SegmentHelper(factory, new MockHostControllerStore(), executorService());
+        String tableName = "transactionsInEpoch-0.#.a4fa6f45-b49d-4364-b91e-597c6e9ff78e";
+        CompletableFuture<WireCommands.TableSegmentInfo> result = helper.getTableSegmentInfo(tableName, "", 0L);
+        long requestId = ((MockConnection) (factory.connection)).getRequestId();
+        factory.rp.process(new WireCommands.TableSegmentInfo(requestId, tableName, 0L, 100L, 7L, 10));
+        WireCommands.TableSegmentInfo tableInfo = result.join();
+        assertEquals(7L, tableInfo.getEntryCount());
+        assertEquals(0L, tableInfo.getStartOffset());
+        assertEquals(100L, tableInfo.getLength());
+        assertEquals(10, tableInfo.getKeyLength());
+
+        String tableNotExists = "tableNotExists";
+        CompletableFuture<WireCommands.TableSegmentInfo> result1 = helper.getTableSegmentInfo(tableNotExists, "", 1L);
+        requestId = ((MockConnection) (factory.connection)).getRequestId();
+        factory.rp.process(new WireCommands.NoSuchSegment(requestId, tableNotExists, "", -1));
+        AssertExtensions.assertThrows("",
+                () -> result1.join(),
+                ex -> Exceptions.unwrap(ex) instanceof WireCommandFailedException
+                        && ((WireCommandFailedException) Exceptions.unwrap(ex)).getReason().equals(WireCommandFailedException.Reason.SegmentDoesNotExist)
+        );
+
+        final String exceptionTestTable = "testTable";
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.getTableSegmentInfo(exceptionTestTable, "", 2L);
+        validateProcessingFailureCFE(factory, futureSupplier);
+        testConnectionFailure(factory, futureSupplier);
+    }
+
+    @Test
     public void testGetSegmentAttribute() {
         MockConnectionFactory factory = new MockConnectionFactory();
         @Cleanup

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -979,7 +979,6 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             log.info(requestId, "Segment '{}' already exists and cannot perform operation '{}'.",
                      segment, operation);
             invokeSafely(connection::send, new SegmentAlreadyExists(requestId, segment, clientReplyStackTrace), failureHandler);
-
         } else if (u instanceof StreamSegmentNotExistsException) {
             log.warn(requestId, "Segment '{}' does not exist and cannot perform operation '{}'.",
                      segment, operation);

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -804,6 +804,7 @@ public class PravegaRequestProcessorTest {
         // Execute and Verify createTableSegment calling stack is executed as design.
         processor.createTableSegment(new WireCommands.CreateTableSegment(++requestId, tableSegmentName, false, keyLength, "", 0));
         order.verify(connection).send(new WireCommands.SegmentCreated(requestId, tableSegmentName));
+
         processor.createTableSegment(new WireCommands.CreateTableSegment(++requestId, tableSegmentName, false, keyLength, "", 0));
         order.verify(connection).send(new WireCommands.SegmentAlreadyExists(requestId, tableSegmentName, ""));
         verify(recorderMock).createTableSegment(eq(tableSegmentName), any());
@@ -821,6 +822,11 @@ public class PravegaRequestProcessorTest {
         // Verify segment info can be retrieved.
         processor.getTableSegmentInfo(new WireCommands.GetTableSegmentInfo(++requestId, tableSegmentName, ""));
         order.verify(connection).send(new WireCommands.TableSegmentInfo(requestId, tableSegmentName, 0, 0, 0, keyLength));
+        
+        // Verify invoking GetTableSegmentInfo on a non-existing segment returns NoSuchSegment
+        String nonExistingSegment = "nonExistingSegment";
+        processor.getTableSegmentInfo(new WireCommands.GetTableSegmentInfo(++requestId, nonExistingSegment, ""));
+        order.verify(connection).send(new WireCommands.NoSuchSegment(requestId, nonExistingSegment, "", -1));
 
         // Verify table segment has correct rollover size
         // Verify default value


### PR DESCRIPTION
**Change log description**  
Added entries for expected and failing replies for WireCommands.GetTableSegmentInfo in SegmentHelper.

**Purpose of the change**  
Cherry pick for PR #6316 to r0.10
Fixes #6332 

**How to verify it**  
All tests should pass