### PR TITLE
Issue 6409: Cherry pick PR 6397 into r0.10

### DIFF
--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -71,7 +71,6 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 @ToString
 public class InProcPravegaCluster implements AutoCloseable {
 
-    private static final String LOCALHOST = "localhost";
     private static final String ALL_INTERFACES = "0.0.0.0";
     private static final int THREADPOOL_SIZE = 20;
     private boolean isInMemStorage;
@@ -308,7 +307,6 @@ public class InProcPravegaCluster implements AutoCloseable {
                         .with(ServiceConfig.CERT_FILE, this.certFile)
                         .with(ServiceConfig.ENABLE_TLS_RELOAD, this.enableTlsReload)
                         .with(ServiceConfig.LISTENING_IP_ADDRESS, ALL_INTERFACES)
-                        .with(ServiceConfig.PUBLISHED_IP_ADDRESS, LOCALHOST)
                         .with(ServiceConfig.CACHE_POLICY_MAX_TIME, 60)
                         .with(ServiceConfig.CACHE_POLICY_MAX_SIZE, 128 * 1024 * 1024L)
                         .with(ServiceConfig.DATALOG_IMPLEMENTATION, isInMemStorage ?


### PR DESCRIPTION
Issue #6060: Use default published IP in standalone (#6397)

Signed-off-by: Derek Moore <derek.moore@dell.com>

Co-authored-by: Andrei Paduroiu <andreipaduroiu@users.noreply.github.com>

**Change log description**  
Cherry pick PR #6397 into r0.10

**Purpose of the change**  
Fixes #6409

**What the code does**  
Removes a blanket override on Published IP config from standalone.

**How to verify it**  
See #6397
