### PR TITLE
Issue 6110: Pipeline and batch merge transactional segments

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -17,7 +17,6 @@ package io.pravega.controller.server;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.netty.buffer.Unpooled;
@@ -97,7 +96,7 @@ public class SegmentHelper implements AutoCloseable {
                     WireCommands.SegmentIsTruncated.class))
             .put(WireCommands.MergeSegments.class, ImmutableSet.of(WireCommands.SegmentsMerged.class,
                     WireCommands.NoSuchSegment.class))
-            .put(WireCommands.MergeSegmentsBatch.class, ImmutableSet.of(WireCommands.SegmentsMergedBatch.class))
+            .put(WireCommands.MergeSegmentsBatch.class, ImmutableSet.of(WireCommands.SegmentsBatchMerged.class))
             .put(WireCommands.ReadSegment.class, ImmutableSet.of(WireCommands.SegmentRead.class))
             .put(WireCommands.GetSegmentAttribute.class, ImmutableSet.of(WireCommands.SegmentAttribute.class))
             .put(WireCommands.UpdateSegmentAttribute.class, ImmutableSet.of(WireCommands.SegmentAttributeUpdated.class))
@@ -291,7 +290,7 @@ public class SegmentHelper implements AutoCloseable {
         return sendRequest(connection, clientRequestId, request)
                 .thenApply(r -> {
                         handleReply(clientRequestId, r, connection, qualifiedNameTarget, WireCommands.MergeSegmentsBatch.class, type);
-                        return ((WireCommands.SegmentsMergedBatch) r).getNewTargetWriteOffset();
+                        return ((WireCommands.SegmentsBatchMerged) r).getNewTargetWriteOffset();
                 });
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -17,6 +17,7 @@ package io.pravega.controller.server;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.netty.buffer.Unpooled;
@@ -288,9 +289,9 @@ public class SegmentHelper implements AutoCloseable {
         WireCommands.MergeSegmentsBatch request = new WireCommands.MergeSegmentsBatch(requestId, qualifiedNameTarget, transactionNames, delegationToken);
 
         return sendRequest(connection, clientRequestId, request)
-                .thenCompose(r -> {
-                    handleReply(clientRequestId, r, connection, qualifiedNameTarget, WireCommands.MergeSegmentsBatch.class, type);
-                    return CompletableFuture.completedFuture(((WireCommands.SegmentsMergedBatch) r).getNewTargetWriteOffset());
+                .thenApply(r -> {
+                        handleReply(clientRequestId, r, connection, qualifiedNameTarget, WireCommands.MergeSegmentsBatch.class, type);
+                        return ((WireCommands.SegmentsMergedBatch) r).getNewTargetWriteOffset();
                 });
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -96,6 +96,7 @@ public class SegmentHelper implements AutoCloseable {
                     WireCommands.SegmentIsTruncated.class))
             .put(WireCommands.MergeSegments.class, ImmutableSet.of(WireCommands.SegmentsMerged.class,
                     WireCommands.NoSuchSegment.class))
+            .put(WireCommands.MergeSegmentsBatch.class, ImmutableSet.of(WireCommands.SegmentsMergedBatch.class))
             .put(WireCommands.ReadSegment.class, ImmutableSet.of(WireCommands.SegmentRead.class))
             .put(WireCommands.GetSegmentAttribute.class, ImmutableSet.of(WireCommands.SegmentAttribute.class))
             .put(WireCommands.UpdateSegmentAttribute.class, ImmutableSet.of(WireCommands.SegmentAttributeUpdated.class))
@@ -302,6 +303,39 @@ public class SegmentHelper implements AutoCloseable {
                         }
                     } else {
                         return CompletableFuture.completedFuture(((WireCommands.SegmentsMerged) r).getNewTargetWriteOffset());
+                    }
+                });
+    }
+
+    public CompletableFuture<List<Long>> commitTransactions(final String scope,
+                                                     final String stream,
+                                                     final long targetSegmentId,
+                                                     final long sourceSegmentId,
+                                                     final List<UUID> txId,
+                                                     final String delegationToken,
+                                                     final long clientRequestId) {
+        Preconditions.checkArgument(getSegmentNumber(targetSegmentId) == getSegmentNumber(sourceSegmentId));
+        final Controller.NodeUri uri = getSegmentUri(scope, stream, sourceSegmentId);
+        final String qualifiedNameTarget = getQualifiedStreamSegmentName(scope, stream, targetSegmentId);
+        final List<String> transactionNames = txId.stream().map(x -> getTransactionName(scope, stream, sourceSegmentId, x)).collect(Collectors.toList());
+        final WireCommandType type = WireCommandType.MERGE_SEGMENTS_BATCH;
+
+        RawClient connection = new RawClient(ModelHelper.encode(uri), connectionPool);
+        final long requestId = connection.getFlow().asLong();
+        
+        WireCommands.MergeSegmentsBatch request = new WireCommands.MergeSegmentsBatch(requestId,
+                qualifiedNameTarget, transactionNames, delegationToken);
+
+        return sendRequest(connection, clientRequestId, request)
+                .thenCompose(r -> {
+                    handleReply(clientRequestId, r, connection, qualifiedNameTarget, WireCommands.MergeSegmentsBatch.class, type);
+                    if (r instanceof WireCommands.NoSuchSegment) {
+                        WireCommands.NoSuchSegment reply = (WireCommands.NoSuchSegment) r;
+                        log.warn(clientRequestId, "Commit Transaction: Source segment {} not found.", 
+                                reply.getSegment());
+                        return CompletableFuture.completedFuture(transactionNames.stream().map(x -> -1L).collect(Collectors.toList()));
+                    } else {
+                        return CompletableFuture.completedFuture(((WireCommands.SegmentsMergedBatch) r).getNewTargetWriteOffset());
                     }
                 });
     }

