### PR TITLE
Issue 6437: Fix flaky test EventProcessorGroupTest.testFailingCellShutdown

### DIFF
--- a/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
@@ -139,15 +139,12 @@ public class EventProcessorGroupTest {
     }
 
     @Test(timeout = 10000)
-    public void testFailingCellShutdown() throws CheckpointStoreException {
+    public void testShutdown() throws CheckpointStoreException {
         this.requestEventProcessors = system.createEventProcessorGroup(requestConfig, checkpointStore, rebalanceExecutor);
         requestEventProcessors.awaitRunning();
         assertTrue(requestEventProcessors.isRunning());
-
         Position mockReaderPosition = mock(Position.class);
         doReturn(ImmutableMap.of("reader1", mockReaderPosition)).when(checkpointStore).sealReaderGroup("host1", "scaleGroup");
-        String exceptionMsg = "Exception marking reader offline.";
-        doThrow(new RuntimeException(exceptionMsg)).when(reader).closeAt(any());
         requestEventProcessors.stopAsync();
         requestEventProcessors.awaitTerminated();
         verify(checkpointStore, times(1)).sealReaderGroup("host1", "scaleGroup");


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
Test EventProcessorGroupTest.testFailingCellShutdown used to fail intermittently with a mockito exception. Fixed this by removing the `Mockito.doThrow()` as the exception did not help with testing additional code paths in EventProccessorGroup.shutdown()

**Purpose of the change**  
Fixes #6437

**What the code does**  
Removed the doThrow() for reader.closeAt() since it was anyways not help with throwing an exception on `cell.awaitTerminated()`

**How to verify it**  
All tests should pass and EventProcessorGroupTest.testFailingCellShutdown should consistently pass.
