### PR TITLE
Issue 6391: LTS - Enable STS temp tokens with S3 Binding.

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/s3/S3StorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/s3/S3StorageConfig.java
@@ -38,7 +38,8 @@ public class S3StorageConfig {
     public static final Property<String> BUCKET = Property.named("bucket", "");
     public static final Property<String> PREFIX = Property.named("prefix", "/");
     public static final Property<Boolean> USENONEMATCH = Property.named("noneMatch.enable", false, "useNoneMatch");
-
+    public static final Property<Boolean> ASSUME_ROLE = Property.named("connect.config.assumeRole.enable", false);
+    public static final Property<String> USER_ROLE = Property.named("connect.config.role", "");
     private static final String COMPONENT_CODE = "s3";
     private static final String PATH_SEPARATOR = "/";
 
@@ -94,6 +95,19 @@ public class S3StorageConfig {
      */
     @Getter
     private final boolean shouldOverrideUri;
+
+    /**
+     * Whether to use STS tokens by using assume role.
+     */
+    @Getter
+    private final boolean assumeRoleEnabled;
+
+    /**
+     *  The role to assume.
+     */
+    @Getter
+    private final String userRole;
+
     //endregion
 
     //region Constructor
@@ -113,6 +127,8 @@ public class S3StorageConfig {
         String givenPrefix = Preconditions.checkNotNull(properties.get(PREFIX), "prefix");
         this.prefix = givenPrefix.endsWith(PATH_SEPARATOR) ? givenPrefix : givenPrefix + PATH_SEPARATOR;
         this.useNoneMatch = properties.getBoolean(USENONEMATCH);
+        this.assumeRoleEnabled = properties.getBoolean(ASSUME_ROLE);
+        this.userRole = Preconditions.checkNotNull(properties.get(USER_ROLE), "userRole");
     }
 
     /**

--- a/bindings/src/test/java/io/pravega/storage/StorageFactoryTests.java
+++ b/bindings/src/test/java/io/pravega/storage/StorageFactoryTests.java
@@ -165,7 +165,34 @@ public class StorageFactoryTests extends ThreadPooledTestSuite {
     }
 
     @Test
-    public void testS3StorageFactoryCreator() {
+    public void testS3StorageFactoryCreatorWithoutRole() {
+        val config = S3StorageConfig.builder()
+                .with(S3StorageConfig.CONFIGURI, "http://127.0.0.1")
+                .with(S3StorageConfig.BUCKET, "bucket")
+                .with(S3StorageConfig.PREFIX, "samplePrefix")
+                .with(S3StorageConfig.ACCESS_KEY, "user")
+                .with(S3StorageConfig.SECRET_KEY, "secret")
+                .build();
+
+        testS3StorageFactoryCreator(config);
+    }
+
+    @Test
+    public void testS3StorageFactoryCreatorWithRole() {
+        val config = S3StorageConfig.builder()
+                .with(S3StorageConfig.CONFIGURI, "http://127.0.0.1")
+                .with(S3StorageConfig.ASSUME_ROLE, true)
+                .with(S3StorageConfig.BUCKET, "bucket")
+                .with(S3StorageConfig.PREFIX, "samplePrefix")
+                .with(S3StorageConfig.ACCESS_KEY, "user")
+                .with(S3StorageConfig.SECRET_KEY, "secret")
+                .with(S3StorageConfig.USER_ROLE, "role")
+                .build();
+
+        testS3StorageFactoryCreator(config);
+    }
+
+    private void testS3StorageFactoryCreator(S3StorageConfig config) {
         StorageFactoryCreator factoryCreator = new S3StorageFactoryCreator();
         val expected = new StorageFactoryInfo[]{
                 StorageFactoryInfo.builder()
@@ -180,13 +207,7 @@ public class StorageFactoryTests extends ThreadPooledTestSuite {
 
         // Simple Storage
         ConfigSetup configSetup1 = mock(ConfigSetup.class);
-        val config = S3StorageConfig.builder()
-                .with(S3StorageConfig.CONFIGURI, "http://127.0.0.1")
-                .with(S3StorageConfig.BUCKET, "bucket")
-                .with(S3StorageConfig.PREFIX, "samplePrefix")
-                .with(S3StorageConfig.ACCESS_KEY, "user")
-                .with(S3StorageConfig.SECRET_KEY, "secret")
-                .build();
+
         when(configSetup1.getConfig(any())).thenReturn(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, config);
         val factory1 = factoryCreator.createFactory(expected[0], configSetup1, executorService());
         Assert.assertTrue(factory1 instanceof S3SimpleStorageFactory);

--- a/bindings/src/test/java/io/pravega/storage/s3/S3SimpleStorageTests.java
+++ b/bindings/src/test/java/io/pravega/storage/s3/S3SimpleStorageTests.java
@@ -55,6 +55,11 @@ public class S3SimpleStorageTests extends SimpleStorageTests {
         return new S3ChunkStorage(testContext.s3Client, testContext.adapterConfig, executorService(), false);
     }
 
+    @Override
+    protected ChunkedSegmentStorageConfig getDefaultConfig() {
+        return this.testContext.defaultConfig;
+    }
+
     /**
      * {@link ChunkedRollingStorageTests} tests for {@link S3ChunkStorage} based {@link io.pravega.segmentstore.storage.Storage}.
      */
@@ -80,10 +85,7 @@ public class S3SimpleStorageTests extends SimpleStorageTests {
 
         @Override
         protected ChunkedSegmentStorageConfig getDefaultConfig() {
-            return ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
-                    .minSizeLimitForConcat(5 * 1024 * 1024)
-                    .maxSizeLimitForConcat(5 * 1024 * 1024 * 1024)
-                    .build();
+            return this.testContext.defaultConfig;
         }
     }
 
@@ -112,6 +114,11 @@ public class S3SimpleStorageTests extends SimpleStorageTests {
         @Override
         protected ChunkStorage createChunkStorage() {
             return new S3ChunkStorage(testContext.s3Client, testContext.adapterConfig, executorService(), false);
+        }
+
+        @Override
+        protected int getMinimumConcatSize() {
+            return Math.max(1, Math.toIntExact(this.testContext.defaultConfig.getMinSizeLimitForConcat()));
         }
 
         /**

--- a/bindings/src/test/java/io/pravega/storage/s3/S3StorageConfigTest.java
+++ b/bindings/src/test/java/io/pravega/storage/s3/S3StorageConfigTest.java
@@ -45,7 +45,9 @@ public class S3StorageConfigTest {
                 .with(Property.named("connect.config.region"), "my-region")
                 .with(Property.named("connect.config.access.key"), "key")
                 .with(Property.named("connect.config.secret.key"), "secret")
-                .with(Property.named("connect.config.uri.override"), true);
+                .with(Property.named("connect.config.role"), "role")
+                .with(Property.named("connect.config.uri.override"), true)
+                .with(Property.named("connect.config.assumeRole.enable"), true);
         S3StorageConfig config = builder.build();
         assertEquals("testBucket", config.getBucket());
         assertEquals("testPrefix/", config.getPrefix());
@@ -55,5 +57,7 @@ public class S3StorageConfigTest {
         assertEquals( "my-region", config.getRegion());
         assertEquals( "key", config.getAccessKey());
         assertEquals( "secret", config.getSecretKey());
+        assertEquals( "role", config.getUserRole());
+        assertEquals( true, config.isAssumeRoleEnabled());
     }
 }

--- a/bindings/src/test/java/io/pravega/storage/s3/S3TestContext.java
+++ b/bindings/src/test/java/io/pravega/storage/s3/S3TestContext.java
@@ -15,6 +15,7 @@
  */
 package io.pravega.storage.s3;
 
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.test.common.TestUtils;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -24,13 +25,14 @@ import java.util.UUID;
  * Test context S3 tests.
  */
 public class S3TestContext {
-    public static final String BUCKET_NAME_PREFIX = "pravega-unit-test-";
+    public static final String BUCKET_NAME_PREFIX = "pravega-unit-test/";
     public final S3StorageConfig adapterConfig;
 
     public final int port;
     public final String configUri;
     public final S3Client s3Client;
     public final S3Mock s3Mock;
+    public final ChunkedSegmentStorageConfig defaultConfig = ChunkedSegmentStorageConfig.DEFAULT_CONFIG;
 
     public S3TestContext() {
         try {


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Enable STS temp tokens with S3 Binding.

**Purpose of the change**  
Fix #6391 

**What the code does**  

- While initializing SDK client use credential provider based on STS token
- Assumes predefined role and identity (provided in config) and that access key and secret are assumed to be passed as env variables 
- Minor unit test fixes to make it more generic.

**How to verify it**  
Tests should pass.
System tests should pass with AWS
