### PR TITLE
Issue 6334: Defensive fix for update Reader Group remaining in stuck state

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestHandler.java
@@ -139,20 +139,30 @@ public class StreamRequestHandler extends AbstractRequestProcessor<ControllerEve
     public CompletableFuture<Void> processCreateReaderGroup(CreateReaderGroupEvent createRGEvent) {
         log.info(createRGEvent.getRequestId(), "Processing create request for ReaderGroup {}/{}", 
                 createRGEvent.getScope(), createRGEvent.getRgName());
-        return createRGTask.execute(createRGEvent);
+        return createRGTask.execute(createRGEvent).thenAccept(v -> {
+            log.info(createRGEvent.getRequestId(), "Processing of create event for Reader Group {}/{} completed successfully.",
+                    createRGEvent.getScope(), createRGEvent.getRgName());
+        });
     }
 
     @Override
     public CompletableFuture<Void> processDeleteReaderGroup(DeleteReaderGroupEvent deleteRGEvent) {
         log.info(deleteRGEvent.getRequestId(), "Processing delete request for ReaderGroup {}/{}",
                 deleteRGEvent.getScope(), deleteRGEvent.getRgName());
-        return deleteRGTask.execute(deleteRGEvent);
+        return deleteRGTask.execute(deleteRGEvent).thenAccept(v -> {
+            log.info(deleteRGEvent.getRequestId(), "Processing of delete event for Reader Group {}/{} completed successfully.",
+                    deleteRGEvent.getScope(), deleteRGEvent.getRgName());
+        });
     }
 
     @Override
     public CompletableFuture<Void> processUpdateReaderGroup(UpdateReaderGroupEvent updateRGEvent) {
         log.info(updateRGEvent.getRequestId(), "Processing update request for ReaderGroup {}/{}",
                 updateRGEvent.getScope(), updateRGEvent.getRgName());
-        return updateRGTask.execute(updateRGEvent);
+        return updateRGTask.execute(updateRGEvent)
+                .thenAccept(v -> {
+                    log.info(updateRGEvent.getRequestId(), "Processing of update event for Reader Group {}/{} completed successfully.",
+                            updateRGEvent.getScope(), updateRGEvent.getRgName());
+                });
     }
 }

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateReaderGroupTask.java
@@ -25,8 +25,6 @@ import io.pravega.common.tracing.TagLogger;
 import io.pravega.controller.retryable.RetryableException;
 import io.pravega.controller.store.stream.OperationContext;
 import io.pravega.controller.store.stream.StreamMetadataStore;
-import io.pravega.controller.store.stream.records.ReaderGroupConfigRecord;
-import io.pravega.controller.store.VersionedMetadata;
 import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.controller.util.RetryHelper;
 import io.pravega.shared.NameUtils;

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateReaderGroupTask.java
@@ -116,18 +116,14 @@ public class UpdateReaderGroupTask implements ReaderGroupTask<UpdateReaderGroupE
                                        }
                                        return CompletableFuture.completedFuture(null);
                                    })
-                                   .thenCompose(v -> completeConfigUpdate(scope, readerGroup, rgConfigRecord, context, executor));
+                                   .thenCompose(v -> streamMetadataStore.completeRGConfigUpdate(scope, readerGroup, rgConfigRecord, context, executor));
                                }
                                // We get here for non-transition updates
-                               return completeConfigUpdate(scope, readerGroup, rgConfigRecord, context, executor);
+                               return streamMetadataStore.completeRGConfigUpdate(scope, readerGroup, rgConfigRecord, context, executor);
                            }
                            return CompletableFuture.completedFuture(null);
                        });
         }), UPDATE_RETRY_PREDICATE, Integer.MAX_VALUE, executor);
     }
 
