### PR TITLE
Issue 6327: Cherry pick #6307 to r0.10 #6327

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -224,7 +224,9 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         checkInitialized();
         return executeSerialized(() -> {
             val traceId = LoggerHelpers.traceEnter(log, "openWrite", streamSegmentName);
+            val timer = new Timer();
             Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
+            log.debug("{} openWrite - started segment={}.", logPrefix, streamSegmentName);
             return tryWith(metadataStore.beginTransaction(false, streamSegmentName),
                     txn -> txn.get(streamSegmentName)
                             .thenComposeAsync(storageMetadata -> {
@@ -235,14 +237,7 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
                                 final CompletableFuture<Void> f;
                                 if (segmentMetadata.getOwnerEpoch() < this.epoch) {
                                     log.debug("{} openWrite - Segment needs ownership change - segment={}.", logPrefix, segmentMetadata.getName());
-                                    f = claimOwnership(txn, segmentMetadata)
-                                            .exceptionally(e -> {
-                                                val ex = Exceptions.unwrap(e);
-                                                if (ex instanceof StorageMetadataWritesFencedOutException) {
-                                                    throw new CompletionException(new StorageNotPrimaryException(streamSegmentName, ex));
-                                                }
-                                                throw new CompletionException(ex);
-                                            });
+                                    f = claimOwnership(txn, segmentMetadata);
                                 } else {
                                     f = CompletableFuture.completedFuture(null);
                                 }
@@ -252,11 +247,19 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
 
                                     // This instance is the owner, return a handle.
                                     val retValue = SegmentStorageHandle.writeHandle(streamSegmentName);
+                                    log.debug("{} openWrite - finished segment={} latency={}.", logPrefix, streamSegmentName, timer.getElapsedMillis());
                                     LoggerHelpers.traceLeave(log, "openWrite", traceId, retValue);
                                     return retValue;
                                 }, executor);
                             }, executor),
-                    executor);
+                    executor)
+                    .handleAsync( (v, ex) -> {
+                        if (null != ex) {
+                            log.debug("{} openWrite - exception segment={} latency={}.", logPrefix, streamSegmentName, timer.getElapsedMillis(), ex);
+                            handleException(streamSegmentName, ex);
+                        }
+                        return v;
+                    }, executor);
         }, streamSegmentName);
     }
 
@@ -352,7 +355,7 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         return executeSerialized(() -> {
             val traceId = LoggerHelpers.traceEnter(log, "create", streamSegmentName, rollingPolicy);
             val timer = new Timer();
-
+            log.debug("{} create - started segment={}, rollingPolicy={}, latency={}.", logPrefix, streamSegmentName, rollingPolicy);
             return tryWith(metadataStore.beginTransaction(false, streamSegmentName), txn -> {
                 // Retrieve metadata and make sure it does not exist.
                 return txn.get(streamSegmentName)
@@ -378,27 +381,28 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
                                         Duration elapsed = timer.getElapsed();
                                         SLTS_CREATE_LATENCY.reportSuccessEvent(elapsed);
                                         SLTS_CREATE_COUNT.inc();
-                                        log.debug("{} create - segment={}, rollingPolicy={}, latency={}.", logPrefix, streamSegmentName, rollingPolicy, elapsed.toMillis());
+                                        log.debug("{} create - finished segment={}, rollingPolicy={}, latency={}.", logPrefix, streamSegmentName, rollingPolicy, elapsed.toMillis());
                                         LoggerHelpers.traceLeave(log, "create", traceId, retValue);
                                         return retValue;
-                                    }, executor)
-                                    .handleAsync((v, e) -> {
-                                        handleException(streamSegmentName, e);
-                                        return v;
                                     }, executor);
                         }, executor);
+            }, executor)
+            .handleAsync((v, e) -> {
+                if (null != e) {
+                    log.debug("{} create - exception segment={}, rollingPolicy={}, latency={}.", logPrefix, streamSegmentName, rollingPolicy, timer.getElapsedMillis(), e);
+                    handleException(streamSegmentName, e);
+                }
+                return v;
             }, executor);
         }, streamSegmentName);
     }
 
     private void handleException(String streamSegmentName, Throwable e) {
-        if (null != e) {
             val ex = Exceptions.unwrap(e);
             if (ex instanceof StorageMetadataWritesFencedOutException) {
                 throw new CompletionException(new StorageNotPrimaryException(streamSegmentName, ex));
             }
             throw new CompletionException(ex);
-        }
     }
 
     @Override
