### PR TITLE
Issue 6335: Segment storage and core threads stats always have zero values

### DIFF
--- a/common/src/main/java/io/pravega/common/concurrent/ExecutorServiceHelpers.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ExecutorServiceHelpers.java
@@ -99,6 +99,9 @@ public final class ExecutorServiceHelpers {
         } else if (service instanceof ForkJoinPool) {
             val fjp = (ForkJoinPool) service;
             return new Snapshot(fjp.getQueuedSubmissionCount(), fjp.getActiveThreadCount(), fjp.getPoolSize());
+        } else if (service instanceof ThreadPoolScheduledExecutorService) {
+            val tpse = (ThreadPoolScheduledExecutorService) service;
+            return new Snapshot(tpse.getRunner().getQueue().size(), tpse.getRunner().getActiveCount(), tpse.getRunner().getPoolSize());
         } else {
             return null;
         }

--- a/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.Data;
+import lombok.Getter;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -61,6 +62,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class ThreadPoolScheduledExecutorService extends AbstractExecutorService implements ScheduledExecutorService  {
 
     private static final AtomicLong COUNTER = new AtomicLong(0);
+    @Getter
     private final ThreadPoolExecutor runner;
     private final ScheduledQueue<ScheduledRunnable<?>> queue;
 

--- a/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
@@ -63,7 +63,7 @@ public class ThreadPoolScheduledExecutorService extends AbstractExecutorService 
 
     private static final AtomicLong COUNTER = new AtomicLong(0);
     @Getter
-    private final ThreadPoolExecutor runner;
+    final ThreadPoolExecutor runner;
     private final ScheduledQueue<ScheduledRunnable<?>> queue;
 
     /**

--- a/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
@@ -41,6 +41,7 @@ import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import lombok.AccessLevel;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -62,8 +63,8 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class ThreadPoolScheduledExecutorService extends AbstractExecutorService implements ScheduledExecutorService  {
 
     private static final AtomicLong COUNTER = new AtomicLong(0);
-    @Getter
-    final ThreadPoolExecutor runner;
+    @Getter(AccessLevel.PACKAGE)
+    private final ThreadPoolExecutor runner;
     private final ScheduledQueue<ScheduledRunnable<?>> queue;
 
     /**

--- a/common/src/test/java/io/pravega/common/concurrent/ExecutorServiceHelpersTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/ExecutorServiceHelpersTests.java
@@ -96,7 +96,6 @@ public class ExecutorServiceHelpersTests extends ThreadPooledTestSuite {
 
         ExecutorServiceHelpers.Snapshot snapshot = ExecutorServiceHelpers.getSnapshot(coreExecutor);
         Assert.assertEquals("Unexpected pool size", 30, snapshot.getPoolSize());
-        Assert.assertEquals("Unexpected active thread count", 0, snapshot.getActiveThreadCount());
         Assert.assertEquals("Unexpected queue size", 0, snapshot.getQueueSize());
     }
 }

--- a/common/src/test/java/io/pravega/common/concurrent/ExecutorServiceHelpersTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/ExecutorServiceHelpersTests.java
@@ -16,8 +16,10 @@
 package io.pravega.common.concurrent;
 
 import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.InlineExecutor;
 import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.ThreadPooledTestSuite;
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -72,7 +74,7 @@ public class ExecutorServiceHelpersTests extends ThreadPooledTestSuite {
 
         // Scheduling exception
         val closedExecutor = Executors.newSingleThreadExecutor();
-        closedExecutor.shutdown();
+        ExecutorServiceHelpers.shutdown(closedExecutor);
         runCount.set(0);
         exceptionHolder.set(null);
         finallyCount.set(0);
@@ -97,5 +99,11 @@ public class ExecutorServiceHelpersTests extends ThreadPooledTestSuite {
         ExecutorServiceHelpers.Snapshot snapshot = ExecutorServiceHelpers.getSnapshot(coreExecutor);
         Assert.assertEquals("Unexpected pool size", 30, snapshot.getPoolSize());
         Assert.assertEquals("Unexpected queue size", 0, snapshot.getQueueSize());
+
+        ScheduledExecutorService inlineExecutor = new InlineExecutor();
+        ExecutorServiceHelpers.Snapshot inlineSnapshot = ExecutorServiceHelpers.getSnapshot(inlineExecutor);
+        Assert.assertNull("Unexpected snapshot", inlineSnapshot);
+
+        ExecutorServiceHelpers.shutdown(Duration.ofSeconds(1), coreExecutor, inlineExecutor);
     }
 }

--- a/common/src/test/java/io/pravega/common/concurrent/ExecutorServiceHelpersTests.java
+++ b/common/src/test/java/io/pravega/common/concurrent/ExecutorServiceHelpersTests.java
@@ -20,8 +20,11 @@ import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+
+import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
@@ -84,5 +87,16 @@ public class ExecutorServiceHelpersTests extends ThreadPooledTestSuite {
         Assert.assertEquals("Unexpected number of runs (rejected execution)", 0, runCount.get());
         Assert.assertNull("Unexpected exception set (rejected execution)", exceptionHolder.get());
         Assert.assertEquals("Unexpected number of finally runs (rejected execution)", 1, finallyCount.get());
+    }
+
+    @Test
+    public void testSnapshot() {
+        @Cleanup("shutdown")
+        ScheduledExecutorService coreExecutor = ExecutorServiceHelpers.newScheduledThreadPool(30, "core", Thread.NORM_PRIORITY);
+
+        ExecutorServiceHelpers.Snapshot snapshot = ExecutorServiceHelpers.getSnapshot(coreExecutor);
+        Assert.assertEquals("Unexpected pool size", 30, snapshot.getPoolSize());
+        Assert.assertEquals("Unexpected active thread count", 0, snapshot.getActiveThreadCount());
+        Assert.assertEquals("Unexpected queue size", 0, snapshot.getQueueSize());
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentStoreMetrics.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentStoreMetrics.java
@@ -20,13 +20,12 @@ import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.segmentstore.server.logs.operations.CompletableOperation;
 import io.pravega.segmentstore.storage.cache.CacheState;
 import io.pravega.shared.MetricsNames;
-import io.pravega.shared.metrics.DynamicLogger;
-import io.pravega.shared.metrics.MetricsProvider;
-import io.pravega.shared.metrics.StatsLogger;
-import io.pravega.shared.metrics.OpStatsLogger;
-import io.pravega.shared.metrics.OpStatsData;
 import io.pravega.shared.metrics.Counter;
+import io.pravega.shared.metrics.DynamicLogger;
 import io.pravega.shared.metrics.Meter;
+import io.pravega.shared.metrics.MetricsProvider;
+import io.pravega.shared.metrics.OpStatsLogger;
+import io.pravega.shared.metrics.StatsLogger;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -109,27 +108,11 @@ public final class SegmentStoreMetrics {
         public ThreadPool(ScheduledExecutorService executor, ScheduledExecutorService storageExecutor) {
             this.executor = Preconditions.checkNotNull(executor, "executor");
             this.storageExecutor = Preconditions.checkNotNull(storageExecutor, "storageExecutor");
-            queueSize = STATS_LOGGER.createStats(MetricsNames.THREAD_POOL_QUEUE_SIZE);
-            activeThreads = STATS_LOGGER.createStats(MetricsNames.THREAD_POOL_ACTIVE_THREADS);
-            storageQueueSize = STATS_LOGGER.createStats(MetricsNames.STORAGE_THREAD_POOL_QUEUE_SIZE);
-            storageActiveThreads = STATS_LOGGER.createStats(MetricsNames.STORAGE_THREAD_POOL_ACTIVE_THREADS);
+            this.queueSize = STATS_LOGGER.createStats(MetricsNames.THREAD_POOL_QUEUE_SIZE);
+            this.activeThreads = STATS_LOGGER.createStats(MetricsNames.THREAD_POOL_ACTIVE_THREADS);
+            this.storageQueueSize = STATS_LOGGER.createStats(MetricsNames.STORAGE_THREAD_POOL_QUEUE_SIZE);
+            this.storageActiveThreads = STATS_LOGGER.createStats(MetricsNames.STORAGE_THREAD_POOL_ACTIVE_THREADS);
             this.reporter = executor.scheduleWithFixedDelay(this::report, 1000, 1000, TimeUnit.MILLISECONDS);
-        }
-
-        public OpStatsData getQueueSize() {
-            return queueSize.toOpStatsData();
-        }
-
-        public OpStatsData getActiveThreads() {
-            return activeThreads.toOpStatsData();
-        }
-
-        public OpStatsData getStorageQueueSize() {
-            return storageQueueSize.toOpStatsData();
-        }
-
-        public OpStatsData getStorageActiveThreads() {
-            return storageActiveThreads.toOpStatsData();
         }
 
         @Override
@@ -141,7 +124,7 @@ public final class SegmentStoreMetrics {
             this.storageActiveThreads.close();
         }
 
-        public void report() {
+        private void report() {
             ExecutorServiceHelpers.Snapshot s = ExecutorServiceHelpers.getSnapshot(this.executor);
             if (s != null) {
                 this.queueSize.reportSuccessValue(s.getQueueSize());

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentStoreMetrics.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentStoreMetrics.java
@@ -26,7 +26,6 @@ import io.pravega.shared.metrics.Meter;
 import io.pravega.shared.metrics.MetricsProvider;
 import io.pravega.shared.metrics.OpStatsLogger;
 import io.pravega.shared.metrics.StatsLogger;
-
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
@@ -25,7 +25,6 @@ import io.pravega.shared.MetricsNames;
 import io.pravega.shared.metrics.MetricRegistryUtils;
 import io.pravega.shared.metrics.MetricsConfig;
 import io.pravega.shared.metrics.MetricsProvider;
-import io.pravega.shared.metrics.OpStatsData;
 import io.pravega.test.common.SerializedClassRunner;
 import java.time.Duration;
 import java.util.Arrays;
@@ -200,7 +199,7 @@ public class SegmentStoreMetricsTests {
     }
 
     @Test
-    public void testTreadPoolMetrics() {
+    public void testTreadPoolMetrics() throws InterruptedException {
         @Cleanup("shutdown")
         ScheduledExecutorService coreExecutor = ExecutorServiceHelpers.newScheduledThreadPool(30, "core", Thread.NORM_PRIORITY);
         @Cleanup("shutdown")
@@ -208,17 +207,12 @@ public class SegmentStoreMetricsTests {
 
         @Cleanup
         SegmentStoreMetrics.ThreadPool pool = new SegmentStoreMetrics.ThreadPool(coreExecutor, storageExecutor);
-        pool.report();
+        Thread.sleep(2000);
 
-        OpStatsData queueSize = pool.getQueueSize();
-        OpStatsData activeThreads = pool.getActiveThreads();
-        OpStatsData storageActiveThreads = pool.getStorageActiveThreads();
-        OpStatsData storageQueueSize = pool.getStorageQueueSize();
-
-        assertEquals(1, queueSize.getNumSuccessfulEvents());
-        assertEquals(1, activeThreads.getNumSuccessfulEvents());
-        assertEquals(1, storageActiveThreads.getNumSuccessfulEvents());
-        assertEquals(1, storageQueueSize.getNumSuccessfulEvents());
+        assertEquals(1, MetricRegistryUtils.getTimer(MetricsNames.THREAD_POOL_QUEUE_SIZE).count());
+        assertEquals(1, MetricRegistryUtils.getTimer(MetricsNames.STORAGE_THREAD_POOL_ACTIVE_THREADS).count());
+        assertEquals(1, MetricRegistryUtils.getTimer(MetricsNames.STORAGE_THREAD_POOL_QUEUE_SIZE).count());
+        assertEquals(1, MetricRegistryUtils.getTimer(MetricsNames.STORAGE_THREAD_POOL_ACTIVE_THREADS).count());
     }
 
     @Test

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
@@ -25,6 +25,7 @@ import io.pravega.shared.MetricsNames;
 import io.pravega.shared.metrics.MetricRegistryUtils;
 import io.pravega.shared.metrics.MetricsConfig;
 import io.pravega.shared.metrics.MetricsProvider;
+import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.SerializedClassRunner;
 import java.time.Duration;
 import java.util.Arrays;
@@ -199,7 +200,7 @@ public class SegmentStoreMetricsTests {
     }
 
     @Test
-    public void testTreadPoolMetrics() throws InterruptedException {
+    public void testTreadPoolMetrics() throws Exception {
         @Cleanup("shutdown")
         ScheduledExecutorService coreExecutor = ExecutorServiceHelpers.newScheduledThreadPool(30, "core", Thread.NORM_PRIORITY);
         @Cleanup("shutdown")
@@ -207,12 +208,11 @@ public class SegmentStoreMetricsTests {
 
         @Cleanup
         SegmentStoreMetrics.ThreadPool pool = new SegmentStoreMetrics.ThreadPool(coreExecutor, storageExecutor);
-        Thread.sleep(2000);
 
-        assertEquals(1, MetricRegistryUtils.getTimer(MetricsNames.THREAD_POOL_QUEUE_SIZE).count());
-        assertEquals(1, MetricRegistryUtils.getTimer(MetricsNames.STORAGE_THREAD_POOL_ACTIVE_THREADS).count());
-        assertEquals(1, MetricRegistryUtils.getTimer(MetricsNames.STORAGE_THREAD_POOL_QUEUE_SIZE).count());
-        assertEquals(1, MetricRegistryUtils.getTimer(MetricsNames.STORAGE_THREAD_POOL_ACTIVE_THREADS).count());
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricRegistryUtils.getTimer(MetricsNames.THREAD_POOL_QUEUE_SIZE).count() == 1, 2000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricRegistryUtils.getTimer(MetricsNames.STORAGE_THREAD_POOL_ACTIVE_THREADS).count() == 1, 2000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricRegistryUtils.getTimer(MetricsNames.STORAGE_THREAD_POOL_QUEUE_SIZE).count() == 1, 2000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricRegistryUtils.getTimer(MetricsNames.STORAGE_THREAD_POOL_ACTIVE_THREADS).count() == 1, 2000);
     }
 
     @Test

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
@@ -210,10 +210,10 @@ public class SegmentStoreMetricsTests {
         SegmentStoreMetrics.ThreadPool pool = new SegmentStoreMetrics.ThreadPool(coreExecutor, storageExecutor);
         pool.report();
 
-        OpStatsData queueSize = SegmentStoreMetrics.ThreadPool.getQueueSize();
-        OpStatsData activeThreads = SegmentStoreMetrics.ThreadPool.getActiveThreads();
-        OpStatsData storageActiveThreads = SegmentStoreMetrics.ThreadPool.getStorageActiveThreads();
-        OpStatsData storageQueueSize = SegmentStoreMetrics.ThreadPool.getStorageQueueSize();
+        OpStatsData queueSize = pool.getQueueSize();
+        OpStatsData activeThreads = pool.getActiveThreads();
+        OpStatsData storageActiveThreads = pool.getStorageActiveThreads();
+        OpStatsData storageQueueSize = pool.getStorageQueueSize();
 
         assertEquals(1, queueSize.getNumSuccessfulEvents());
         assertEquals(1, activeThreads.getNumSuccessfulEvents());

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
@@ -200,7 +200,7 @@ public class SegmentStoreMetricsTests {
     }
 
     @Test
-    public void testTreadPoolMetrics() throws Exception {
+    public void testThreadPoolMetrics() throws Exception {
         @Cleanup("shutdown")
         ScheduledExecutorService coreExecutor = ExecutorServiceHelpers.newScheduledThreadPool(30, "core", Thread.NORM_PRIORITY);
         @Cleanup("shutdown")


### PR DESCRIPTION
**Change log description**  
`getSnapshot()` in `ExecutiveServiceHelpers` can now get values for executor type `ThreadPoolScheduledExecutorService`

**Purpose of the change**  
Fixes #6335 

**What the code does**  
Segment store creates executors of type `ThreadPoolScheduledExecutorService` for dealing with thread pool data. So, added another check in `ExecutiveServiceHelpers` to make sure the following metrics are published:
- THREAD_POOL_QUEUE_SIZE
- THREAD_POOL_ACTIVE_THREADS
- STORAGE_THREAD_POOL_QUEUE_SIZE
- STORAGE_THREAD_POOL_ACTIVE_THREADS

**How to verify it**  
Run `testTreadPoolMetrics()` in `SegmentStoreMetricsTest`