-    private CompletableFuture<Void> completeConfigUpdate(String scope, String rgName, VersionedMetadata<ReaderGroupConfigRecord> record, OperationContext context, ScheduledExecutorService executor) {
-        return RetryHelper.withIndefiniteRetriesAsync(() -> streamMetadataStore.completeRGConfigUpdate(scope, rgName, record, context, executor),
-                ex -> log.warn("Complete Reader Group config update failed with exception: {}", ex.getMessage()), executor);
-    }
 }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -681,6 +681,8 @@ public abstract class StreamMetadataTasksTest {
         assertEquals(subscriberToNonSubscriberConfig.getAutomaticCheckpointIntervalMillis(), responseRG3.getConfig().getAutomaticCheckpointIntervalMillis());
         assertEquals(subscriberToNonSubscriberConfig.getStartingStreamCuts().size(), responseRG3.getConfig().getStartingStreamCutsCount());
         assertEquals(subscriberToNonSubscriberConfig.getEndingStreamCuts().size(), responseRG3.getConfig().getEndingStreamCutsCount());
+
+
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -681,8 +681,6 @@ public abstract class StreamMetadataTasksTest {
         assertEquals(subscriberToNonSubscriberConfig.getAutomaticCheckpointIntervalMillis(), responseRG3.getConfig().getAutomaticCheckpointIntervalMillis());
         assertEquals(subscriberToNonSubscriberConfig.getStartingStreamCuts().size(), responseRG3.getConfig().getStartingStreamCutsCount());
         assertEquals(subscriberToNonSubscriberConfig.getEndingStreamCuts().size(), responseRG3.getConfig().getEndingStreamCutsCount());
-
-
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -90,7 +90,18 @@ import io.pravega.controller.task.EventHelper;
 import io.pravega.controller.task.KeyValueTable.TableMetadataTasks;
 import io.pravega.controller.util.Config;
 import io.pravega.shared.NameUtils;
-import io.pravega.shared.controller.event.*;
+import io.pravega.shared.controller.event.AbortEvent;
+import io.pravega.shared.controller.event.CommitEvent;
+import io.pravega.shared.controller.event.ControllerEvent;
+import io.pravega.shared.controller.event.DeleteStreamEvent;
+import io.pravega.shared.controller.event.ScaleOpEvent;
+import io.pravega.shared.controller.event.SealStreamEvent;
+import io.pravega.shared.controller.event.TruncateStreamEvent;
+import io.pravega.shared.controller.event.UpdateStreamEvent;
+import io.pravega.shared.controller.event.CreateReaderGroupEvent;
+import io.pravega.shared.controller.event.UpdateReaderGroupEvent;
+import io.pravega.shared.controller.event.DeleteReaderGroupEvent;
+import io.pravega.shared.controller.event.RGStreamCutRecord;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
 import java.time.Duration;
@@ -692,7 +703,7 @@ public abstract class StreamMetadataTasksTest {
                 .retentionType(ReaderGroupConfig.StreamDataRetention.NONE)
                 .build();
         CreateReaderGroupEvent badCreateEvent = buildCreateRGEvent(SCOPE, "rg", rgConf, 1L, System.currentTimeMillis());
-       
+
         requestEventWriter.writeEvent(badCreateEvent);
         AssertExtensions.assertFutureThrows("DataNotFoundException", processFailingEvent(requestEventWriter), e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException);
 

--- a/controller/src/test/java/io/pravega/controller/task/Stream/ZkStreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/ZkStreamMetadataTasksTest.java
@@ -107,4 +107,10 @@ public class ZkStreamMetadataTasksTest extends StreamMetadataTasksTest {
     public void sizeBasedRetentionStreamTest() {
         // no op
     }
+
+    @Test
+    @Override
+    public void readerGroupFailureTests() {
+        // no op
+    }
 }


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
The processing of UpdateReaderGroupEvent involves making one or more metadata updates on Segment Store using the PravegaTablesStoreHelper APIs. These APIs can throw WireCommandFailedException (all Retryable exceptions) or a ConnectionFailedException which is thrown when an unexpected response is returned by Segment Store.
The existing code for update event processing does not retry on ConnectionFailedException and so in a rare case when this response is returned, event processing would not be retried leaving the ReaderGroupUpdateRecord in "updating" state forever.

**Purpose of the change**  
Fixes #6334

**What the code does**  
This PR makes the following changes to UpdateReaderGroupEvent processing:
1. Adds `ConnectionFailedException` to the retry predicate for update event processing.
2. Logging improvements for create, delete and update event processing.

**How to verify it**  
All tests should pass.