@@ -425,6 +429,8 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         checkInitialized();
         return executeSerialized(() -> {
             val traceId = LoggerHelpers.traceEnter(log, "seal", handle);
+            Timer timer = new Timer();
+            log.debug("{} seal - started segment={} latency={}.", logPrefix, handle.getSegmentName());
             Preconditions.checkNotNull(handle, "handle");
             String streamSegmentName = handle.getSegmentName();
             Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
@@ -448,16 +454,14 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
                                 }
                             }, executor)
                             .thenRunAsync(() -> {
-                                log.debug("{} seal - segment={}.", logPrefix, handle.getSegmentName());
+                                log.debug("{} seal - finished segment={} latency={}.", logPrefix, handle.getSegmentName(), timer.getElapsedMillis());
                                 LoggerHelpers.traceLeave(log, "seal", traceId, handle);
-                            }, executor)
-                            .exceptionally(e -> {
-                                val ex = Exceptions.unwrap(e);
-                                if (ex instanceof StorageMetadataWritesFencedOutException) {
-                                    throw new CompletionException(new StorageNotPrimaryException(streamSegmentName, ex));
-                                }
-                                throw new CompletionException(ex);
-                            }), executor);
+                            }, executor), executor)
+                    .exceptionally( ex -> {
+                        log.warn("{} seal - exception segment={} latency={}.", logPrefix, handle.getSegmentName(), timer.getElapsedMillis(), ex);
+                        handleException(streamSegmentName, ex);
+                        return null;
+                    });
         }, handle.getSegmentName());
     }
 
@@ -512,6 +516,7 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         }
         return executeSerialized(() -> {
             val traceId = LoggerHelpers.traceEnter(log, "delete", handle);
+            log.debug("{} delete - started segment={}, latency={}.", logPrefix, handle.getSegmentName());
             val timer = new Timer();
             val streamSegmentName = handle.getSegmentName();
             return tryWith(metadataStore.beginTransaction(false, streamSegmentName), txn -> txn.get(streamSegmentName)
@@ -535,18 +540,16 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
                                                 val elapsed = timer.getElapsed();
                                                 SLTS_DELETE_LATENCY.reportSuccessEvent(elapsed);
                                                 SLTS_DELETE_COUNT.inc();
-                                                log.debug("{} delete - segment={}, latency={}.", logPrefix, handle.getSegmentName(), elapsed.toMillis());
+                                                log.debug("{} delete - finished segment={}, latency={}.", logPrefix, handle.getSegmentName(), elapsed.toMillis());
                                                 LoggerHelpers.traceLeave(log, "delete", traceId, handle);
-                                            }, executor)
-                                            .exceptionally(e -> {
-                                                val ex = Exceptions.unwrap(e);
-                                                if (ex instanceof StorageMetadataWritesFencedOutException) {
-                                                    throw new CompletionException(new StorageNotPrimaryException(streamSegmentName, ex));
-                                                }
-                                                throw new CompletionException(ex);
-                                            });
+                                            }, executor);
                                 }, executor);
-                    }, executor), executor);
+                    }, executor), executor)
+                    .exceptionally( ex -> {
+                        log.warn("{} delete - exception segment={}, latency={}.", logPrefix, handle.getSegmentName(), timer.getElapsedMillis(), ex);
+                        handleException(streamSegmentName, ex);
+                        return null;
+                    });
         }, handle.getSegmentName());
     }
 
@@ -582,8 +585,10 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         checkInitialized();
         return executeParallel(() -> {
             val traceId = LoggerHelpers.traceEnter(log, "openRead", streamSegmentName);
+            val timer = new Timer();
             // Validate preconditions and return handle.
             Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
+            log.debug("{} openRead - started segment={}.", logPrefix, streamSegmentName);
             return tryWith(metadataStore.beginTransaction(false, streamSegmentName), txn ->
                             txn.get(streamSegmentName).thenComposeAsync(storageMetadata -> {
                                 val segmentMetadata = (SegmentMetadata) storageMetadata;
@@ -596,24 +601,25 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
                                     // In case of a fail-over, length recorded in metadata will be lagging behind its actual length in the storage.
                                     // This can happen with lazy commits that were still not committed at the time of fail-over.
                                     f = executeSerialized(() ->
-                                        claimOwnership(txn, segmentMetadata)
-                                            .exceptionally(e -> {
-                                                val ex = Exceptions.unwrap(e);
-                                                if (ex instanceof StorageMetadataWritesFencedOutException) {
-                                                    throw new CompletionException(new StorageNotPrimaryException(streamSegmentName, ex));
-                                                }
-                                                throw new CompletionException(ex);
-                                            }), streamSegmentName);
+                                        claimOwnership(txn, segmentMetadata), streamSegmentName);
                                 } else {
                                     f = CompletableFuture.completedFuture(null);
                                 }
                                 return f.thenApplyAsync(v -> {
                                     val retValue = SegmentStorageHandle.readHandle(streamSegmentName);
+                                    log.debug("{} openRead - finished segment={} latency={}.", logPrefix, streamSegmentName, timer.getElapsedMillis());
                                     LoggerHelpers.traceLeave(log, "openRead", traceId, retValue);
                                     return retValue;
                                 }, executor);
                             }, executor),
-                    executor);
+                    executor)
+                    .handleAsync( (v, ex) -> {
+                        if (null != ex) {
+                            log.debug("{} openRead - exception segment={} latency={}.", logPrefix, streamSegmentName, timer.getElapsedMillis(), ex);
+                            handleException(streamSegmentName, ex);
+                        }
+                        return v;
+                    }, executor);
         }, streamSegmentName);
     }
 
