### PR TITLE
Issue 6400: Change Pravega Version on branch r0.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,7 @@ jjwtVersion=0.9.1
 bouncyCastleVersion=1.69
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.10.1-SNAPSHOT
+pravegaVersion=0.10.2-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Brian Zhou <b.zhou@dell.com>

**Change log description**  
As part of the release process, the version needs to be changed to `0.10.2-SNAPSHOT` on the release branch.
The downstream projects like connectors need to update with `0.10.2-SNAPSHOT` Pravega.

**Purpose of the change**  
Fixes #6400 

**What the code does**  
Change pravegaVersion in gradle.properties to 0.10.2-SNAPSHOT

**How to verify it**  
All tests should pass