--- a/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
+++ b/controller/src/main/java/io/pravega/controller/server/SegmentHelper.java
@@ -123,6 +123,7 @@ public class SegmentHelper implements AutoCloseable {
             .put(WireCommands.ReadTableKeys.class, ImmutableSet.of(WireCommands.NoSuchSegment.class))
             .put(WireCommands.ReadTableEntries.class, ImmutableSet.of(WireCommands.NoSuchSegment.class))
             .put(WireCommands.GetTableSegmentInfo.class, ImmutableSet.of(WireCommands.NoSuchSegment.class))
+            .put(WireCommands.MergeSegmentsBatch.class, ImmutableSet.of(WireCommands.NoSuchSegment.class))
             .build();
 
     protected final ConnectionPool connectionPool;
@@ -268,52 +269,13 @@ public class SegmentHelper implements AutoCloseable {
         return getTransactionNameFromId(qualifiedName, txId);
     }
 
-    public CompletableFuture<Long> commitTransaction(final String scope,
-                                                     final String stream,
-                                                     final long targetSegmentId,
-                                                     final long sourceSegmentId,
-                                                     final UUID txId,
-                                                     final String delegationToken,
-                                                     final long clientRequestId) {
-        Preconditions.checkArgument(getSegmentNumber(targetSegmentId) == getSegmentNumber(sourceSegmentId));
-        final Controller.NodeUri uri = getSegmentUri(scope, stream, sourceSegmentId);
-        final String qualifiedNameTarget = getQualifiedStreamSegmentName(scope, stream, targetSegmentId);
-        final String transactionName = getTransactionName(scope, stream, sourceSegmentId, txId);
-        final WireCommandType type = WireCommandType.MERGE_SEGMENTS;
-
-        RawClient connection = new RawClient(ModelHelper.encode(uri), connectionPool);
-        final long requestId = connection.getFlow().asLong();
-        
-        WireCommands.MergeSegments request = new WireCommands.MergeSegments(requestId,
-                qualifiedNameTarget, transactionName, delegationToken);
-
-        return sendRequest(connection, clientRequestId, request)
-                .thenCompose(r -> {
-                    handleReply(clientRequestId, r, connection, transactionName, WireCommands.MergeSegments.class, type);
-                    if (r instanceof WireCommands.NoSuchSegment) {
-                        WireCommands.NoSuchSegment reply = (WireCommands.NoSuchSegment) r;
-                        if (reply.getSegment().equals(transactionName)) {
-                            // idempotent case when segment is already merged, we get the write offset for the parent segment.
-                            return getSegmentInfo(scope, stream, targetSegmentId, delegationToken, clientRequestId)
-                                    .thenApply(WireCommands.StreamSegmentInfo::getWriteOffset);
-                        } else {
-                            log.warn(clientRequestId, "Commit Transaction: Source segment {} not found.",
-                                    reply.getSegment());
-                            return CompletableFuture.completedFuture(-1L);
-                        }
-                    } else {
-                        return CompletableFuture.completedFuture(((WireCommands.SegmentsMerged) r).getNewTargetWriteOffset());
-                    }
-                });
-    }
-
-    public CompletableFuture<List<Long>> commitTransactions(final String scope,
-                                                     final String stream,
-                                                     final long targetSegmentId,
-                                                     final long sourceSegmentId,
-                                                     final List<UUID> txId,
-                                                     final String delegationToken,
-                                                     final long clientRequestId) {
+    public CompletableFuture<List<Long>> mergeTxnSegments(final String scope,
+                                                          final String stream,
+                                                          final long targetSegmentId,
+                                                          final long sourceSegmentId,
+                                                          final List<UUID> txId,
+                                                          final String delegationToken,
+                                                          final long clientRequestId) {
         Preconditions.checkArgument(getSegmentNumber(targetSegmentId) == getSegmentNumber(sourceSegmentId));
         final Controller.NodeUri uri = getSegmentUri(scope, stream, sourceSegmentId);
         final String qualifiedNameTarget = getQualifiedStreamSegmentName(scope, stream, targetSegmentId);
@@ -323,20 +285,12 @@ public class SegmentHelper implements AutoCloseable {
         RawClient connection = new RawClient(ModelHelper.encode(uri), connectionPool);
         final long requestId = connection.getFlow().asLong();
         
-        WireCommands.MergeSegmentsBatch request = new WireCommands.MergeSegmentsBatch(requestId,
-                qualifiedNameTarget, transactionNames, delegationToken);
+        WireCommands.MergeSegmentsBatch request = new WireCommands.MergeSegmentsBatch(requestId, qualifiedNameTarget, transactionNames, delegationToken);
 
         return sendRequest(connection, clientRequestId, request)
                 .thenCompose(r -> {
                     handleReply(clientRequestId, r, connection, qualifiedNameTarget, WireCommands.MergeSegmentsBatch.class, type);
-                    if (r instanceof WireCommands.NoSuchSegment) {
-                        WireCommands.NoSuchSegment reply = (WireCommands.NoSuchSegment) r;
-                        log.warn(clientRequestId, "Commit Transaction: Source segment {} not found.", 
-                                reply.getSegment());
-                        return CompletableFuture.completedFuture(transactionNames.stream().map(x -> -1L).collect(Collectors.toList()));
-                    } else {
-                        return CompletableFuture.completedFuture(((WireCommands.SegmentsMergedBatch) r).getNewTargetWriteOffset());
-                    }
+                    return CompletableFuture.completedFuture(((WireCommands.SegmentsMergedBatch) r).getNewTargetWriteOffset());
                 });
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -359,7 +359,7 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
         List<UUID> transactionsToCommit = txnRecord.getObject().getTransactionsToCommit();
         boolean noteTime = commitContext.writerMarks.size() > 0;
         Timer segMergeTimer = new Timer();
-        return streamMetadataTasks.notifyTxnsCommit(commitContext.scope, commitContext.stream, segments, transactionsToCommit, commitContext.context.getRequestId())
+        return streamMetadataTasks.mergeTxnSegmentsIntoStreamSegments(commitContext.scope, commitContext.stream, segments, transactionsToCommit, commitContext.context.getRequestId())
                 .thenCompose(segmentOffsets -> {
                     TransactionMetrics.getInstance().commitTransactionSegments(segMergeTimer.getElapsed());
                     if (noteTime) {
@@ -377,7 +377,6 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
                                 commitContext.stream, executor);
                     }
                     return CompletableFuture.completedFuture(null);
-
                 });
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -50,7 +50,6 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/CommitRequestHandler.java
@@ -36,6 +36,8 @@ import io.pravega.controller.store.stream.records.EpochRecord;
 import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
 import io.pravega.shared.controller.event.CommitEvent;
+import lombok.AllArgsConstructor;
+import lombok.val;
 import org.apache.curator.shaded.com.google.common.base.Strings;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +67,18 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
     private final BucketStore bucketStore;
     private final ScheduledExecutorService executor;
     private final BlockingQueue<CommitEvent> processedEvents;
+
+    /**
+     *  A helper class that holds variables related to Transaction commit processing.
+     * */
+    @AllArgsConstructor
+    private static class CommitTxnContext {
+        private final String scope;
+        private final String stream;
+        private final OperationContext context;
+        private final Map<UUID, String> txnIdToWriterId;
+        private final Map<String, TxnWriterMark> writerMarks;
+    }
 
     public CommitRequestHandler(final StreamMetadataStore streamMetadataStore,
                                 final StreamMetadataTasks streamMetadataTasks,
@@ -223,17 +237,15 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
                                             .thenCompose(records -> {
                                                 EpochRecord txnEpochRecord = records.get(0);
                                                 EpochRecord activeEpochRecord = records.get(1);
+                                                CommitTxnContext commitContext = new CommitTxnContext(scope, stream, context, txnIdToWriterId, writerMarks);
                                                 if (activeEpochRecord.getEpoch() == txnEpoch ||
                                                         activeEpochRecord.getReferenceEpoch() == txnEpochRecord.getReferenceEpoch()) {
                                                     // If active epoch's reference is same as transaction epoch,
                                                     // we can commit transactions immediately
-                                                    return commitTransactions(scope, stream, 
-                                                            new ArrayList<>(activeEpochRecord.getSegmentIds()), txnList, 
-                                                            context, txnIdToWriterId, writerMarks)
+                                                    return commitTransactions(commitContext, committingTxnsRecord, activeEpochRecord.getSegmentIds().stream().collect(Collectors.toList()))
                                                             .thenApply(txnOffsets -> committingTxnsRecord);
                                                 } else {
-                                                    return rollTransactions(scope, stream, txnEpochRecord, activeEpochRecord,
-                                                            committingTxnsRecord, context, txnIdToWriterId, writerMarks);
+                                                    return rollTransactions(commitContext, committingTxnsRecord, txnEpochRecord, activeEpochRecord);
                                                 }
                                             }));
                                 }
@@ -250,69 +262,60 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
                 }, executor);
     }
 
