### PR TITLE
Issue 6356: ContainerEventProcessor internal segment could be evicted from memory

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -160,6 +160,7 @@ import org.junit.rules.Timeout;
 
 import static io.pravega.common.concurrent.ExecutorServiceHelpers.newScheduledThreadPool;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for StreamSegmentContainer class.
@@ -2491,6 +2492,25 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
         ContainerEventProcessor containerEventProcessor = new ContainerEventProcessorImpl(container, container.metadataStore,
                 TIMEOUT_EVENT_PROCESSOR_ITERATION, TIMEOUT_EVENT_PROCESSOR_ITERATION, this.executorService());
         ContainerEventProcessorTests.testEventRejectionOnMaxOutstanding(containerEventProcessor);
+    }
+
+    /**
+     * Tests that call to getOrCreateInternalSegment is idempotent and always provides pinned segments.
+     */
+    @Test(timeout = 30000)
+    public void testPinnedSegmentReload() {
+        @Cleanup
+        TestContext context = createContext();
+        val container = (StreamSegmentContainer) context.container;
+        container.startAsync().awaitRunning();
+        Function<String, CompletableFuture<DirectSegmentAccess>> segmentSupplier =
+                ContainerEventProcessorImpl.getOrCreateInternalSegment(container, container.metadataStore, TIMEOUT_EVENT_PROCESSOR_ITERATION);
+        long segmentId = segmentSupplier.apply("dummySegment").join().getSegmentId();
+        for (int i = 0; i < 10; i++) {
+            DirectSegmentAccess segment = segmentSupplier.apply("dummySegment").join();
+            assertTrue(segment.getInfo().isPinned());
+            assertEquals(segmentId, segment.getSegmentId());
+        }
     }
 
     /**


### PR DESCRIPTION
**Change log description**  
Make sure to always call `registerPinnedSegment` when loading/creating the internal segment for `ContainerEventProcessor`.

**Purpose of the change**  
Fixes #6356.

**What the code does**  
This PR simplifies the supplier function in `ContainerEventProcessorImpl` and makes sure that the segment loaded/created by `ContainerEventProcessorImpl` is always a result of invoking `registerPinnedSegment`. Otherwise, there may be a chance that the internal segment is not registered as pinned and could be evicted from memory.

**How to verify it**  
Added a test to validate the idempotent behavior of `ContainerEventProcessorImpl.getOrCreateInternalSegment`. All other test should pass.