### PR TITLE
Issue 6407: Fixing test memory leak

### DIFF
--- a/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
@@ -42,6 +42,7 @@ import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Cleanup;
+import lombok.SneakyThrows;
 import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -103,10 +104,12 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
 
     @Override
     @After
+    @SneakyThrows
     public void tearDown() {
         System.setOut(originalOut);
         System.setIn(originalIn);
         STATE.get().close();
+        super.tearDown();
     }
 
     @Test

--- a/test/integration/src/main/java/io/pravega/test/integration/utils/SetupUtils.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/utils/SetupUtils.java
@@ -75,6 +75,7 @@ public final class SetupUtils {
     @Getter
     private EventStreamClientFactory clientFactory = null;
     private ControllerWrapper controllerWrapper = null;
+    private ServiceBuilder serviceBuilder = null;
     private PravegaConnectionListener server = null;
     private AdminConnectionListener adminListener = null;
     @Getter
@@ -168,9 +169,9 @@ public final class SetupUtils {
         this.zkTestServer.start();
 
         // Start Pravega Service.
-        ServiceBuilder serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
+        this.serviceBuilder = ServiceBuilder.newInMemoryBuilder(ServiceBuilderConfig.getDefaultConfig());
 
-        serviceBuilder.initialize();
+        this.serviceBuilder.initialize();
         StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
         TableStore tableStore = serviceBuilder.createTableStoreService();
         this.server = new PravegaConnectionListener(enableTls, false, "localhost",
@@ -217,6 +218,7 @@ public final class SetupUtils {
 
         this.controllerWrapper.close();
         this.server.close();
+        this.serviceBuilder.close();
         this.adminListener.close();
         this.zkTestServer.close();
         this.clientFactory.close();


### PR DESCRIPTION

**Change log description**  
Fixed:
- SetupUtils not shutting down segment store
- BookkeeperCommandsTest not shutting down BK server

**Purpose of the change**  
Fixes #6407.

**What the code does**  
Mem leak fix.

**How to verify it**  
Build shall pass.