### PR TITLE
Issue 4912 : LTS - Efficient space reclamation after truncation by relocating first chunk.

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageMetrics.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageMetrics.java
@@ -64,7 +64,7 @@ public class ChunkStorageMetrics {
     static final Counter SLTS_SYSTEM_READ_BYTES = STATS_LOGGER.createCounter(MetricsNames.SLTS_SYSTEM_READ_BYTES);
     static final Counter SLTS_SYSTEM_WRITE_BYTES = STATS_LOGGER.createCounter(MetricsNames.SLTS_SYSTEM_WRITE_BYTES);
     static final Counter SLTS_CONCAT_BYTES = STATS_LOGGER.createCounter(MetricsNames.SLTS_CONCAT_BYTES);
-
+    static final Counter SLTS_TRUNCATE_RELOCATION_BYTES = STATS_LOGGER.createCounter(MetricsNames.SLTS_TRUNCATE_RELOCATION_BYTES);
     static final Counter SLTS_GC_TASK_PROCESSED = STATS_LOGGER.createCounter(MetricsNames.SLTS_GC_TASK_PROCESSED);
 
     static final Counter SLTS_GC_CHUNK_NEW = STATS_LOGGER.createCounter(MetricsNames.SLTS_GC_CHUNK_NEW);
@@ -90,6 +90,7 @@ public class ChunkStorageMetrics {
     static final Counter SLTS_DELETE_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_DELETE_COUNT);
     static final Counter SLTS_CONCAT_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_CONCAT_COUNT);
     static final Counter SLTS_TRUNCATE_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_TRUNCATE_COUNT);
+    static final Counter SLTS_TRUNCATE_RELOCATION_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_TRUNCATE_RELOCATION_COUNT);
     static final Counter SLTS_SYSTEM_TRUNCATE_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_SYSTEM_TRUNCATE_COUNT);
 
     static final Counter LARGE_CONCAT_COUNT = STATS_LOGGER.createCounter(MetricsNames.STORAGE_LARGE_CONCAT_COUNT);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -976,4 +976,8 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         Preconditions.checkState(0 != this.epoch, "epoch must not be zero");
         Preconditions.checkState(!closed.get(), "ChunkedSegmentStorage instance must not be closed");
     }