-    private CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> rollTransactions(
-            String scope, String stream, EpochRecord txnEpoch, EpochRecord activeEpoch,
-            VersionedMetadata<CommittingTransactionsRecord> existing, OperationContext context,
-            Map<UUID, String> txnIdToWriterId,
-            Map<String, TxnWriterMark> writerMarks) {
-        CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> future = CompletableFuture.completedFuture(existing);
-        if (!existing.getObject().isRollingTxnRecord()) {
-            future = future.thenCompose(
-                    x -> streamMetadataStore.startRollingTxn(scope, stream, activeEpoch.getEpoch(),
-                            existing, context, executor));
-        }
+    private CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> rollTransactions(CommitTxnContext commitContext, VersionedMetadata<CommittingTransactionsRecord> txnRecord, EpochRecord txnEpoch, EpochRecord activeEpoch) {
+        CompletableFuture<VersionedMetadata<CommittingTransactionsRecord>> future = CompletableFuture.completedFuture(txnRecord);
+        if (!txnRecord.getObject().isRollingTxnRecord()) {
+            future = future.thenCompose(record -> streamMetadataStore.startRollingTxn(commitContext.scope, commitContext.stream, activeEpoch.getEpoch(),
+                    record, commitContext.context, executor));
 
+        }
         return future.thenCompose(record -> {
             if (activeEpoch.getEpoch() > record.getObject().getCurrentEpoch()) {
                 return CompletableFuture.completedFuture(record);
             } else {
-                return runRollingTxn(scope, stream, txnEpoch, activeEpoch, record, context, txnIdToWriterId, writerMarks)
+                return runRollingTxn(commitContext, record, txnEpoch, activeEpoch)
                         .thenApply(v -> record);
             }
         });
     }
 
-    private CompletableFuture<Void> runRollingTxn(String scope, String stream, EpochRecord txnEpoch,
-                                                  EpochRecord activeEpoch, 
-                                                  VersionedMetadata<CommittingTransactionsRecord> existing,
-                                                  OperationContext context, Map<UUID, String> txnIdToWriterId,
-                                                  Map<String, TxnWriterMark> writerMarks) {
+    private CompletableFuture<Void> runRollingTxn(CommitTxnContext commitContext, VersionedMetadata<CommittingTransactionsRecord> txnRecord, EpochRecord txnEpoch, EpochRecord activeEpoch) {
         String delegationToken = streamMetadataTasks.retrieveDelegationToken();
         long timestamp = System.currentTimeMillis();
 
-        int newTxnEpoch = existing.getObject().getNewTxnEpoch();
-        int newActiveEpoch = existing.getObject().getNewActiveEpoch();
+        int newTxnEpoch = txnRecord.getObject().getNewTxnEpoch();
+        int newActiveEpoch = txnRecord.getObject().getNewActiveEpoch();
 
         List<Long> txnEpochDuplicate = txnEpoch.getSegments().stream().map(segment ->
                 computeSegmentId(segment.getSegmentNumber(), newTxnEpoch)).collect(Collectors.toList());
         List<Long> activeEpochSegmentIds = new ArrayList<>(activeEpoch.getSegmentIds());
         List<Long> activeEpochDuplicate = activeEpoch.getSegments().stream()
-                                                    .map(segment -> computeSegmentId(segment.getSegmentNumber(), 
-                                                            newActiveEpoch))
-                                                     .collect(Collectors.toList());
-        List<UUID> transactionsToCommit = existing.getObject().getTransactionsToCommit();
-        return copyTxnEpochSegmentsAndCommitTxns(scope, stream, transactionsToCommit, txnEpochDuplicate, context, txnIdToWriterId, writerMarks)
-                .thenCompose(v -> streamMetadataTasks.notifyNewSegments(scope, stream, activeEpochDuplicate, context,
-                        delegationToken, context.getRequestId()))
-                .thenCompose(v -> streamMetadataTasks.getSealedSegmentsSize(scope, stream, txnEpochDuplicate,
-                        delegationToken, context.getRequestId()))
+                .map(segment -> computeSegmentId(segment.getSegmentNumber(),
+                        newActiveEpoch))
+                .collect(Collectors.toList());
+        return copyTxnEpochSegmentsAndCommitTxns(commitContext, txnRecord, txnEpochDuplicate)
+                .thenCompose(v -> streamMetadataTasks.notifyNewSegments(commitContext.scope, commitContext.stream, activeEpochDuplicate, commitContext.context,
+                        delegationToken, commitContext.context.getRequestId()))
+                .thenCompose(v -> streamMetadataTasks.getSealedSegmentsSize(commitContext.scope, commitContext.stream, txnEpochDuplicate,
+                        delegationToken, commitContext.context.getRequestId()))
+
                 .thenCompose(sealedSegmentsMap -> {
-                    log.info(context.getRequestId(), 
-                            "Rolling transaction, created duplicate of active epoch {} for stream {}/{}", 
-                            activeEpoch, scope, stream);
-                    return streamMetadataStore.rollingTxnCreateDuplicateEpochs(scope, stream, sealedSegmentsMap,
-                            timestamp, existing, context, executor);
+                    log.info(commitContext.context.getRequestId(),
+                            "Rolling transaction, created duplicate of active epoch {} for stream {}/{}",
+                            activeEpoch, commitContext.scope, commitContext.stream);
+                    return streamMetadataStore.rollingTxnCreateDuplicateEpochs(commitContext.scope, commitContext.stream, sealedSegmentsMap,
+                            timestamp, txnRecord, commitContext.context, executor);
                 })
-                .thenCompose(v -> streamMetadataTasks.notifySealedSegments(scope, stream, activeEpochSegmentIds,
-                        delegationToken, context.getRequestId())
-                        .thenCompose(x -> streamMetadataTasks.getSealedSegmentsSize(scope, stream, activeEpochSegmentIds,
-                                delegationToken, context.getRequestId()))
+                .thenCompose(v -> streamMetadataTasks.notifySealedSegments(commitContext.scope, commitContext.stream, activeEpochSegmentIds,
+                                delegationToken, commitContext.context.getRequestId())
+                        .thenCompose(x -> streamMetadataTasks.getSealedSegmentsSize(commitContext.scope, commitContext.stream, activeEpochSegmentIds,
+                                delegationToken, commitContext.context.getRequestId()))
                         .thenCompose(sealedSegmentsMap -> {
-                            log.info(context.getRequestId(), 
+                            log.info(commitContext.context.getRequestId(),
                                     "Rolling transaction, sealed active epoch {} for stream {}/{}",
-                                    activeEpoch, scope, stream);
-                            return streamMetadataStore.completeRollingTxn(scope, stream, sealedSegmentsMap, existing,
-                                    context, executor);
+                                    activeEpoch, commitContext.scope, commitContext.stream);
+                            return streamMetadataStore.completeRollingTxn(commitContext.scope, commitContext.stream, sealedSegmentsMap, txnRecord,
+                                    commitContext.context, executor);
                         }));
     }
 
@@ -321,9 +324,7 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
      * This method creates duplicate segments for transaction epoch. It then merges all transactions from the list into
      * those duplicate segments.
      */
-    private CompletableFuture<Void> copyTxnEpochSegmentsAndCommitTxns(String scope, String stream, List<UUID> transactionsToCommit,
-                                                                      List<Long> segmentIds, OperationContext context, Map<UUID, String> txnIdToWriterId,
-                                                                                            Map<String, TxnWriterMark> writerMarks) {
+    private CompletableFuture<Void> copyTxnEpochSegmentsAndCommitTxns(CommitTxnContext commitContext, VersionedMetadata<CommittingTransactionsRecord> txnRecord, List<Long> segmentIds) {
         // 1. create duplicate segments
         // 2. merge transactions in those segments
         // 3. seal txn epoch segments
@@ -331,54 +332,53 @@ public class CommitRequestHandler extends AbstractRequestProcessor<CommitEvent> 
         CompletableFuture<Void> createSegmentsFuture = Futures.allOf(segmentIds.stream().map(segment -> {
             // Use fixed scaling policy for these segments as they are created, merged into and sealed and are not
             // supposed to auto scale.
-            return streamMetadataStore.getConfiguration(scope, stream, context, executor).thenCompose(config ->
-                    streamMetadataTasks.notifyNewSegment(scope, stream, segment, ScalingPolicy.fixed(1), delegationToken,
-                    context.getRequestId(), config.getRolloverSizeBytes()));
+            return streamMetadataStore.getConfiguration(commitContext.scope, commitContext.stream, commitContext.context, executor)
+                    .thenCompose(config -> streamMetadataTasks.notifyNewSegment(commitContext.scope, commitContext.stream, segment, ScalingPolicy.fixed(1), delegationToken,
+                            commitContext.context.getRequestId(), config.getRolloverSizeBytes()));
+
         }).collect(Collectors.toList()));
 
         return createSegmentsFuture
                 .thenCompose(v -> {
-                    log.info(context.getRequestId(), 
-                            "Rolling transaction, successfully created duplicate txn epoch {} for stream {}/{}", 
-                            segmentIds, scope, stream);
+                    log.info(commitContext.context.getRequestId(),
+                            "Rolling transaction, successfully created duplicate txn epoch {} for stream {}/{}",
+                            segmentIds, commitContext.scope, commitContext.stream);
                     // now commit transactions into these newly created segments
-                    return commitTransactions(scope, stream, segmentIds, transactionsToCommit, context, txnIdToWriterId, writerMarks);
-                })
-                .thenAccept(v -> streamMetadataTasks.notifySealedSegments(scope, stream, segmentIds, delegationToken,
-                        context.getRequestId()));
+                    return commitTransactions(commitContext, txnRecord, segmentIds);
+                }).thenAccept(v -> streamMetadataTasks.notifySealedSegments(commitContext.scope, commitContext.stream, segmentIds, delegationToken,
+                        commitContext.context.getRequestId()));
     }
 
     /**
      * This method loops over each transaction in the list, and commits them in order
      * At the end of this method's execution, all transactions in the list would have committed into given list of segments.
      */
-    private CompletableFuture<Void> commitTransactions(String scope, String stream, List<Long> segments,
-                                                                             List<UUID> transactionsToCommit, OperationContext context,
-                                                                             Map<UUID, String> txnIdToWriterId,
-                                                                             Map<String, TxnWriterMark> writerMarks) {
+    private CompletableFuture<Void> commitTransactions(CommitTxnContext commitContext, VersionedMetadata<CommittingTransactionsRecord> txnRecord, List<Long> segments) {
         // Chain all transaction commit futures one after the other. This will ensure that order of commit
         // if honoured and is based on the order in the list.
-        boolean noteTime = writerMarks.size() > 0;
-        CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
-        for (UUID txnId : transactionsToCommit) {
-            log.info(context.getRequestId(), "Committing transaction {} on stream {}/{}", txnId, scope, stream);
-            // commit transaction in segment store
-            future = future
-                    .thenCompose(v -> streamMetadataTasks.notifyTxnCommit(scope, stream, segments, txnId, context.getRequestId()))
-                    .thenAccept(txnOffsets -> {
-                        String writerId = txnIdToWriterId.get(txnId);
-                        if (!Strings.isNullOrEmpty(writerId) && writerMarks.get(writerId).getTransactionId().equals(txnId)) {
-                            TxnWriterMark mark = writerMarks.get(writerId);
-                            writerMarks.put(writerId, new TxnWriterMark(mark.getTimestamp(), txnOffsets, mark.getTransactionId()));
+        List<UUID> transactionsToCommit = txnRecord.getObject().getTransactionsToCommit();
+        boolean noteTime = commitContext.writerMarks.size() > 0;
+        Timer segMergeTimer = new Timer();
+        return streamMetadataTasks.notifyTxnsCommit(commitContext.scope, commitContext.stream, segments, transactionsToCommit, commitContext.context.getRequestId())
+                .thenCompose(segmentOffsets -> {
+                    TransactionMetrics.getInstance().commitTransactionSegments(segMergeTimer.getElapsed());
+                    if (noteTime) {
+                        for (int i = 0; i < transactionsToCommit.size(); i++) {
+                            int index = i;
+                            val txnOffsets = segmentOffsets.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, x -> x.getValue().get(index)));
+                            val txnId = transactionsToCommit.get(i);
+                            String writerId = commitContext.txnIdToWriterId.get(txnId);
+                            if (!Strings.isNullOrEmpty(writerId) && commitContext.writerMarks.get(writerId).getTransactionId().equals(txnId)) {
+                                TxnWriterMark mark = commitContext.writerMarks.get(writerId);
+                                commitContext.writerMarks.put(writerId, new TxnWriterMark(mark.getTimestamp(), txnOffsets, mark.getTransactionId()));
                             }
                         }
-            );
-        }
-        return future.thenAcceptAsync(x -> {
-            if (noteTime) {
-                bucketStore.addStreamToBucketStore(BucketStore.ServiceType.WatermarkingService, scope, stream, executor);
-            }
-        });
+                        return bucketStore.addStreamToBucketStore(BucketStore.ServiceType.WatermarkingService, commitContext.scope,
+                                commitContext.stream, executor);
+                    }
+                    return CompletableFuture.completedFuture(null);
+
+                });
     }
 
     /**

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -1973,6 +1973,29 @@ public class StreamMetadataTasks extends TaskBase {
         }
     }
 
+    public CompletableFuture<Map<Long, List<Long>>> notifyTxnsCommit(final String scope, final String stream,
+                                                                     final List<Long> segments, final List<UUID> txnId, long requestId) {
+        Timer timer = new Timer();
+        return Futures.allOfWithResults(segments.stream()
+                        .collect(Collectors.toMap(x -> x, x -> notifyTxnsCommit(scope, stream, x, txnId, requestId))))
+                .whenComplete((r, e) -> {
+                    if (e != null) {
+                        Duration elapsed = timer.getElapsed();
+                        TransactionMetrics.getInstance().commitTransactionSegments(elapsed);
+                    }
+                });
+    }
+
+    private CompletableFuture<List<Long>> notifyTxnsCommit(final String scope, final String stream,
+                                                           final long segmentNumber, final List<UUID> txnId, long requestId) {
+        return TaskStepsRetryHelper.withRetries(() -> segmentHelper.commitTransactions(scope,
+                stream,
+                segmentNumber,
+                segmentNumber,
+                txnId,
+                this.retrieveDelegationToken(), requestId), executor);
+    }
+
     public CompletableFuture<Map<Long, Long>> notifyTxnCommit(final String scope, final String stream,
                                                    final List<Long> segments, final UUID txnId, long requestId) {
         Timer timer = new Timer();

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -1994,7 +1994,7 @@ public class StreamMetadataTasks extends TaskBase {
                         WireCommandFailedException wcfe = (WireCommandFailedException) ex;
                         if (WireCommandFailedException.Reason.SegmentDoesNotExist.equals(wcfe.getReason())) {
                             final String qualifiedSegmentName = getQualifiedStreamSegmentName(scope, stream, segmentNumber);
-                            String message = String.format("Segment Merge failed as source segment [%s] was not found.", qualifiedSegmentName);
+                            String message = String.format("Segment Merge failed as target segment [%s] was not found.", qualifiedSegmentName);
                             throw new IllegalStateException(message);
                         }
                     }

--- a/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
@@ -81,13 +81,13 @@ public class SegmentHelperMock {
         doReturn(CompletableFuture.completedFuture(txnStatus)).when(helper).abortTransaction(
                 anyString(), anyString(), anyLong(), any(), any(), anyLong());
 
-        doReturn(CompletableFuture.completedFuture(0L)).when(helper).commitTransaction(
+        doReturn(CompletableFuture.completedFuture(0L)).when(helper).mergeTxnSegments(
                 anyString(), anyString(), anyLong(), anyLong(), any(), any(), anyLong());
         
         doAnswer(x -> {
             List<Long> list = ((List<UUID>) x.getArgument(4)).stream().map(z -> 0L).collect(Collectors.toList());
             return CompletableFuture.completedFuture(list);
-        }).when(helper).commitTransactions(
+        }).when(helper).mergeTxnSegments(
                 anyString(), anyString(), anyLong(), anyLong(), any(), any(), anyLong());
 
         doReturn(CompletableFuture.completedFuture(null)).when(helper).updatePolicy(
@@ -129,8 +129,8 @@ public class SegmentHelperMock {
         doReturn(Futures.failedFuture(new RuntimeException())).when(helper).abortTransaction(
                 anyString(), anyString(), anyLong(), any(), any(), anyLong());
 
-        doReturn(Futures.failedFuture(new RuntimeException())).when(helper).commitTransaction(
-                anyString(), anyString(), anyLong(), anyLong(), any(), any(), anyLong());
+        doReturn(Futures.failedFuture(new RuntimeException())).when(helper).mergeTxnSegments(
+                anyString(), anyString(), anyLong(), anyLong(), any(), anyString(), anyLong());
 
         doReturn(Futures.failedFuture(new RuntimeException())).when(helper).updatePolicy(
                 anyString(), anyString(), any(), anyLong(), any(), anyLong());

--- a/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/SegmentHelperMock.java
@@ -41,6 +41,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
@@ -81,6 +82,12 @@ public class SegmentHelperMock {
                 anyString(), anyString(), anyLong(), any(), any(), anyLong());
 
         doReturn(CompletableFuture.completedFuture(0L)).when(helper).commitTransaction(
+                anyString(), anyString(), anyLong(), anyLong(), any(), any(), anyLong());
+        
+        doAnswer(x -> {
+            List<Long> list = ((List<UUID>) x.getArgument(4)).stream().map(z -> 0L).collect(Collectors.toList());
+            return CompletableFuture.completedFuture(list);
+        }).when(helper).commitTransactions(
                 anyString(), anyString(), anyLong(), anyLong(), any(), any(), anyLong());
 
         doReturn(CompletableFuture.completedFuture(null)).when(helper).updatePolicy(

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -292,7 +292,7 @@ public class SegmentHelperTest extends ThreadPooledTestSuite {
         CompletableFuture<List<Long>> result = helper.mergeTxnSegments(scope, stream, targetSegmentId, sourceSegmentId,
                 txnIdList, delegationToken, System.nanoTime());
         requestId = ((MockConnection) (factory.connection)).getRequestId();
-        factory.rp.process(new WireCommands.SegmentsMergedBatch(requestId, getQualifiedStreamSegmentName(scope, stream, targetSegmentId), List.of(getQualifiedStreamSegmentName(scope, stream, sourceSegmentId)), List.of(10L)));
+        factory.rp.process(new WireCommands.SegmentsBatchMerged(requestId, getQualifiedStreamSegmentName(scope, stream, targetSegmentId), List.of(getQualifiedStreamSegmentName(scope, stream, sourceSegmentId)), List.of(10L)));
         result.join();
 
         CompletableFuture<List<Long>> resultException =  helper.mergeTxnSegments(scope, stream, targetSegmentId, sourceSegmentId,

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -268,10 +268,19 @@ public class SegmentHelperTest extends ThreadPooledTestSuite {
     @Test
     public void commitTransaction() {
         MockConnectionFactory factory = new MockConnectionFactory();
+        String scope = "testScope";
+        String stream = "testStream";
+        String delegationToken = "";
+        long sourceSegmentId = 1L;
+        long targetSegmentId = 1L;
+        UUID txnId = new UUID(0, 0L);
+        List<UUID> txnIdList = List.of(txnId);
+
         @Cleanup
         SegmentHelper helper = new SegmentHelper(factory, new MockHostControllerStore(), executorService());
-        CompletableFuture<Long> retVal = helper.commitTransaction("", "", 0L, 
-                0L, new UUID(0, 0L), "", System.nanoTime());
+
+        CompletableFuture<List<Long>> retVal = helper.mergeTxnSegments(scope, stream, targetSegmentId,
+                sourceSegmentId, txnIdList, delegationToken, System.nanoTime());
         long requestId = ((MockConnection) (factory.connection)).getRequestId();
         factory.rp.process(new WireCommands.AuthTokenCheckFailed(requestId, "SomeException"));
         AssertExtensions.assertThrows("",
@@ -280,20 +289,22 @@ public class SegmentHelperTest extends ThreadPooledTestSuite {
                         && ex.getCause() instanceof AuthenticationException
         );
 
-        CompletableFuture<Long> result = helper.commitTransaction("", "", 0L, 0L,
-                new UUID(0L, 0L), "", System.nanoTime());
+        CompletableFuture<List<Long>> result = helper.mergeTxnSegments(scope, stream, targetSegmentId, sourceSegmentId,
+                txnIdList, delegationToken, System.nanoTime());
         requestId = ((MockConnection) (factory.connection)).getRequestId();
-        factory.rp.process(new WireCommands.SegmentsMerged(requestId, getQualifiedStreamSegmentName("", "", 0L), getQualifiedStreamSegmentName("", "", 0L), 0L));
+        factory.rp.process(new WireCommands.SegmentsMergedBatch(requestId, getQualifiedStreamSegmentName(scope, stream, targetSegmentId), List.of(getQualifiedStreamSegmentName(scope, stream, sourceSegmentId)), List.of(10L)));
         result.join();
 
-        result = helper.commitTransaction("", "", 0L, 0L, 
-                new UUID(0L, 0L), "", System.nanoTime());
+        CompletableFuture<List<Long>> resultException =  helper.mergeTxnSegments(scope, stream, targetSegmentId, sourceSegmentId,
+                txnIdList, delegationToken, System.nanoTime());
         requestId = ((MockConnection) (factory.connection)).getRequestId();
-        factory.rp.process(new WireCommands.NoSuchSegment(requestId, getQualifiedStreamSegmentName("", "", 0L), "", 0L));
-        result.join();
+        factory.rp.process(new WireCommands.NoSuchSegment(requestId, getQualifiedStreamSegmentName(scope, stream, targetSegmentId), "", 0L));
+        AssertExtensions.assertThrows("",
+                () -> resultException.join(),
+                ex -> ex instanceof WireCommandFailedException
+                        && ((WireCommandFailedException)ex).getReason().equals(WireCommandFailedException.Reason.SegmentDoesNotExist));
 
-        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.commitTransaction("", "", 0L, 
-                0L, new UUID(0, 0L), "", System.nanoTime());
+        Supplier<CompletableFuture<?>> futureSupplier = () -> helper.mergeTxnSegments(scope, stream, targetSegmentId, sourceSegmentId, txnIdList, delegationToken, System.nanoTime());
         validateProcessingFailureCFE(factory, futureSupplier);
 
         testConnectionFailure(factory, futureSupplier);

--- a/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/SegmentHelperTest.java
@@ -302,7 +302,7 @@ public class SegmentHelperTest extends ThreadPooledTestSuite {
         AssertExtensions.assertThrows("",
                 () -> resultException.join(),
                 ex -> ex instanceof WireCommandFailedException
-                        && ((WireCommandFailedException)ex).getReason().equals(WireCommandFailedException.Reason.SegmentDoesNotExist));
+                        && ((WireCommandFailedException) ex).getReason().equals(WireCommandFailedException.Reason.SegmentDoesNotExist));
 
         Supplier<CompletableFuture<?>> futureSupplier = () -> helper.mergeTxnSegments(scope, stream, targetSegmentId, sourceSegmentId, txnIdList, delegationToken, System.nanoTime());
         validateProcessingFailureCFE(factory, futureSupplier);

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -51,7 +51,6 @@ import io.pravega.controller.store.stream.State;
 import io.pravega.controller.store.stream.StoreException;
 import io.pravega.controller.store.stream.StreamMetadataStore;
 import io.pravega.controller.store.stream.StreamStoreFactory;
-import io.pravega.controller.store.stream.TxnStatus;
 import io.pravega.controller.store.stream.VersionedTransactionData;
 import io.pravega.controller.store.stream.records.CommittingTransactionsRecord;
 import io.pravega.controller.store.stream.records.EpochRecord;
@@ -92,7 +91,6 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -553,14 +553,16 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
                         recordStatForTransaction(r, mergeSegments.getTargetSegmentId());
                         return CompletableFuture.completedFuture(r.getTargetSegmentLength());
                     }
-                })).collect(toList()))
-               .thenAccept(mergeResults -> {
-                   connection.send(new WireCommands.SegmentsMergedBatch(mergeSegments.getRequestId(),
+                })).collect(Collectors.toUnmodifiableList())).thenAccept(mergeResults -> {
+                    connection.send(new WireCommands.SegmentsMergedBatch(mergeSegments.getRequestId(),
                            mergeSegments.getTargetSegmentId(),
                            sources,
                            mergeResults));
                })
-               .exceptionally(e -> handleException(mergeSegments.getRequestId(), mergeSegments.getTargetSegmentId(), operation, e));
+               .exceptionally(e -> {
+                   log.debug("error");
+                   return handleException(mergeSegments.getRequestId(), mergeSegments.getTargetSegmentId(), operation, e);
+               });
     }
 
     @Override

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -77,7 +77,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import net.jcip.annotations.Immutable;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessorTest.java
@@ -463,7 +463,7 @@ public class PravegaRequestProcessorTest {
 
         List<String> txnSegmentNames = ImmutableList.of(transaction1SegmentName, transaction2SegmentName, transaction3SegmentName);
         processor.mergeSegmentsBatch(new WireCommands.MergeSegmentsBatch(requestId, streamSegmentName, txnSegmentNames, ""));
-        order.verify(connection).send(new WireCommands.SegmentsMergedBatch(requestId, streamSegmentName, txnSegmentNames, ImmutableList.of(2L, 5L, 9L)));
+        order.verify(connection).send(new WireCommands.SegmentsBatchMerged(requestId, streamSegmentName, txnSegmentNames, ImmutableList.of(2L, 5L, 9L)));
 
         // verify that txn segments are merged and so do not exist any more
         processor.getStreamSegmentInfo(new WireCommands.GetStreamSegmentInfo(requestId, transaction1SegmentName, ""));
@@ -502,7 +502,7 @@ public class PravegaRequestProcessorTest {
         store.sealStreamSegment(txnName, Duration.ZERO).join();
 
         processor.mergeSegmentsBatch(new WireCommands.MergeSegmentsBatch(requestId, streamSegmentName, ImmutableList.of(transactionSegmentName), ""));
-        order.verify(connection).send(new WireCommands.SegmentsMergedBatch(requestId, streamSegmentName, ImmutableList.of(transactionSegmentName), ImmutableList.of(11L)));
+        order.verify(connection).send(new WireCommands.SegmentsBatchMerged(requestId, streamSegmentName, ImmutableList.of(transactionSegmentName), ImmutableList.of(11L)));
         processor.getStreamSegmentInfo(new WireCommands.GetStreamSegmentInfo(requestId, transactionSegmentName, ""));
         order.verify(connection).send(new WireCommands.NoSuchSegment(requestId, NameUtils.getTransactionNameFromId(streamSegmentName, txnid), "", -1L));
 
@@ -535,7 +535,7 @@ public class PravegaRequestProcessorTest {
         processor.createSegment(new WireCommands.CreateSegment(requestId, transactionName, WireCommands.CreateSegment.NO_SCALE, 0, "", 0));
         order.verify(connection).send(new WireCommands.SegmentCreated(requestId, transactionName));
         processor.mergeSegmentsBatch(new WireCommands.MergeSegmentsBatch(requestId, streamSegmentName, ImmutableList.of(transactionName), ""));
-        order.verify(connection).send(new WireCommands.SegmentsMergedBatch(requestId, streamSegmentName, ImmutableList.of(transactionName), List.of(0L)));
+        order.verify(connection).send(new WireCommands.SegmentsBatchMerged(requestId, streamSegmentName, ImmutableList.of(transactionName), List.of(0L)));
     }
 
     @Test(timeout = 20000)

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
@@ -82,6 +82,11 @@ public abstract class DelegatingRequestProcessor implements RequestProcessor {
     }
 
     @Override
+    public void mergeSegmentsBatch(WireCommands.MergeSegmentsBatch mergeSegments) {
+        getNextRequestProcessor().mergeSegmentsBatch(mergeSegments);
+    }
+
+    @Override
     public void sealSegment(SealSegment sealSegment) {
         getNextRequestProcessor().sealSegment(sealSegment);
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -142,6 +142,11 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
     }
 
     @Override
+    public void segmentsMergedBatch(WireCommands.SegmentsMergedBatch segmentsMerged) {
+        throw new IllegalStateException("Unexpected operation: " + segmentsMerged);
+    }
+
+    @Override
     public void segmentSealed(SegmentSealed segmentSealed) {
         throw new IllegalStateException("Unexpected operation: " + segmentSealed);
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -142,7 +142,7 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
     }
 
     @Override
-    public void segmentsMergedBatch(WireCommands.SegmentsMergedBatch segmentsMerged) {
+    public void segmentsMergedBatch(WireCommands.SegmentsBatchMerged segmentsMerged) {
         throw new IllegalStateException("Unexpected operation: " + segmentsMerged);
     }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -142,7 +142,7 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
     }
 
     @Override
-    public void segmentsMergedBatch(WireCommands.SegmentsBatchMerged segmentsMerged) {
+    public void segmentsBatchMerged(WireCommands.SegmentsBatchMerged segmentsMerged) {
         throw new IllegalStateException("Unexpected operation: " + segmentsMerged);
     }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
@@ -126,6 +126,11 @@ public class FailingRequestProcessor implements RequestProcessor {
     }
 
     @Override
+    public void mergeSegmentsBatch(WireCommands.MergeSegmentsBatch mergeSegments) {
+        throw new IllegalStateException("Unexpected operation");
+    }
+
+    @Override
     public void sealSegment(SealSegment sealSegment) {
         throw new IllegalStateException("Unexpected operation");
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -62,7 +62,7 @@ public interface ReplyProcessor {
 
     void segmentsMerged(WireCommands.SegmentsMerged segmentsMerged);
     
-    void segmentsMergedBatch(WireCommands.SegmentsMergedBatch segmentsMerged);
+    void segmentsMergedBatch(WireCommands.SegmentsBatchMerged segmentsMerged);
 
     void segmentSealed(WireCommands.SegmentSealed segmentSealed);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -62,7 +62,7 @@ public interface ReplyProcessor {
 
     void segmentsMerged(WireCommands.SegmentsMerged segmentsMerged);
     
-    void segmentsMergedBatch(WireCommands.SegmentsBatchMerged segmentsMerged);
+    void segmentsBatchMerged(WireCommands.SegmentsBatchMerged segmentsMerged);
 
     void segmentSealed(WireCommands.SegmentSealed segmentSealed);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -61,6 +61,8 @@ public interface ReplyProcessor {
     void segmentCreated(WireCommands.SegmentCreated segmentCreated);
 
     void segmentsMerged(WireCommands.SegmentsMerged segmentsMerged);
+    
+    void segmentsMergedBatch(WireCommands.SegmentsMergedBatch segmentsMerged);
 
     void segmentSealed(WireCommands.SegmentSealed segmentSealed);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
@@ -54,6 +54,8 @@ public interface RequestProcessor {
     void createSegment(CreateSegment createSegment);
 
     void mergeSegments(MergeSegments mergeSegments);
+    
+    void mergeSegmentsBatch(WireCommands.MergeSegmentsBatch mergeSegments);
 
     void sealSegment(SealSegment sealSegment);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -117,6 +117,8 @@ public enum WireCommandType {
     READ_TABLE_ENTRIES_DELTA(88, WireCommands.ReadTableEntriesDelta::readFrom),
 
     CONDITIONAL_BLOCK_END(89, WireCommands.ConditionalBlockEnd::readFrom),
+    MERGE_SEGMENTS_BATCH(90, WireCommands.MergeSegmentsBatch::readFrom),
+    SEGMENTS_MERGED_BATCH(91, WireCommands.SegmentsMergedBatch::readFrom),
 
     KEEP_ALIVE(100, WireCommands.KeepAlive::readFrom);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -118,7 +118,7 @@ public enum WireCommandType {
 
     CONDITIONAL_BLOCK_END(89, WireCommands.ConditionalBlockEnd::readFrom),
     MERGE_SEGMENTS_BATCH(90, WireCommands.MergeSegmentsBatch::readFrom),
-    SEGMENTS_MERGED_BATCH(91, WireCommands.SegmentsMergedBatch::readFrom),
+    SEGMENTS_BATCH_MERGED(91, WireCommands.SegmentsBatchMerged::readFrom),
 
     KEEP_ALIVE(100, WireCommands.KeepAlive::readFrom);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -1533,7 +1533,7 @@ public final class WireCommands {
 
         @Override
         public void process(ReplyProcessor cp) {
-            cp.segmentsMergedBatch(this);
+            cp.segmentsBatchMerged(this);
         }
 
         @Override

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -1485,6 +1485,83 @@ public final class WireCommands {
     }
 
     @Data
+    public static final class MergeSegmentsBatch implements Request, WireCommand {
+        final WireCommandType type = WireCommandType.MERGE_SEGMENTS_BATCH;
+        final long requestId;
+        final String target;
+        final List<String> sources;
+        @ToString.Exclude
+        final String delegationToken;
+
+        @Override
+        public void process(RequestProcessor cp) {
+            cp.mergeSegmentsBatch(this);
+        }
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeLong(requestId);
+            out.writeUTF(target);
+            out.writeInt(sources.size());
+            for (int i = 0; i < sources.size(); i++) {
+                out.writeUTF(sources.get(i));
+            }
+            out.writeUTF(delegationToken == null ? "" : delegationToken);
+        }
+
+        public static WireCommand readFrom(DataInput in, int length) throws IOException {
+            long requestId = in.readLong();
+            String target = in.readUTF();
+            int sourceCount = in.readInt();
+            List<String> sources = new ArrayList<>(sourceCount);
+            for (int i = 0; i < sourceCount; i++) {
+                sources.add(in.readUTF());
+            }
+            String delegationToken = in.readUTF();
+            return new MergeSegmentsBatch(requestId, target, sources, delegationToken);
+        }
+    }
+
+    @Data
+    public static final class SegmentsMergedBatch implements Reply, WireCommand {
+        final WireCommandType type = WireCommandType.SEGMENTS_MERGED_BATCH;
+        final long requestId;
+        final String target;
+        final List<String> sources;
+        final List<Long> newTargetWriteOffset;
+
+        @Override
+        public void process(ReplyProcessor cp) {
+            cp.segmentsMergedBatch(this);
+        }
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeLong(requestId);
+            out.writeUTF(target);
+            out.writeInt(sources.size());
+            for (int i = 0; i < sources.size(); i++) {
+                out.writeUTF(sources.get(i));
+                out.writeLong(newTargetWriteOffset.get(i));
+            }
+        }
+
+        public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
+            long requestId = in.readLong();
+            String target = in.readUTF();
+            int count = in.readInt();
+            List<String> sources = new ArrayList<>(count);
+            List<Long> offsets = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                sources.add(in.readUTF());
+                offsets.add(in.readLong());
+            }
+
+            return new SegmentsMergedBatch(requestId, target, sources, offsets);
+        }
+    }
+
+    @Data
     public static final class SealSegment implements Request, WireCommand {
         final WireCommandType type = WireCommandType.SEAL_SEGMENT;
         final long requestId;

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -1488,8 +1488,8 @@ public final class WireCommands {
     public static final class MergeSegmentsBatch implements Request, WireCommand {
         final WireCommandType type = WireCommandType.MERGE_SEGMENTS_BATCH;
         final long requestId;
-        final String target;
-        final List<String> sources;
+        final String targetSegmentId;
+        final List<String> sourceSegmentIds;
         @ToString.Exclude
         final String delegationToken;
 
@@ -1501,10 +1501,10 @@ public final class WireCommands {
         @Override
         public void writeFields(DataOutput out) throws IOException {
             out.writeLong(requestId);
-            out.writeUTF(target);
-            out.writeInt(sources.size());
-            for (int i = 0; i < sources.size(); i++) {
-                out.writeUTF(sources.get(i));
+            out.writeUTF(targetSegmentId);
+            out.writeInt(sourceSegmentIds.size());
+            for (int i = 0; i < sourceSegmentIds.size(); i++) {
+                out.writeUTF(sourceSegmentIds.get(i));
             }
             out.writeUTF(delegationToken == null ? "" : delegationToken);
         }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -63,7 +63,7 @@ import static io.netty.buffer.Unpooled.wrappedBuffer;
  * Incompatible changes should instead create a new WireCommand object.
  */
 public final class WireCommands {
-    public static final int WIRE_VERSION = 14;
+    public static final int WIRE_VERSION = 15;
     public static final int OLDEST_COMPATIBLE_VERSION = 5;
     public static final int TYPE_SIZE = 4;
     public static final int TYPE_PLUS_LENGTH_SIZE = 8;
@@ -1523,11 +1523,12 @@ public final class WireCommands {
     }
 
     @Data
-    public static final class SegmentsMergedBatch implements Reply, WireCommand {
-        final WireCommandType type = WireCommandType.SEGMENTS_MERGED_BATCH;
+    public static final class SegmentsBatchMerged implements Reply, WireCommand {
+        final WireCommandType type = WireCommandType.SEGMENTS_BATCH_MERGED;
         final long requestId;
         final String target;
         final List<String> sources;
+        /** newTargetWriteOffset may not be the exact offset on the Segment post merge but just some offset following the merge.**/
         final List<Long> newTargetWriteOffset;
 
         @Override
@@ -1557,7 +1558,7 @@ public final class WireCommands {
                 offsets.add(in.readLong());
             }
 
-            return new SegmentsMergedBatch(requestId, target, sources, offsets);
+            return new SegmentsBatchMerged(requestId, target, sources, offsets);
         }
     }
 

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -654,10 +654,10 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
     }
 
     @Test
-    public void testSegmentsMergedBatch() throws IOException {
+    public void testSegmentsBatchMerged() throws IOException {
         List<String> txnSegmentIds = ImmutableList.of("txn1seg0", "txn2seg0");
         String streamSegmentId = "seg0";
-        testCommand(new WireCommands.SegmentsMergedBatch(l, streamSegmentId, txnSegmentIds, ImmutableList.of(10L, 11L)));
+        testCommand(new WireCommands.SegmentsBatchMerged(l, streamSegmentId, txnSegmentIds, ImmutableList.of(10L, 11L)));
     }
 
     @Test

--- a/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/protocol/netty/WireCommandsTest.java
@@ -15,6 +15,7 @@
  */
 package io.pravega.shared.protocol.netty;
 
+import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.pravega.common.io.ByteBufferOutputStream;
@@ -643,6 +644,20 @@ public class WireCommandsTest extends LeakDetectorTestSuite {
         cmd.process(rp);
         verify(rp, times(1)).createTransientSegment(cmd);
         testCommand(cmd);
+    }
+
+    @Test
+    public void testMergeSegmentsBatch() throws IOException {
+        List<String> txnSegmentIds = ImmutableList.of("txn1seg0", "txn2seg0");
+        String streamSegmentId = "seg0";
+        testCommand(new WireCommands.MergeSegmentsBatch(l, streamSegmentId, txnSegmentIds, ""));
+    }
+
+    @Test
+    public void testSegmentsMergedBatch() throws IOException {
+        List<String> txnSegmentIds = ImmutableList.of("txn1seg0", "txn2seg0");
+        String streamSegmentId = "seg0";
+        testCommand(new WireCommands.SegmentsMergedBatch(l, streamSegmentId, txnSegmentIds, ImmutableList.of(10L, 11L)));
     }
 
     @Test

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpWithTxnTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpWithTxnTest.java
@@ -37,7 +37,6 @@ import io.pravega.client.stream.impl.UTF8StringSerializer;
 import io.pravega.client.stream.mock.MockClientFactory;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.util.Retry;
-import io.pravega.controller.store.stream.TxnStatus;
 import io.pravega.controller.util.Config;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
@@ -55,9 +54,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.pravega.test.integration.utils.IntegerSerializer;
 import lombok.Cleanup;
-import lombok.CustomLog;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.curator.test.TestingServer;

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpWithTxnTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpWithTxnTest.java
@@ -53,7 +53,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;

--- a/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpWithTxnTest.java
+++ b/test/integration/src/main/java/io/pravega/test/integration/demo/EndToEndAutoScaleUpWithTxnTest.java
@@ -37,6 +37,7 @@ import io.pravega.client.stream.impl.UTF8StringSerializer;
 import io.pravega.client.stream.mock.MockClientFactory;
 import io.pravega.common.concurrent.ExecutorServiceHelpers;
 import io.pravega.common.util.Retry;
+import io.pravega.controller.store.stream.TxnStatus;
 import io.pravega.controller.util.Config;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
@@ -53,7 +54,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.pravega.test.integration.utils.IntegerSerializer;
 import lombok.Cleanup;
+import lombok.CustomLog;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.curator.test.TestingServer;
@@ -199,3 +203,4 @@ public class EndToEndAutoScaleUpWithTxnTest {
         });
     }
 }
+


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
Changes to Controller for pipelining & batch merging of transactional segments to a target Stream segment during commit processing.

**Purpose of the change**  
Fixes #6110

**What the code does**  
_Classes with major changes:_
1. CommitRequestHandler - changes to `commitTransaction` method to enable batch merge of transactional segments.
2. WireCommands - Added a new wire command `MergeSegmentsBatch` and its response command `SegmentsMergedBatch`.
3. PravegaPrequestProcessor - A new method `mergeSegmentsBatch` added that enables merging of a batch of segments **in-order** to a target segment.
4. SegmentHelper - A new `commitTransactions` method added for batch merging of transactional segments.

**How to verify it**  
All tests should pass
