### PR TITLE
Issue 6419: Internal Reader Groups cannot read events on Controller restart

### DIFF
--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorCell.java
@@ -141,7 +141,7 @@ class EventProcessorCell<T extends ControllerEvent> {
                 try {
                     reader.closeAt(getCheckpoint());
                 } catch (Exception e) {
-                    log.info("Exception while closing EventProcessorCell reader from checkpointStore: {}.", e.getMessage());
+                    log.warn("Exception while closing EventProcessorCell reader from checkpointStore: {}.", e.getMessage());
                 }
             }
         }

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
@@ -252,8 +252,7 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
         try {
             Map<String, Position> map = sealReaderGroup(controllerId);
             cleanupReaderGroup(controllerId, map);
-        }
-        finally {
+        } finally {
             LoggerHelpers.traceLeave(log, "notifyProcessFailure", traceId, controllerId);
         }
     }

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
@@ -223,22 +223,12 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
                         log.info("Termination of event processor cell: {} completed successfully.", cell);
                     } catch (Exception e) {
                         log.warn("Failed terminating event processor cell {}.", cell, e);
-                        throw e;
                     }
                 }
 
                 // Finally, clean up Reader Group data from Checkpoint store.
                 try {
-                    String controllerId = actorSystem.getProcess();
-                    for (String reader : readerPositions.keySet()) {
-                        //Remove reader from Checkpoint Store
-                        log.info("{} Removing reader={} from checkpoint store", this.objectId, reader);
-                        checkpointStore.removeReader(controllerId, readerGroup.getGroupName(), reader);
-                    }
-
-                    // Finally, remove reader group from the checkpoint store
-                    log.info("Removing reader group {} from process {}", readerGroup.getGroupName(), controllerId);
-                    checkpointStore.removeReaderGroup(actorSystem.getProcess(), readerGroup.getGroupName());
+                    cleanupReaderGroup(actorSystem.getProcess(), readerPositions);
                 } catch (CheckpointStoreException e) {
                     log.warn("Error removing data for Reader Group {} from checkpoint store. ", readerGroup.getGroupName(), e);
                 }

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
@@ -204,7 +204,7 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
                 // its readers and their position objects from checkpoint store.
 
                 // Seal the Reader Group
