### PR TITLE
Issue 6040: Fix sporadic failure in GarbageCollectorTests.testIOException

### DIFF
--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollectorTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollectorTests.java
@@ -608,7 +608,7 @@ public class GarbageCollectorTests extends ThreadPooledTestSuite {
         Function<Duration, CompletableFuture<Void>> noDelay = d -> CompletableFuture.completedFuture(null);
         val testTaskQueue = new InMemoryTaskQueueManager();
 
-        chunkStorage.setReadOnly(chunkStorage.openWrite("deletedChunk").get(), true);
+        chunkStorage.setReadOnly(chunkStorage.openWrite("deletedChunk").get(), true).join();
 
         @Cleanup
         GarbageCollector garbageCollector = new GarbageCollector(containerId,


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Issue 6040: Fix sporadic failure in GarbageCollectorTests.testIOException

**Purpose of the change**  
Fixes #6040 

**What the code does**  
Add missing join on one of the test setup step. 

**How to verify it**  
Build should pass
