### PR TITLE
Issue 6345: Fix system test false positives

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/ZookeeperK8sService.java
@@ -111,7 +111,7 @@ public class ZookeeperK8sService extends AbstractService {
                 .put("spec", ImmutableMap.builder().put("image",  getImageSpec(DOCKER_REGISTRY + PREFIX + "/" + ZOOKEEPER_IMAGE_NAME, PRAVEGA_ZOOKEEPER_IMAGE_VERSION))
                                          .put("replicas", clusterSize)
                                          .put("persistence", ImmutableMap.of("reclaimPolicy", "Delete"))
-                                         .put("pod", ImmutableMap.of("resources",getZookeeperResources()))
+                                         .put("pod", ImmutableMap.of("resources", getZookeeperResources()))
                                          .build())
                 .build();
     }


### PR DESCRIPTION
**Change log description**  
When we run the system tests we do see intermittently that some tests are marked as failed when they have actually passed. These failures were mainly due to ZK restarting during the test and we do expect the tests to be marked as failed even if the test itself has completed succesfully. 
This PR targets the ZK restart issue which happens during these tests and was potentially caused due to missing resource configuration.

**Purpose of the change**  
Fixes #6345 

**What the code does**  
The code assigns resources to ZK in the system test framework.

**How to verify it**  
When we run the system tests we shouldnt see any tests marked as failed(when they have actually passed) due to ZK restart.