+
+    String getNewChunkName(String segmentName, long offset) {
+        return NameUtils.getSegmentChunkName(segmentName, getEpoch(), offset);
+    }
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
@@ -69,6 +69,11 @@ public class ChunkedSegmentStorageConfig {
     public static final Property<Long> MAX_SAFE_SIZE = Property.named("safe.size.bytes.max", Long.MAX_VALUE);
     public static final Property<Boolean> ENABLE_SAFE_SIZE_CHECK = Property.named("safe.size.check.enable", true);
     public static final Property<Integer> SAFE_SIZE_CHECK_FREQUENCY = Property.named("safe.size.check.frequency.seconds", 60);
+
+    public static final Property<Boolean> RELOCATE_ON_TRUNCATE_ENABLED = Property.named("truncate.relocate.enable", true);
+    public static final Property<Long> MIN_TRUNCATE_RELOCATION_SIZE_BYTES = Property.named("truncate.relocate.size.bytes.min", 64 * 1024 * 1024L);
+    public static final Property<Integer> MIN_TRUNCATE_RELOCATION_PERCENT = Property.named("truncate.relocate.percent.min", 80);
+
     /**
      * Default configuration for {@link ChunkedSegmentStorage}.
      */
@@ -101,6 +106,9 @@ public class ChunkedSegmentStorageConfig {
             .maxSafeStorageSize(Long.MAX_VALUE)
             .safeStorageSizeCheckEnabled(true)
             .safeStorageSizeCheckFrequencyInSeconds(60)
+            .relocateOnTruncateEnabled(true)
+            .minSizeForTruncateRelocationInbytes(64 * 1024 * 1024L)
+            .minPercentForTruncateRelocation(80)
             .build();
 
     static final String COMPONENT_CODE = "storage";
@@ -175,6 +183,24 @@ public class ChunkedSegmentStorageConfig {
      */
     @Getter
     final private boolean inlineDefragEnabled;
+
+    /**
+     * Whether the relocation on truncate functionality is enabled or disabled.
+     */
+    @Getter
+    final private boolean relocateOnTruncateEnabled;
+
+    /**
+     * Minimum size of chunk required for it to be eligible for relocation.
+     */
+    @Getter
+    final private long minSizeForTruncateRelocationInbytes;
+
+    /**
+     * Minimum percentage of wasted space required for it to be eligible for relocation.
+     */
+    @Getter
+    final private int minPercentForTruncateRelocation;
 
     @Getter
     final private int lateWarningThresholdInMillis;
@@ -313,6 +339,9 @@ public class ChunkedSegmentStorageConfig {
         this.maxSafeStorageSize = properties.getPositiveLong(MAX_SAFE_SIZE);
         this.safeStorageSizeCheckEnabled = properties.getBoolean(ENABLE_SAFE_SIZE_CHECK);
         this.safeStorageSizeCheckFrequencyInSeconds = properties.getPositiveInt(SAFE_SIZE_CHECK_FREQUENCY);
+        this.relocateOnTruncateEnabled = properties.getBoolean(RELOCATE_ON_TRUNCATE_ENABLED);
+        this.minSizeForTruncateRelocationInbytes = properties.getPositiveLong(MIN_TRUNCATE_RELOCATION_SIZE_BYTES);
+        this.minPercentForTruncateRelocation = properties.getPositiveInt(MIN_TRUNCATE_RELOCATION_PERCENT);
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
@@ -29,6 +29,7 @@ import io.pravega.segmentstore.storage.metadata.StorageMetadataWritesFencedOutEx
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,9 +38,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_SYSTEM_TRUNCATE_COUNT;
-import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_TRUNCATE_COUNT;
-import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.SLTS_TRUNCATE_LATENCY;
+import static io.pravega.segmentstore.storage.chunklayer.ChunkStorageMetrics.*;
 
 /**
  * Implements truncate operation.
@@ -58,6 +57,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
     private final AtomicLong startOffset = new AtomicLong();
     private volatile SegmentMetadata segmentMetadata;
     private volatile boolean isLoopExited;
+    private volatile boolean isFirstChunkRelocated;
 
     TruncateOperation(ChunkedSegmentStorage chunkedSegmentStorage, SegmentHandle handle, long offset) {
         this.handle = handle;
@@ -89,6 +89,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
                             val oldChunkCount = segmentMetadata.getChunkCount();
                             val oldStartOffset = segmentMetadata.getStartOffset();
                             return updateFirstChunk(txn)
+                                    .thenComposeAsync(v -> relocateFirstChunkIfRequired(txn), chunkedSegmentStorage.getExecutor())
                                     .thenComposeAsync(v -> deleteChunks(txn)
                                             .thenComposeAsync( vvv -> {
                                                 txn.update(segmentMetadata);
@@ -97,9 +98,14 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
                                                 segmentMetadata.checkInvariants();
                                                 Preconditions.checkState(segmentMetadata.getLength() == oldLength,
                                                         "truncate should not change segment length. oldLength=%s Segment=%s", oldLength, segmentMetadata);
-                                                Preconditions.checkState(oldChunkCount - chunksToDelete.size() == segmentMetadata.getChunkCount(),
-                                                        "Number of chunks do not match. old value (%s) - number of chunks deleted (%s) must match current chunk count(%s)",
+                                                Preconditions.checkState(oldChunkCount - chunksToDelete.size()  + (isFirstChunkRelocated ? 1 : 0) == segmentMetadata.getChunkCount(),
+                                                        "Number of chunks do not match. old value (%s) - number of chunks deleted (%s) + number of chunks added (%s) must match current chunk count(%s)",
                                                         oldChunkCount, chunksToDelete.size(), segmentMetadata.getChunkCount());
+                                                if ( isFirstChunkRelocated) {
+                                                    Preconditions.checkState(segmentMetadata.getFirstChunkStartOffset() == segmentMetadata.getStartOffset(),
+                                                            "After relocation of first chunk FirstChunkStartOffset (%) must match StartOffset (%s)",
+                                                            segmentMetadata.getFirstChunkStartOffset(), segmentMetadata.getStartOffset());
+                                                }
                                                 if (null != currentMetadata && null != segmentMetadata.getFirstChunk()) {
                                                     Preconditions.checkState(segmentMetadata.getFirstChunk().equals(currentMetadata.getName()),
                                                             "First chunk name must match current metadata. Expected = %s Actual = %s", segmentMetadata.getFirstChunk(), currentMetadata.getName());
@@ -122,7 +128,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
                                                 // Collect garbage.
                                                 return chunkedSegmentStorage.getGarbageCollector().addChunksToGarbage(txn.getVersion(), chunksToDelete)
                                                         .thenComposeAsync( vv ->  {
-                                                            // Finally commit.
+                                                            // Finally, commit.
                                                             return commit(txn)
                                                                     .handleAsync(this::handleException, chunkedSegmentStorage.getExecutor())
                                                                     .thenRunAsync(this::postCommit, chunkedSegmentStorage.getExecutor());
@@ -133,9 +139,98 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
                 chunkedSegmentStorage.getExecutor());
     }
 
+    private CompletableFuture<Void> relocateFirstChunkIfRequired(MetadataTransaction txn) {
+        if (shouldRelocate()) {
+            String oldChunkName = segmentMetadata.getFirstChunk();
+            String newChunkName = chunkedSegmentStorage.getNewChunkName(handle.getSegmentName(), segmentMetadata.getStartOffset());
+            val startOffsetInChunk = segmentMetadata.getStartOffset() - segmentMetadata.getFirstChunkStartOffset();
+            val newLength = Math.toIntExact(currentMetadata.getLength() - startOffsetInChunk);
+            log.debug("{} truncate - relocating first chunk op={}, segment={}, offset={} old={} new={} relocatedBytes={}.",
+                    chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(),
+                    offset, oldChunkName, newChunkName, newLength);
+            return chunkedSegmentStorage.getGarbageCollector().trackNewChunk(txn.getVersion(), newChunkName)
+                    .thenComposeAsync( v -> chunkedSegmentStorage.getChunkStorage().create(newChunkName), chunkedSegmentStorage.getExecutor())
+                    .thenComposeAsync( chunkHandle -> copyBytes(chunkHandle, ChunkHandle.readHandle(oldChunkName), startOffsetInChunk, newLength), chunkedSegmentStorage.getExecutor())
+                    .thenRunAsync(() -> {
+                        // Create metadata for new chunk.
+                        val newFirstChunkMetadata = ChunkMetadata.builder()
+                                .name(newChunkName)
+                                .nextChunk(currentMetadata.getNextChunk())
+                                .length(newLength)
+                                .build()
+                                .setActive(true);
+                        txn.create(newFirstChunkMetadata);
+
+                        // Update segment metadata.
+                        segmentMetadata.setFirstChunkStartOffset(segmentMetadata.getStartOffset());
+                        segmentMetadata.setFirstChunk(newChunkName);
+
+                        // Handle case when there is only one chunk
+                        if (segmentMetadata.getChunkCount() == 1) {
+                            segmentMetadata.setLastChunk(newChunkName);
+                            segmentMetadata.setLastChunkStartOffset(segmentMetadata.getStartOffset());
+                        }
+
+                        // Mark old first chunk for deletion.
+                        chunksToDelete.add(oldChunkName);
+                        currentMetadata.setActive(false);
+
+                        // Add block index entries.
+                        chunkedSegmentStorage.addBlockIndexEntriesForChunk(txn,
+                                segmentMetadata.getName(),
+                                newChunkName,
+                                segmentMetadata.getFirstChunkStartOffset(),
+                                segmentMetadata.getFirstChunkStartOffset(),
+                                segmentMetadata.getFirstChunkStartOffset() + newFirstChunkMetadata.getLength()
+                                );
+
+                        isFirstChunkRelocated = true;
+                        currentMetadata = newFirstChunkMetadata;
+                        currentChunkName = newChunkName;
+                    }, chunkedSegmentStorage.getExecutor());
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private CompletableFuture<Void> copyBytes(ChunkHandle writeHandle, ChunkHandle readHandle, long startOffset, int length) {
+        val bytesToRead = new AtomicLong(length);
+        val readAtOffset = new AtomicLong(startOffset);
+        val writeAtOffset = new AtomicLong(0);
+        return Futures.loop(
+                () -> bytesToRead.get() > 0,
+                () -> {
+                    val buffer = new byte[Math.toIntExact(Math.min(chunkedSegmentStorage.getConfig().getMaxBufferSizeForChunkDataTransfer(), bytesToRead.get()))];
+                    return chunkedSegmentStorage.getChunkStorage().read(readHandle, readAtOffset.get(), buffer.length, buffer, 0)
+                            .thenComposeAsync(size -> {
+                                bytesToRead.addAndGet(-size);
+                                readAtOffset.addAndGet(size);
+                                return chunkedSegmentStorage.getChunkStorage().write(writeHandle, writeAtOffset.get(), size, new ByteArrayInputStream(buffer, 0, size))
+                                        .thenAcceptAsync(writeAtOffset::addAndGet, chunkedSegmentStorage.getExecutor());
+                            }, chunkedSegmentStorage.getExecutor());
+                },
+                chunkedSegmentStorage.getExecutor()
+        );
+    }
+
+    private boolean shouldRelocate() {
+        return chunkedSegmentStorage.getConfig().isRelocateOnTruncateEnabled()
+            && chunkedSegmentStorage.shouldAppend()
+            && !chunkedSegmentStorage.isSegmentInSystemScope(handle)
+            && currentMetadata.getLength() >  chunkedSegmentStorage.getConfig().getMinSizeForTruncateRelocationInbytes()
+            && getWastedSpacePercentage() >= chunkedSegmentStorage.getConfig().getMinPercentForTruncateRelocation();
+    }
+
+    private long getWastedSpacePercentage() {
+        val wastedSpace = segmentMetadata.getStartOffset() - segmentMetadata.getFirstChunkStartOffset();
+        return 100 * wastedSpace / currentMetadata.getLength();
+    }
+
     private void postCommit() {
         // Update the read index by removing all entries below truncate offset.
         chunkedSegmentStorage.getReadIndexCache().truncateReadIndex(handle.getSegmentName(), segmentMetadata.getStartOffset());
+        if (isFirstChunkRelocated ) {
+            chunkedSegmentStorage.getReadIndexCache().addIndexEntry(handle.getSegmentName(), segmentMetadata.getFirstChunk(), segmentMetadata.getFirstChunkStartOffset());
+        }
         logEnd();
     }
 
@@ -146,6 +241,10 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
         if (segmentMetadata.isStorageSystemSegment()) {
             SLTS_SYSTEM_TRUNCATE_COUNT.inc();
             chunkedSegmentStorage.reportMetricsForSystemSegment(segmentMetadata);
+        }
+        if (isFirstChunkRelocated) {
+            SLTS_TRUNCATE_RELOCATION_COUNT.inc();
+            SLTS_TRUNCATE_RELOCATION_BYTES.add(currentMetadata.getLength());
         }
         if (chunkedSegmentStorage.getConfig().getLateWarningThresholdInMillis() < elapsed.toMillis()) {
             log.warn("{} truncate - late op={}, segment={}, offset={}, latency={}.",
@@ -182,7 +281,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
                                                         .build()));
         }
 
-        // Finally commit.
+        // Finally, commit.
         return txn.commit();
     }
 
@@ -213,8 +312,17 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
                 chunkedSegmentStorage.getExecutor()
         ).thenAcceptAsync(v -> {
             segmentMetadata.setFirstChunk(currentChunkName);
+            if (null != currentChunkName) {
+                Preconditions.checkState(currentMetadata.getName().equals(segmentMetadata.getFirstChunk()),
+                        "currentMetadata does not match. Expected = (%s), Actual = (%s)",
+                        currentMetadata.getName(), segmentMetadata.getFirstChunk());
+                Preconditions.checkState(currentMetadata.getName().equals(currentChunkName),
+                        "currentMetadata does not match. Expected = (%s), Actual = (%s)",
+                        currentMetadata.getName(), currentChunkName);
+            }
             segmentMetadata.setStartOffset(offset);
             segmentMetadata.setFirstChunkStartOffset(startOffset.get());
+
         }, chunkedSegmentStorage.getExecutor());
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
@@ -222,7 +222,8 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
 
     private long getWastedSpacePercentage() {
         val wastedSpace = segmentMetadata.getStartOffset() - segmentMetadata.getFirstChunkStartOffset();
-        return 100 * wastedSpace / currentMetadata.getLength();
+        val length = currentMetadata.getLength();
+        return 0 == length ? 0 : 100 * wastedSpace / length;
     }
 
     private void postCommit() {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/WriteOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/WriteOperation.java
@@ -29,7 +29,6 @@ import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
 import io.pravega.segmentstore.storage.metadata.MetadataTransaction;
 import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
 import io.pravega.segmentstore.storage.metadata.StorageMetadataWritesFencedOutException;
-import io.pravega.shared.NameUtils;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
@@ -279,8 +278,7 @@ class WriteOperation implements Callable<CompletableFuture<Void>> {
 
     private CompletableFuture<Void> addNewChunk(MetadataTransaction txn) {
         // Create new chunk
-        String newChunkName = getNewChunkName(handle.getSegmentName(),
-                segmentMetadata.getLength());
+        String newChunkName = chunkedSegmentStorage.getNewChunkName(handle.getSegmentName(), segmentMetadata.getLength());
 
         return chunkedSegmentStorage.getGarbageCollector().trackNewChunk(txn.getVersion(), newChunkName)
                 .thenComposeAsync( v -> {
@@ -343,10 +341,6 @@ class WriteOperation implements Callable<CompletableFuture<Void>> {
         Preconditions.checkArgument(!handle.isReadOnly(), "handle must not be read only. Segment = %s", handle.getSegmentName());
         Preconditions.checkArgument(offset >= 0, "offset must be non negative. Segment = %s", handle.getSegmentName());
         Preconditions.checkArgument(length >= 0, "length must be non negative. Segment = %s", handle.getSegmentName());
-    }
-
-    private String getNewChunkName(String segmentName, long offset) {
-        return NameUtils.getSegmentChunkName(segmentName, chunkedSegmentStorage.getEpoch(), offset);
     }
 
     /**

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
@@ -51,6 +51,9 @@ public class ChunkedSegmentStorageConfigTests {
         props.setProperty(ChunkedSegmentStorageConfig.MAX_SAFE_SIZE.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "18");
         props.setProperty(ChunkedSegmentStorageConfig.ENABLE_SAFE_SIZE_CHECK.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "false");
         props.setProperty(ChunkedSegmentStorageConfig.SAFE_SIZE_CHECK_FREQUENCY.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "19");
+        props.setProperty(ChunkedSegmentStorageConfig.RELOCATE_ON_TRUNCATE_ENABLED.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "false");
+        props.setProperty(ChunkedSegmentStorageConfig.MIN_TRUNCATE_RELOCATION_SIZE_BYTES.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "20");
+        props.setProperty(ChunkedSegmentStorageConfig.MIN_TRUNCATE_RELOCATION_PERCENT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "21");
 
         TypedProperties typedProperties = new TypedProperties(props, "storage");
         ChunkedSegmentStorageConfig config = new ChunkedSegmentStorageConfig(typedProperties);
@@ -77,6 +80,9 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertEquals(config.getMaxSafeStorageSize(), 18);
         Assert.assertFalse(config.isSafeStorageSizeCheckEnabled());
         Assert.assertEquals(config.getSafeStorageSizeCheckFrequencyInSeconds(), 19);
+        Assert.assertFalse(config.isRelocateOnTruncateEnabled());
+        Assert.assertEquals(config.getMinSizeForTruncateRelocationInbytes(), 20);
+        Assert.assertEquals(config.getMinPercentForTruncateRelocation(), 21);
     }
 
     @Test
@@ -112,6 +118,9 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertEquals(config.getMaxSafeStorageSize(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxSafeStorageSize());
         Assert.assertEquals(config.isSafeStorageSizeCheckEnabled(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.isSafeStorageSizeCheckEnabled());
         Assert.assertEquals(config.getSafeStorageSizeCheckFrequencyInSeconds(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getSafeStorageSizeCheckFrequencyInSeconds());
+        Assert.assertEquals(config.isRelocateOnTruncateEnabled(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.isRelocateOnTruncateEnabled());
+        Assert.assertEquals(config.getMinSizeForTruncateRelocationInbytes(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMinSizeForTruncateRelocationInbytes());
+        Assert.assertEquals(config.getMinPercentForTruncateRelocation(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMinPercentForTruncateRelocation());
     }
 
     @Test

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageMockTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageMockTests.java
@@ -41,14 +41,7 @@ import java.util.concurrent.CompletionException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
     private static final int CONTAINER_ID = 42;
@@ -347,6 +340,54 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
                 "write succeeded when exception was expected.",
                 chunkedSegmentStorage.write(h1, 10, new ByteArrayInputStream(new byte[10]), 10, null),
                 ex -> clazz.equals(ex.getClass()));
+    }
+
+    @Test
+    public void testIOExceptionDuringTruncate() throws Exception {
+        String testSegmentName = "test";
+        SegmentRollingPolicy policy = new SegmentRollingPolicy(100);
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .relocateOnTruncateEnabled(true)
+                .minSizeForTruncateRelocationInbytes(1)
+                .minPercentForTruncateRelocation(50)
+                .storageMetadataRollingPolicy(policy).build();
+        @Cleanup
+        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(config, executorService()));
+        @Cleanup
+        BaseChunkStorage spyChunkStorage = spy(new NoOpChunkStorage(executorService()));
+        ((NoOpChunkStorage) spyChunkStorage).setShouldSupportConcat(false);
+        @Cleanup
+        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, spyChunkStorage, spyMetadataStore, executorService(), config);
+        chunkedSegmentStorage.initialize(1);
+        val taskQueueManager = new InMemoryTaskQueueManager();
+        chunkedSegmentStorage.getGarbageCollector().initialize(taskQueueManager).join();
+        // Step 1: Create segment and write some data.
+        val h1 = chunkedSegmentStorage.create(testSegmentName, policy, null).get();
+
+        Assert.assertEquals(h1.getSegmentName(), testSegmentName);
+        Assert.assertFalse(h1.isReadOnly());
+        chunkedSegmentStorage.write(h1, 0, new ByteArrayInputStream(new byte[10]), 10, null).get();
+        val chunksListBefore = TestUtils.getChunkNameList(spyMetadataStore, testSegmentName);
+        Assert.assertEquals(1, chunksListBefore.size());
+        // Step 2: Inject fault.
+        Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
+        val clazz = ChunkStorageException.class;
+        doThrow(exceptionToThrow).when(spyChunkStorage).doWrite(any(), anyLong(), anyInt(), any());
+        AssertExtensions.assertFutureThrows(
+                "truncate succeeded when exception was expected.",
+                chunkedSegmentStorage.truncate(h1, 8, null),
+                ex -> clazz.equals(ex.getClass()));
+        TestUtils.checkSegmentLayout(spyMetadataStore, testSegmentName, new long[] {10});
+        val chunksListAfter = TestUtils.getChunkNameList(spyMetadataStore, testSegmentName);
+        Assert.assertEquals(1, chunksListAfter.size());
+        Assert.assertTrue(chunksListAfter.containsAll(chunksListBefore));
+
+        Assert.assertEquals(2, chunkedSegmentStorage.getGarbageCollector().getQueueSize().get());
+        val list = taskQueueManager.drain(chunkedSegmentStorage.getGarbageCollector().getTaskQueueName(), 2);
+        Assert.assertTrue(chunksListBefore.contains(list.get(0).getName()));
+
+        val nameTemplate = String.format("%s.E-%d-O-%d.", testSegmentName, chunkedSegmentStorage.getEpoch(), 8);
+        Assert.assertTrue("New first chunk should be added to GC queue.", list.get(1).getName().startsWith(nameTemplate));
     }
 
     @Test

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -2017,23 +2017,35 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
 
     @Test
     public void testRepeatedTruncates() throws Exception {
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().indexBlockSize(4).build();
+        testRepeatedTruncates(config, 1, 3);
+        testRepeatedTruncates(config, 3, 1);
+        testRepeatedTruncates(config, 2, 3);
+        testRepeatedTruncates(config, 3, 2);
+        testRepeatedTruncates(config, 3, 3);
+
+    }
+
+    private void testRepeatedTruncates(ChunkedSegmentStorageConfig config, long maxChunkLength, int numberOfChunks) throws Exception {
         @Cleanup
-        TestContext testContext = getTestContext(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().indexBlockSize(4).build());
+        TestContext testContext = getTestContext(config);
         String testSegmentName = "testSegmentName";
 
-        // Populate sgement.
-        val h1 = populateSegment(testContext, testSegmentName, 3, 3);
-        byte[] buffer = new byte[10];
+        // Populate segment.
+        val expectedLength = Math.toIntExact(maxChunkLength * numberOfChunks);
+        val h1 = populateSegment(testContext, testSegmentName, maxChunkLength, numberOfChunks);
+        byte[] buffer = new byte[expectedLength];
 
         // Perform series of truncates.
-        for (int truncateAt = 0; truncateAt < 9; truncateAt++) {
+        for (int truncateAt = 0; truncateAt < expectedLength; truncateAt++) {
             HashSet<String> chunksBefore = new HashSet<>();
             chunksBefore.addAll(TestUtils.getChunkNameList(testContext.metadataStore, testSegmentName));
 
             testContext.chunkedSegmentStorage.truncate(h1, truncateAt, null).join();
-            TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, 3, 3 - (truncateAt / 3));
-            TestUtils.checkSegmentBounds(testContext.metadataStore, testSegmentName, truncateAt, 9);
-            TestUtils.checkReadIndexEntries(testContext.chunkedSegmentStorage, testContext.metadataStore, testSegmentName, truncateAt, 9, true);
+            TestUtils.checkSegmentBounds(testContext.metadataStore, testSegmentName, truncateAt, expectedLength);
+            val expectedChunkLengths = calculateExpectedChunkLengths(config, maxChunkLength, truncateAt, expectedLength);
+            TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, expectedChunkLengths);
+            TestUtils.checkReadIndexEntries(testContext.chunkedSegmentStorage, testContext.metadataStore, testSegmentName, truncateAt, expectedLength, true);
             TestUtils.checkChunksExistInStorage(testContext.chunkStorage, testContext.metadataStore, testSegmentName);
             HashSet<String>  chunksAfter = new HashSet<>();
             chunksAfter.addAll(TestUtils.getChunkNameList(testContext.metadataStore, testSegmentName));
@@ -2041,19 +2053,24 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
 
             val metadata = TestUtils.getSegmentMetadata(testContext.metadataStore, testSegmentName);
             // length doesn't change.
-            Assert.assertEquals(9, metadata.getLength());
+            Assert.assertEquals(expectedLength, metadata.getLength());
             // start offset should match i.
             Assert.assertEquals(truncateAt, metadata.getStartOffset());
-            // Each time the first offest is multiple of 3
-            Assert.assertEquals(3 * (truncateAt / 3), metadata.getFirstChunkStartOffset());
+            // Check first chunk start offset.
+            if (metadata.getFirstChunkStartOffset() % maxChunkLength == 0) {
+                Assert.assertEquals(maxChunkLength * (numberOfChunks - expectedChunkLengths.length), metadata.getFirstChunkStartOffset());
+            } else {
+                val threshold = config.getMinPercentForTruncateRelocation() * maxChunkLength / 100;
+                Assert.assertEquals(maxChunkLength * (numberOfChunks - expectedChunkLengths.length) + threshold, metadata.getFirstChunkStartOffset());
+            }
 
             // try to read some bytes.
-            val bytesRead = testContext.chunkedSegmentStorage.read(h1, truncateAt, buffer, 0, 9 - truncateAt, null).get().intValue();
-            Assert.assertEquals(9 - truncateAt, bytesRead);
+            val bytesRead = testContext.chunkedSegmentStorage.read(h1, truncateAt, buffer, 0, buffer.length - truncateAt, null).get().intValue();
+            Assert.assertEquals(buffer.length - truncateAt, bytesRead);
             if (truncateAt > 0) {
                 AssertExtensions.assertFutureThrows(
                         "read succeeded on missing segment.",
-                        testContext.chunkedSegmentStorage.read(h1, truncateAt - 1, buffer, 0, 9 - truncateAt, null),
+                        testContext.chunkedSegmentStorage.read(h1, truncateAt - 1, buffer, 0, buffer.length - truncateAt, null),
                         ex -> ex instanceof StreamSegmentTruncatedException);
             }
         }
@@ -2202,27 +2219,128 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
         testTruncate(3, 3, 4, 3, 12);
     }
 
-    private void testTruncate(long maxChunkLength, long truncateAt, int chunksCountBefore, int chunksCountAfter, long expectedLength) throws Exception {
-        @Cleanup
-        TestContext testContext = getTestContext(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().indexBlockSize(3).build());
-        String testSegmentName = "testSegmentName";
+    @Test
+    public void testBaseRelocatingTruncate() throws Exception {
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .indexBlockSize(3)
+                .relocateOnTruncateEnabled(true)
+                .minSizeForTruncateRelocationInbytes(10)
+                .minPercentForTruncateRelocation(80)
+                .build();
+        val numberOfChunks = 3;
+        val maxChunkSize = 20;
+        val threshold = 16;
+        testRelocatingTruncate(config, numberOfChunks, maxChunkSize, threshold);
+    }
 
+    @Test
+    public void testRelocatingTruncateHalfEmpty() throws Exception {
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .indexBlockSize(3)
+                .relocateOnTruncateEnabled(true)
+                .minSizeForTruncateRelocationInbytes(1)
+                .minPercentForTruncateRelocation(50)
+                .build();
+        for (int threshold = 16; threshold > 2; threshold /= 2) {
+            testRelocatingTruncate(config, 1, threshold, threshold / 2);
+        }
+    }
+
+    @Test
+    public void testMultipleRelocatingTruncate() throws Exception {
+        // Force multiple relocation every time relocating half chunk
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .indexBlockSize(3)
+                .relocateOnTruncateEnabled(true)
+                .minSizeForTruncateRelocationInbytes(1)
+                .minPercentForTruncateRelocation(50)
+                .build();
+
+        @Cleanup
+        TestContext testContext = getTestContext(config);
+        String testSegmentName = "testSegmentName";
+        int maxChunkLength = 32;
+        int truncateAt = 0;
+        // Populate
+        val h1 = populateSegment(testContext, testSegmentName, maxChunkLength, 1);
+
+        for (int threshold = maxChunkLength; threshold > 2; threshold /= 2) {
+            truncateAt += threshold / 2;
+            testTruncate(testContext, testSegmentName, maxChunkLength, truncateAt, 1, maxChunkLength, threshold / 2);
+        }
+    }
+
+    private void testRelocatingTruncate(ChunkedSegmentStorageConfig config, int numberOfChunks, long maxChunkSize, int threshold) throws Exception {
+        for (int i = 0; i < numberOfChunks; i++) {
+            testTruncate(config, maxChunkSize, i * maxChunkSize, numberOfChunks, numberOfChunks - i, maxChunkSize * numberOfChunks, maxChunkSize);
+            testTruncate(config, maxChunkSize, i * maxChunkSize + threshold - 1, numberOfChunks, numberOfChunks - i, maxChunkSize * numberOfChunks, maxChunkSize);
+            for (int j = threshold; j < maxChunkSize; j++) {
+                testTruncate(config, maxChunkSize, i * maxChunkSize + j, numberOfChunks, numberOfChunks - i, maxChunkSize * numberOfChunks, maxChunkSize - j);
+            }
+        }
+    }
+
+    @Test
+    public void testRepeatedTruncateWithRelocation() throws Exception {
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .indexBlockSize(3)
+                .relocateOnTruncateEnabled(true)
+                .minSizeForTruncateRelocationInbytes(5)
+                .minPercentForTruncateRelocation(80)
+                .build();
+        testRepeatedTruncates(config, 10, 1);
+        testRepeatedTruncates(config, 10, 2);
+        testRepeatedTruncates(config, 10, 3);
+    }
+
+    private void testTruncate(long maxChunkLength, long truncateAt, int chunksCountBefore, int chunksCountAfter, long expectedLength) throws Exception {
+        testTruncate(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder().indexBlockSize(3).build(), maxChunkLength, truncateAt, chunksCountBefore, chunksCountAfter, expectedLength, maxChunkLength);
+    }
+
+    private void testTruncate(ChunkedSegmentStorageConfig config, long maxChunkLength, long truncateAt, int chunksCountBefore, int chunksCountAfter, long expectedLength, long expectedFirstChunkLength) throws Exception {
+        @Cleanup
+        TestContext testContext = getTestContext(config);
+        String testSegmentName = "testSegmentName";
         // Populate
         val h1 = populateSegment(testContext, testSegmentName, maxChunkLength, chunksCountBefore);
+        testTruncate(testContext, testSegmentName, maxChunkLength, truncateAt, chunksCountAfter, expectedLength, expectedFirstChunkLength);
+    }
+
+    private void testTruncate(TestContext testContext, String testSegmentName, long maxChunkLength, long truncateAt, int chunksCountAfter, long expectedLength, long expectedFirstChunkLength) throws Exception {
         HashSet<String> chunksBefore = new HashSet<>();
         chunksBefore.addAll(TestUtils.getChunkNameList(testContext.metadataStore, testSegmentName));
 
         // Perform truncate.
-        testContext.chunkedSegmentStorage.truncate(h1, truncateAt, null).join();
+        testContext.chunkedSegmentStorage.truncate(SegmentStorageHandle.writeHandle(testSegmentName), truncateAt, null).join();
 
         // Check layout.
-        TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, maxChunkLength, chunksCountAfter);
+        long[] expectedLengths = calculateExpectedChunkLengths(maxChunkLength, chunksCountAfter, expectedFirstChunkLength);
+        TestUtils.checkSegmentLayout(testContext.metadataStore, testSegmentName, expectedLengths);
         TestUtils.checkSegmentBounds(testContext.metadataStore, testSegmentName, truncateAt, expectedLength);
         TestUtils.checkReadIndexEntries(testContext.chunkedSegmentStorage, testContext.metadataStore, testSegmentName, truncateAt, expectedLength, true);
         TestUtils.checkChunksExistInStorage(testContext.chunkStorage, testContext.metadataStore, testSegmentName);
         HashSet<String>  chunksAfter = new HashSet<>();
         chunksAfter.addAll(TestUtils.getChunkNameList(testContext.metadataStore, testSegmentName));
         TestUtils.checkGarbageCollectionQueue(testContext.chunkedSegmentStorage, chunksBefore, chunksAfter);
+    }
+
+    private long[] calculateExpectedChunkLengths(long maxChunkLength, int chunksCountAfter, long expectedFirstChunkLength) {
+        long[] expectedLengths = new long[chunksCountAfter];
+        Arrays.fill(expectedLengths, maxChunkLength);
+        expectedLengths[0] = expectedFirstChunkLength;
+        return expectedLengths;
+    }
+
+    private long[] calculateExpectedChunkLengths(ChunkedSegmentStorageConfig config, long maxChunkLength, long startOffset, long length ) {
+        val chunkCount = Math.toIntExact(length / maxChunkLength - startOffset / maxChunkLength); // Note two independent int divisions.
+        long[] expectedLengths = new long[chunkCount];
+        Arrays.fill(expectedLengths, maxChunkLength);
+        if (config.isRelocateOnTruncateEnabled() && maxChunkLength > config.getMinSizeForTruncateRelocationInbytes()) {
+            val threshold = config.getMinPercentForTruncateRelocation() * maxChunkLength / 100;
+            val offset = startOffset % maxChunkLength;
+            expectedLengths[0] = offset >= threshold ? maxChunkLength - threshold : maxChunkLength;
+        }
+        return expectedLengths;
     }
 
     /**

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -154,10 +154,12 @@ public final class MetricsNames {
     public static final String SLTS_SYSTEM_READ_BYTES = PREFIX + "segmentstore.storage.slts.system_read_bytes";     // Counter
     public static final String SLTS_SYSTEM_WRITE_BYTES = PREFIX + "segmentstore.storage.slts.system_write_bytes";   // Counter
     public static final String SLTS_CONCAT_BYTES = PREFIX + "segmentstore.storage.slts.concat_bytes";      // Counter
+    public static final String SLTS_TRUNCATE_RELOCATION_BYTES = PREFIX + "segmentstore.storage.slts.truncate_relocation_bytes";      // Counter
     public static final String SLTS_CREATE_COUNT = PREFIX + "segmentstore.storage.slts.create_count";      // Counter
     public static final String SLTS_DELETE_COUNT = PREFIX + "segmentstore.storage.slts.delete_count";      // Counter
     public static final String SLTS_CONCAT_COUNT = PREFIX + "segmentstore.storage.slts.concat_count";      // Counter
     public static final String SLTS_TRUNCATE_COUNT = PREFIX + "segmentstore.storage.slts.truncate_count";  // Counter
+    public static final String SLTS_TRUNCATE_RELOCATION_COUNT = PREFIX + "segmentstore.storage.slts.truncate_relocation_count";  // Counter
     public static final String SLTS_SYSTEM_TRUNCATE_COUNT = PREFIX + "segmentstore.storage.slts.system_truncate_count"; // Counter
 
     public static final String SLTS_GC_QUEUE_SIZE = PREFIX + "segmentstore.storage.slts.GC_queue_record_count";         // Counter


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Efficient space reclamation after truncation by relocating first chunk when existing size of first chunk is more than certain limit and percentage wasted space is beyond set threshold. In such cases a smaller chunk is created with copy of valid portion of old chunk and then the old chunk is marked deleted.
This feature is relevant only to append mode.

**Purpose of the change**  
Fixes #4912

**What the code does**  
Relocating first chunk when existing size of first chunk is more than certain limit and percentage wasted space is beyond threshold. In such cases we create a smaller chunk, copy valid portion of old chunk to it and then delete the old chunk.
This feature is relevant only to append mode.

**How to verify it**  
Tests should pass