-                Map<String, Position> readerPositions = ImmutableMap.of();
+                Map<String, Position> readerPositions = Map.of();
                 try {
                     readerPositions = sealReaderGroup(actorSystem.getProcess());
                 } catch (CheckpointStoreException e) {

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
@@ -15,6 +15,7 @@
  */
 package io.pravega.controller.eventProcessor.impl;
 
+import com.google.common.collect.ImmutableMap;
 import io.pravega.client.admin.ReaderGroupManager;
 import io.pravega.client.stream.ReaderSegmentDistribution;
 import io.pravega.client.stream.Stream;
@@ -80,12 +81,6 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
      * We use this lock for mutual exclusion between shutDown and changeEventProcessorCount methods.
      */
     private final Object lock = new Object();
-
-    EventProcessorGroupImpl(final EventProcessorSystemImpl actorSystem,
-                            final EventProcessorConfig<T> eventProcessorConfig,
-                            final CheckpointStore checkpointStore) {
-        this(actorSystem, eventProcessorConfig, checkpointStore, null);
-    }
 
     EventProcessorGroupImpl(final EventProcessorSystemImpl actorSystem,
                             final EventProcessorConfig<T> eventProcessorConfig,
@@ -204,8 +199,41 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
         synchronized (lock) {
             long traceId = LoggerHelpers.traceEnterWithContext(log, this.objectId, "shutDown");
             try {
-                cleanUpCheckpointStore();
+                // If any of the following operations error out, the fact is just logged.
+                // And some other controller process would clean-up the reader group data
+                // its readers and their position objects from checkpoint store.
+
+                // Seal the Reader Group
+                Map<String, Position> readerPositions = ImmutableMap.of();
+                try {
+                    readerPositions = sealReaderGroup(actorSystem.getProcess());
+                } catch (CheckpointStoreException e) {
+                    log.warn("Error sealing Reader Group {}.", readerGroup.getGroupName(), e);
+                }
+
+                // Initiate stop on all event processor cells
+                for (EventProcessorCell<T> cell : eventProcessorMap.values()) {
+                    log.info("Terminating event processor cell: {}", cell);
+                    cell.stopAsync();
+                }
+                // Await termination of cells
+                for (EventProcessorCell<T> cell : eventProcessorMap.values()) {
+                    try {
+                        cell.awaitTerminated();
+                        log.info("Termination of event processor cell: {} completed successfully.", cell);
+                    } catch (Exception e) {
+                        log.warn("Failed terminating event processor cell {}.", cell, e);
+                    }
+                }
+
+                // Finally, clean up Reader Group data from Checkpoint store.
+                try {
+                    cleanupReaderGroup(actorSystem.getProcess(), readerPositions);
+                } catch (CheckpointStoreException e) {
+                    log.warn("Error removing Reader Group {} from checkpoint store. " + readerGroup.getGroupName(), e);
+                }
                 readerGroup.close();
+
                 if (rebalanceFuture != null) {
                     rebalanceFuture.cancel(true);
                 }
@@ -214,71 +242,51 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
                 LoggerHelpers.traceLeave(log, this.objectId, "shutDown", traceId);
             }
         }
-        log.info("Shut down all event processors in {} complete.", this.toString());
-    }
-
-    private void cleanUpCheckpointStore() {
-        // If any of the following operations error out, the fact is just logged.
-        // Some other controller process is responsible for cleaning up the reader group,
-        // its readers and their position objects from checkpoint store.
-        
-        // Initiate stop on all event processor cells 
-        for (EventProcessorCell<T> cell : eventProcessorMap.values()) {
-            log.info("Terminating event processor cell: {}", cell);
-            cell.stopAsync();
-        }
-        
-        for (EventProcessorCell<T> cell : eventProcessorMap.values()) {
-            try {
-                cell.awaitTerminated();
-                log.debug("Termination of event processor cell: {} completed successfully.", cell);
-            } catch (Exception e) {
-                log.warn("Failed terminating event processor cell {}.", cell, e);
-            }
-        }
-        
-        // Finally, clean up reader group from checkpoint store.
-        try {
-            log.debug("Attempting to clean up reader group {} entry from checkpoint store", this.objectId);
-            checkpointStore.removeProcessFromGroup(actorSystem.getProcess(), readerGroup.getGroupName());
-        } catch (CheckpointStoreException e) {
-            log.warn("Error removing reader group " + this.objectId, e);
-            return;
-        }
+        log.info("Shut down of all event processors in {} complete.", this.toString());
     }
 
     @Override
-    public void notifyProcessFailure(String process) throws CheckpointStoreException {
-        long traceId = LoggerHelpers.traceEnterWithContext(log, this.objectId, "notifyProcessFailure", process);
-        log.info("Notifying failure of process {} participating in reader group {}", process, this.objectId);
+    public void notifyProcessFailure(String controllerId) throws CheckpointStoreException {
+        long traceId = LoggerHelpers.traceEnterWithContext(log, this.objectId, "notifyProcessFailure", controllerId);
+        log.info("Notifying failure of process {} participating in reader group {}", controllerId, this.objectId);
         try {
-            Map<String, Position> map;
-            try {
-                map = checkpointStore.sealReaderGroup(process, readerGroup.getGroupName());
-            } catch (CheckpointStoreException e) {
-                if (e.getType().equals(CheckpointStoreException.Type.NoNode)) {
-                    return;
-                } else {
-                    throw e;
-                }
-            }
+            Map<String, Position> map = sealReaderGroup(controllerId);
+            cleanupReaderGroup(controllerId, map);
+        }
+        finally {
+            LoggerHelpers.traceLeave(log, "notifyProcessFailure", traceId, controllerId);
+        }
+    }
 
-            for (Map.Entry<String, Position> entry : map.entrySet()) {
-                // 1. Remove failed readers from Reader Group
-                log.info("{} Notifying readerOffline reader={}, position={}", this.objectId, entry.getKey(), entry.getValue());
+    private Map<String, Position> sealReaderGroup(String controllerId) throws CheckpointStoreException {
+        Map<String, Position> readerPositions = ImmutableMap.of();
+        try {
+            log.debug("Attempting to seal Reader Group {} for Controller {}", readerGroup.getGroupName(), controllerId);
+            // Change Reader Group State to SEALED so no new Readers can join
+            readerPositions = checkpointStore.sealReaderGroup(controllerId, readerGroup.getGroupName());
+        } catch (CheckpointStoreException e) {
+            if (!e.getType().equals(CheckpointStoreException.Type.NoNode)) {
+                throw e;
+            }
+        }
+        log.info("Sealed Reader Group {} for Controller {}", readerGroup.getGroupName(), controllerId);
+        return readerPositions;
+    }
+
+    private void cleanupReaderGroup(String controllerId, Map<String, Position> readerPositions) throws CheckpointStoreException {
+            for (Map.Entry<String, Position> entry : readerPositions.entrySet()) {
+                // 1. Remove failed readers from Reader Group in State Synchronizer
+                log.info("{} Notifying readerOffline reader={}, position={} for Reader Group {}", this.objectId, entry.getKey(), entry.getValue(), readerGroup.getGroupName());
                 readerGroup.readerOffline(entry.getKey(), entry.getValue());
 
-                // 2. Clean up reader from checkpoint store
-                log.info("{} removing reader={} from checkpoint store", this.objectId, entry.getKey());
-                checkpointStore.removeReader(process, readerGroup.getGroupName(), entry.getKey());
+                // 2. Remove reader from Checkpoint Store
+                log.info("{} Removing reader={} from checkpoint store", this.objectId, entry.getKey());
+                checkpointStore.removeReader(controllerId, readerGroup.getGroupName(), entry.getKey());
             }
 
             // Finally, remove reader group from the checkpoint store
-            log.info("Removing reader group {} from process {}", readerGroup.getGroupName(), process);
-            checkpointStore.removeReaderGroup(process, readerGroup.getGroupName());
-        } finally {
-            LoggerHelpers.traceLeave(log, "notifyProcessFailure", traceId, process);
-        }
+            log.info("Removing reader group {} from process {}", readerGroup.getGroupName(), controllerId);
+            checkpointStore.removeReaderGroup(controllerId, readerGroup.getGroupName());
     }
 
     /**

--- a/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
+++ b/controller/src/main/java/io/pravega/controller/eventProcessor/impl/EventProcessorGroupImpl.java
@@ -240,7 +240,7 @@ public final class EventProcessorGroupImpl<T extends ControllerEvent> extends Ab
                     log.info("Removing reader group {} from process {}", readerGroup.getGroupName(), controllerId);
                     checkpointStore.removeReaderGroup(actorSystem.getProcess(), readerGroup.getGroupName());
                 } catch (CheckpointStoreException e) {
-                    log.warn("Error removing Reader Group {} from checkpoint store. ", readerGroup.getGroupName(), e);
+                    log.warn("Error removing data for Reader Group {} from checkpoint store. ", readerGroup.getGroupName(), e);
                 }
                 readerGroup.close();
 

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/CheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/CheckpointStore.java
@@ -90,20 +90,6 @@ public interface CheckpointStore {
      */
     void removeReaderGroup(final String process, final String readerGroup)
             throws CheckpointStoreException;
-
-    /**
-     * Removes the specified process.
-     * This is equivalent to calling {@link #sealReaderGroup(String, String)}, 
-     * then {@link #removeReader(String, String, String)} for all of the readers for that process.
-     * then {@link #removeReaderGroup(String, String)}.
-     * NOTE: this operation is not atomic, but it is idempotent.
-     * 
-     * @param process Process identifier.
-     * @param readerGroup Reader group name.
-     * @return Map of readers to their respective positions in the specified readerGroup.
-     * @throws CheckpointStoreException on error accessing or updating checkpoint store.
-     */
-    Map<String, Position> removeProcessFromGroup(final String process, final String readerGroup) throws CheckpointStoreException;
     
     /**
      * List all the reader groups added to a specified process.

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/CheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/CheckpointStore.java
@@ -90,7 +90,7 @@ public interface CheckpointStore {
      */
     void removeReaderGroup(final String process, final String readerGroup)
             throws CheckpointStoreException;
-    
+
     /**
      * List all the reader groups added to a specified process.
      * @param process Process identifier.

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/InMemoryCheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/InMemoryCheckpointStore.java
@@ -124,17 +124,6 @@ class InMemoryCheckpointStore implements CheckpointStore {
             map.remove(key);
         }
     }
-
-    @Override
-    @Synchronized
-    public Map<String, Position> removeProcessFromGroup(final String process, final String readerGroup) throws CheckpointStoreException {
-        Map<String, Position> result = sealReaderGroup(process, readerGroup);
-        for (String id : result.keySet()) {
-            removeProcessFromGroup(id, readerGroup);
-        }
-        removeReaderGroup(process, readerGroup);
-        return result;
-    }
     
     @Override
     @Synchronized

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
@@ -168,29 +168,6 @@ public class ZKCheckpointStore implements CheckpointStore {
         }
         removeEmptyNode(path);
     }
-    
-    @Override
-    public Map<String, Position> removeProcessFromGroup(String process, String readerGroup) throws CheckpointStoreException {
-        String path = getReaderGroupPath(process, readerGroup);
-
-        try {
-            updateReaderGroupData(path, groupData ->
-                    new ReaderGroupData(ReaderGroupData.State.Sealed, groupData.getReaderIds()));
-            Map<String, Position> result = getPositions(process, readerGroup);
-            for (String readerId : result.keySet()) {
-                removeReader(process, readerGroup, readerId);
-            }
-            removeReaderGroup(process, readerGroup);
-            return result;
-        } catch (KeeperException.NoNodeException e) {
-            throw new CheckpointStoreException(CheckpointStoreException.Type.NoNode, e);
-        } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException
-                | KeeperException.SessionExpiredException e) {
-            throw new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, e);
-        } catch (Exception e) {
-            throw new CheckpointStoreException(e);
-        }
-    }
 
     @Override
     public List<String> getReaderGroups(String process) throws CheckpointStoreException {
@@ -302,7 +279,6 @@ public class ZKCheckpointStore implements CheckpointStore {
                 .retryingOn(KeeperException.BadVersionException.class)
                 .throwingOn(Exception.class)
                 .run(() -> {
-
                     byte[] data = client.getData().storingStatIn(stat).forPath(path);
                     ReaderGroupData groupData = groupDataSerializer.deserialize(ByteBuffer.wrap(data));
                     groupData = updater.apply(groupData);

--- a/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/checkpoint/ZKCheckpointStore.java
@@ -227,7 +227,7 @@ public class ZKCheckpointStore implements CheckpointStore {
             });
 
         } catch (KeeperException.NoNodeException e) {
-            throw new CheckpointStoreException(CheckpointStoreException.Type.NoNode, e);
+            log.debug("ZNode for reader {} in Reader Group {} for Controller {} not found.", readerId, readerGroup, process);
         } catch (KeeperException.ConnectionLossException | KeeperException.OperationTimeoutException
                 | KeeperException.SessionExpiredException e) {
             throw new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, e);

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZKCheckpointStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZKCheckpointStoreTests.java
@@ -125,13 +125,20 @@ public class ZKCheckpointStoreTests extends CheckpointStoreTests {
         Assert.assertNotNull(resultMap);
         Assert.assertEquals(2, resultMap.size());
 
-        Map<String, Position> map = checkpointStore.sealReaderGroup(process1, readerGroup1);
-        Assert.assertEquals(map.size(), 2);
-        Assert.assertTrue(map.containsKey(reader1));
-        Assert.assertNull(map.get(reader1));
-        Assert.assertTrue(map.containsKey(reader2));
-        Assert.assertNull(map.get(reader2));
-        
+        Map<String, Position> readerPositions = checkpointStore.sealReaderGroup(process1, readerGroup1);
+        Assert.assertEquals(readerPositions.size(), 2);
+        Assert.assertTrue(readerPositions.containsKey(reader1));
+        Assert.assertNull(readerPositions.get(reader1));
+        Assert.assertTrue(readerPositions.containsKey(reader2));
+        Assert.assertNull(readerPositions.get(reader2));
+
+        for (Map.Entry<String, Position> entry : readerPositions.entrySet()) {
+            // 2. Remove reader from Checkpoint Store
+            checkpointStore.removeReader(process1, readerGroup1, entry.getKey());
+        }
+
+        // Finally, remove reader group from the checkpoint store
+        checkpointStore.removeReaderGroup(process1, readerGroup1);
         AssertExtensions.assertThrows(KeeperException.NoNodeException.class, () -> {            
             cli.getData().forPath(String.format("/%s/%s/%s/%s", "eventProcessors", process1, readerGroup1, reader1));
         });

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZKCheckpointStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZKCheckpointStoreTests.java
@@ -124,8 +124,8 @@ public class ZKCheckpointStoreTests extends CheckpointStoreTests {
         resultMap = checkpointStore.getPositions(process1, readerGroup1);
         Assert.assertNotNull(resultMap);
         Assert.assertEquals(2, resultMap.size());
-        
-        Map<String, Position> map = checkpointStore.removeProcessFromGroup(process1, readerGroup1);
+
+        Map<String, Position> map = checkpointStore.sealReaderGroup(process1, readerGroup1);
         Assert.assertEquals(map.size(), 2);
         Assert.assertTrue(map.containsKey(reader1));
         Assert.assertNull(map.get(reader1));

--- a/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
@@ -1,0 +1,4 @@
+package io.pravega.controller;
+
+public class EventProcessorGroupTest {
+}

--- a/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
@@ -129,7 +129,9 @@ public class EventProcessorGroupTest {
         assertTrue(requestEventProcessors.isRunning());
         doThrow(new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, new Exception())).when(checkpointStore).sealReaderGroup(anyString(), anyString());
         requestEventProcessors.stopAsync();
+        requestEventProcessors.awaitTerminated();
         verify(checkpointStore, times(1)).sealReaderGroup("host1", "scaleGroup");
+        verify(reader, times(1)).closeAt(any());
         verify(checkpointStore, times(0)).removeReader(anyString(), anyString(), anyString());
         verify(checkpointStore, times(1)).removeReaderGroup("host1", "scaleGroup");
         verify(mockReaderGroup, times(1)).close();
@@ -166,7 +168,4 @@ public class EventProcessorGroupTest {
         verify(checkpointStore, times(0)).removeReader(anyString(), anyString(), anyString());
         verify(checkpointStore, times(0)).removeReaderGroup("host1", "scaleGroup");
     }
-
-
-
 }

--- a/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
@@ -1,4 +1,125 @@
-package io.pravega.controller;
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.controller.eventprocessor;
 
+import io.pravega.client.EventStreamClientFactory;
+import io.pravega.client.admin.ReaderGroupManager;
+import io.pravega.client.stream.EventStreamReader;
+import io.pravega.client.stream.EventStreamWriter;
+import io.pravega.client.stream.ReaderGroup;
+import io.pravega.common.concurrent.ExecutorServiceHelpers;
+import io.pravega.controller.eventProcessor.CheckpointConfig;
+import io.pravega.controller.eventProcessor.EventProcessorConfig;
+import io.pravega.controller.eventProcessor.EventProcessorGroup;
+import io.pravega.controller.eventProcessor.EventProcessorGroupConfig;
+import io.pravega.controller.eventProcessor.EventProcessorSystem;
+import io.pravega.controller.eventProcessor.ExceptionHandler;
+import io.pravega.controller.eventProcessor.impl.ConcurrentEventProcessor;
+import io.pravega.controller.eventProcessor.impl.EventProcessorGroupConfigImpl;
+import io.pravega.controller.eventProcessor.impl.EventProcessorGroupImpl;
+import io.pravega.controller.eventProcessor.impl.EventProcessorSystemImpl;
+import io.pravega.controller.server.eventProcessor.ControllerEventProcessors;
+import io.pravega.controller.server.eventProcessor.requesthandlers.StreamRequestHandler;
+import io.pravega.controller.store.checkpoint.CheckpointStore;
+import io.pravega.controller.store.checkpoint.CheckpointStoreException;
+import io.pravega.shared.controller.event.ControllerEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+
+@Slf4j
 public class EventProcessorGroupTest {
+    @Rule
+    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+    private ScheduledExecutorService executor;
+    private ScheduledExecutorService rebalanceExecutor;
+    private EventProcessorGroup<ControllerEvent> requestEventProcessors;
+    private ReaderGroupManager readerGroupMgr;
+    private EventStreamClientFactory clientFactory;
+    private EventProcessorSystem system;
+    private StreamRequestHandler streamRequestHandler = mock(StreamRequestHandler.class);
+    private CheckpointStore checkpointStore;
+    private EventProcessorGroupConfig requestReadersConfig =
+            EventProcessorGroupConfigImpl.builder()
+                    .streamName("_requestStream")
+                    .readerGroupName("scaleGroup")
+                    .eventProcessorCount(1)
+                    .checkpointConfig(CheckpointConfig.none())
+                    .build();
+    private EventProcessorConfig<ControllerEvent> requestConfig =
+            EventProcessorConfig.builder()
+                    .config(requestReadersConfig)
+                    .decider(ExceptionHandler.DEFAULT_EXCEPTION_HANDLER)
+                    .serializer(ControllerEventProcessors.CONTROLLER_EVENT_SERIALIZER)
+                    .supplier(() -> new ConcurrentEventProcessor<>(streamRequestHandler, executor))
+                    .minRebalanceIntervalMillis(12000L)
+                    .build();
+
+    @Before
+    public void setUp() {
+        this.rebalanceExecutor = ExecutorServiceHelpers.newScheduledThreadPool(1, "event-processor");
+        this.executor = ExecutorServiceHelpers.newScheduledThreadPool(1, "test");
+        this.readerGroupMgr = mock(ReaderGroupManager.class);
+        this.clientFactory = mock(EventStreamClientFactory.class);
+        this.system = new EventProcessorSystemImpl("Controller", "host1", "_system", clientFactory, readerGroupMgr);
+        this.checkpointStore = mock(CheckpointStore.class);
+        try {
+            doNothing().when(checkpointStore).addReaderGroup(anyString(), anyString());
+            doNothing().when(checkpointStore).addReader(anyString(), anyString(), anyString());
+        } catch(CheckpointStoreException ex){
+            ex.printStackTrace();
+        }
+
+        EventStreamWriter<ControllerEvent> writer = mock(EventStreamWriter.class);
+        doReturn(writer).when(clientFactory).createEventWriter(anyString(), any(), any());
+        EventStreamReader<ControllerEvent> reader = mock(EventStreamReader.class);
+        doReturn(reader).when(clientFactory).createReader(anyString(), anyString(), any(), any());
+
+        doReturn(true).when(readerGroupMgr).createReaderGroup(anyString(), any());
+        ReaderGroup mockReaderGroup = mock(ReaderGroup.class);
+        doReturn(mockReaderGroup).when(readerGroupMgr).getReaderGroup(anyString());
+    }
+
+    @After
+    public void tearDown() {
+        executor.shutdownNow();
+        rebalanceExecutor.shutdownNow();
+    }
+
+    @Test(timeout = 10000)
+    public void testEventProcessorGroup() throws CheckpointStoreException {
+        this.requestEventProcessors = system.createEventProcessorGroup(requestConfig, checkpointStore, rebalanceExecutor);
+        requestEventProcessors.awaitRunning();
+        assertTrue(requestEventProcessors.isRunning());
+        doThrow(new CheckpointStoreException(CheckpointStoreException.Type.Connectivity, new Exception())).when(checkpointStore).sealReaderGroup(anyString(), anyString());
+        //EventProcessorGroupImpl eventProcessor = (EventProcessorGroupImpl) requestEventProcessors;
+        requestEventProcessors.stopAsync();
+    }
 }

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/ControllerWrapper.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/ControllerWrapper.java
@@ -239,7 +239,7 @@ public class ControllerWrapper implements AutoCloseable {
 
     @SneakyThrows
     public void awaitPaused() {
-        this.controllerServiceMain.awaitServicePausing().awaitTerminated(30, TimeUnit.SECONDS);
+        this.controllerServiceMain.awaitServicePausing().awaitTerminated(60, TimeUnit.SECONDS);
     }
 
     @SneakyThrows


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
This PR fixes the problem created by removing readers from the checkpoint store prior to declaring them offline. In rare cases when the Controller fails after removing a reader from the ZKCheckpointStore but before invoking reader.readerOffline , this issue manifests. It causes an old reader to stay in the ReaderGroup and continue to hold segments due to which they cannot be assigned to a reader created by the new Controller.

**Purpose of the change**  
Fixes #6419

**What the code does**  
Changed method EventProcessorGroupImpl.notifyProcessFailure() to first seal the Reader Group then mark each reader Offline and remove the Reader from checkpoint store only after it has been successfully marked offline on the Reader Group. 

**How to verify it**  
All tests should pass.