@@ -628,7 +634,9 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         checkInitialized();
         return executeParallel(() -> {
             val traceId = LoggerHelpers.traceEnter(log, "getStreamSegmentInfo", streamSegmentName);
+            val timer = new Timer();
             Preconditions.checkNotNull(streamSegmentName, "streamSegmentName");
+            log.debug("{} getStreamSegmentInfo - started segment={}.", logPrefix, streamSegmentName);
             return tryWith(metadataStore.beginTransaction(true, streamSegmentName), txn ->
                     txn.get(streamSegmentName)
                             .thenApplyAsync(storageMetadata -> {
@@ -643,9 +651,18 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
                                         .startOffset(segmentMetadata.getStartOffset())
                                         .lastModified(new ImmutableDate(segmentMetadata.getLastModified()))
                                         .build();
+                                log.debug("{} getStreamSegmentInfo - finished segment={} latency={}.", logPrefix, streamSegmentName, timer.getElapsedMillis());
                                 LoggerHelpers.traceLeave(log, "getStreamSegmentInfo", traceId, retValue);
                                 return retValue;
-                            }, executor), executor);
+                            }, executor),
+                    executor)
+                    .handleAsync( (v, ex) -> {
+                        if (null != ex) {
+                            log.debug("{} getStreamSegmentInfo - exception segment={}.", logPrefix, streamSegmentName, ex);
+                            handleException(streamSegmentName, ex);
+                        }
+                        return v;
+                    }, executor);
         }, streamSegmentName);
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
@@ -179,8 +179,10 @@ class ConcatOperation implements Callable<CompletableFuture<Void>> {
                                 targetSegmentMetadata.setChunkCount(targetSegmentMetadata.getChunkCount() + sourceSegmentMetadata.getChunkCount());
 
                                 // Delete read index block entries for source.
-                                chunkedSegmentStorage.deleteBlockIndexEntriesForChunk(txn, sourceSegment, sourceSegmentMetadata.getStartOffset(), sourceSegmentMetadata.getLength());
-
+                                // To avoid possibility of unintentional deadlock, skip this step for storage system segments.
+                                if (!sourceSegmentMetadata.isStorageSystemSegment()) {
+                                    chunkedSegmentStorage.deleteBlockIndexEntriesForChunk(txn, sourceSegment, sourceSegmentMetadata.getStartOffset(), sourceSegmentMetadata.getLength());
+                                }
                                 txn.update(targetSegmentMetadata);
                                 txn.delete(sourceSegment);
 

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -72,7 +72,12 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
     }
 
     protected ChunkMetadataStore getMetadataStore() throws Exception {
-        return new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
+        val metadataStore = new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
+        metadataStore.setReadCallback( transactionData -> {
+            Assert.assertFalse("Attempt to read pinned metadata from store", transactionData.getKey().contains("_system/containers"));
+            return CompletableFuture.completedFuture(null);
+        });
+        return metadataStore;
     }
 
     protected ChunkStorage getChunkStorage() throws Exception {


### PR DESCRIPTION
**Change log description**  
Issue 6306: SLTS - avoid deadlock in truncate (#6307)
In case of system segments, do not attempt to delete block read index entries. Add debug logs for openRead, openWrite and getStreamSegmentInfo methods. Reduce log noise in system journals

**Purpose of the change**  
Fix #6327 Cherry-pick #6307 to r0.10

**What the code does**  
Cherry-pick #6307 to r0.10

**How to verify it**  
Tests should pass