### PR TITLE
Issue 6406: Pravega CLI commands that allow updating values in Controller Metadata tables

### DIFF
--- a/cli/admin/README.md
+++ b/cli/admin/README.md
@@ -106,7 +106,7 @@ All available commands:
 	controller list-readergroups <scope-name>: Lists all the existing ReaderGroups in a given Scope.
 	controller list-scopes : Lists all the existing scopes in the system.
 	controller list-streams <scope-name>: Lists all the existing Streams in a given Scope.
-	controller-metadata get <qualified-table-segment-name> <key> <json-file[OPTIONAL]> <segmentstore-endpoint>: Get the controller metadata entry for the given key in the table.
+	controller-metadata get <qualified-table-segment-name> <key> <segmentstore-endpoint> <json-file[OPTIONAL]>: Get the controller metadata entry for the given key in the table.
 	controller-metadata list-entries <qualified-table-segment-name> <entry-count> <segmentstore-endpoint>: List at most the required number of entries from the controller metadata table. Unsupported for stream metadata tables.
 	controller-metadata list-keys <qualified-table-segment-name> <key-count> <segmentstore-endpoint>: List at most the required number of keys from the controller metadata table.
 	controller-metadata tables-info : List all the controller metadata tables.
@@ -228,7 +228,7 @@ Once the config file is updated, the Pravega Admin CLI will be able to connect t
 
 The following commands are available for dealing with controller metadata:
 ```
-controller-metadata get <qualified-table-segment-name> <key> <json-file[OPTIONAL]> <segmentstore-endpoint>: Get the controller metadata entry for the given key in the table.
+controller-metadata get <qualified-table-segment-name> <key> <segmentstore-endpoint> <json-file[OPTIONAL]>: Get the controller metadata entry for the given key in the table.
 controller-metadata list-entries <qualified-table-segment-name> <entry-count> <segmentstore-endpoint>: List at most the required number of entries from the controller metadata table. Unsupported for stream metadata tables.
 controller-metadata list-keys <qualified-table-segment-name> <key-count> <segmentstore-endpoint>: List at most the required number of keys from the controller metadata table.
 controller-metadata tables-info : List all the controller metadata tables.
@@ -271,121 +271,70 @@ The records/values can be queried from these tables using the `get` command. Thi
 Based on the arguments provided, the record can be either, output to the console as a user-friendly string, or saved to a file in JSON format, i.e., 
 if the optional JSON file argument is provided.
 ```
-> controller-metadata get _system/_tables/testScope/testStream/metadata.#.8a9c2559-2f14-431b-85d3-ffa36dd2c6cd epochRecord-0 localhost
-For the given key: epochRecord-0
-EpochRecord metadata info: 
-epoch = 0
-referenceEpoch = 0
-segments = [
-    segmentNumber = 0
-    creationEpoch = 0
-    creationTime = 1638259424440
-    keyStart = 0.0
-    keyEnd = 0.25
-,
-    segmentNumber = 1
-    creationEpoch = 0
-    creationTime = 1638259424440
-    keyStart = 0.25
-    keyEnd = 0.5
-,
-    segmentNumber = 2
-    creationEpoch = 0
-    creationTime = 1638259424440
-    keyStart = 0.5
-    keyEnd = 0.75
-,
-    segmentNumber = 3
-    creationEpoch = 0
-    creationTime = 1638259424440
-    keyStart = 0.75
-    keyEnd = 1.0
-]
-creationTime = 1638259424440
-splits = 0
-merges = 0
+> controller-metadata get _system/_tables/testScope/testStream/metadata.#.e81e4540-fc82-443d-b04e-fc9b073eaa97 configuration localhost
+For the given key: configuration
+StreamConfigurationRecord metadata info: 
+scope = testScope
+streamName = testStream
+streamConfiguration = 
+    scalingPolicy = ScalingPolicy(scaleType=FIXED_NUM_SEGMENTS, targetRate=0, scaleFactor=0, minNumSegments=4)
+    retentionPolicy = null
+    timestampAggregationTimeout = 0
+    tags = []
+    rolloverSizeBytes = 0
+updating = false
+tagOnlyUpdate = false
+removeTags = []
 
-> controller-metadata get _system/_tables/testScope/testStream/metadata.#.8a9c2559-2f14-431b-85d3-ffa36dd2c6cd epochRecord-0 test/epoch.json localhost
-For the given key: epochRecord-0
-Successfully wrote the value to test/epoch.json in JSON.
+> controller-metadata get _system/_tables/testScope/testStream/metadata.#.e81e4540-fc82-443d-b04e-fc9b073eaa97 configuration localhost test/config.json
+For the given key: configuration
+Successfully wrote the value to test/config.json in JSON.
 ``` 
 
-where the file `test/epoch.json` contains:
+where the file `test/config.json` contains:
 ```
 {
-  "epoch": 0,
-  "referenceEpoch": 0,
-  "segments": [
-    {
-      "segmentNumber": 0,
-      "creationEpoch": 0,
-      "creationTime": 1638259424440,
-      "keyStart": 0.0,
-      "keyEnd": 0.25
+  "scope": "testScope",
+  "streamName": "testStream",
+  "streamConfiguration": {
+    "scalingPolicy": {
+      "scaleType": "FIXED_NUM_SEGMENTS",
+      "targetRate": 0,
+      "scaleFactor": 0,
+      "minNumSegments": 4
     },
-    {
-      "segmentNumber": 1,
-      "creationEpoch": 0,
-      "creationTime": 1638259424440,
-      "keyStart": 0.25,
-      "keyEnd": 0.5
-    },
-    {
-      "segmentNumber": 2,
-      "creationEpoch": 0,
-      "creationTime": 1638259424440,
-      "keyStart": 0.5,
-      "keyEnd": 0.75
-    },
-    {
-      "segmentNumber": 3,
-      "creationEpoch": 0,
-      "creationTime": 1638259424440,
-      "keyStart": 0.75,
-      "keyEnd": 1.0
-    }
-  ],
-  "creationTime": 1638259424440,
-  "segmentMap": {
-    "0": {
-      "segmentNumber": 0,
-      "creationEpoch": 0,
-      "creationTime": 1638259424440,
-      "keyStart": 0.0,
-      "keyEnd": 0.25
-    },
-    "1": {
-      "segmentNumber": 1,
-      "creationEpoch": 0,
-      "creationTime": 1638259424440,
-      "keyStart": 0.25,
-      "keyEnd": 0.5
-    },
-    "2": {
-      "segmentNumber": 2,
-      "creationEpoch": 0,
-      "creationTime": 1638259424440,
-      "keyStart": 0.5,
-      "keyEnd": 0.75
-    },
-    "3": {
-      "segmentNumber": 3,
-      "creationEpoch": 0,
-      "creationTime": 1638259424440,
-      "keyStart": 0.75,
-      "keyEnd": 1.0
-    }
+    "retentionPolicy": null,
+    "timestampAggregationTimeout": 0,
+    "tags": [],
+    "rolloverSizeBytes": 0
   },
-  "splits": 0,
-  "merges": 0
+  "updating": false,
+  "tagOnlyUpdate": false,
+  "removeTags": []
 }
 ```
 
 These records/values can be updated using the `update` command. This command takes the updated record as a file in JSON format.
 The record can be obtained in JSON format using the `get` command as detailed above, this JSON file can be updated and then fed into the `update` command. 
+Below `test/config.json` was changed to make `minNumSegments` 10. 
 ```
-> controller-metadata update _system/_tables/testScope/testStream/metadata.#.8a9c2559-2f14-431b-85d3-ffa36dd2c6cd epochRecord-0 test/epoch.json localhost
-Successfully updated the key epochRecord-0 in table _system/_tables/testScope/testStream/metadata.#.8a9c2559-2f14-431b-85d3-ffa36dd2c6cd with version 1020
+> controller-metadata update _system/_tables/testScope/testStream/metadata.#.e81e4540-fc82-443d-b04e-fc9b073eaa97 configuration test/config.json localhost
+Successfully updated the key configuration in table _system/_tables/testScope/testStream/metadata.#.e81e4540-fc82-443d-b04e-fc9b073eaa97 with version 1020
+
+> controller-metadata get _system/_tables/testScope/testStream/metadata.#.e81e4540-fc82-443d-b04e-fc9b073eaa97 configuration localhost
+For the given key: configuration
+StreamConfigurationRecord metadata info: 
+scope = testScope
+streamName = testStream
+streamConfiguration = 
+    scalingPolicy = ScalingPolicy(scaleType=FIXED_NUM_SEGMENTS, targetRate=0, scaleFactor=0, minNumSegments=10)
+    retentionPolicy = null
+    timestampAggregationTimeout = 0
+    tags = []
+    rolloverSizeBytes = 0
+updating = false
+tagOnlyUpdate = false
+removeTags = []
 ```
 
 Note: This command performs a conditional update on the record. This can fail if the record is updated before the CLI's update request.

--- a/cli/admin/README.md
+++ b/cli/admin/README.md
@@ -106,11 +106,11 @@ All available commands:
 	controller list-readergroups <scope-name>: Lists all the existing ReaderGroups in a given Scope.
 	controller list-scopes : Lists all the existing scopes in the system.
 	controller list-streams <scope-name>: Lists all the existing Streams in a given Scope.
-	controller-metadata get <qualified-table-segment-name> <key> <segmentstore-endpoint> <json-file[OPTIONAL]>: Get the controller metadata entry for the given key in the table.
+	controller-metadata get <qualified-table-segment-name> <key> <segmentstore-endpoint> [json-file]: Get the value for the specified key from the specified controller metadata table.
 	controller-metadata list-entries <qualified-table-segment-name> <entry-count> <segmentstore-endpoint>: List at most the required number of entries from the controller metadata table. Unsupported for stream metadata tables.
 	controller-metadata list-keys <qualified-table-segment-name> <key-count> <segmentstore-endpoint>: List at most the required number of keys from the controller metadata table.
 	controller-metadata tables-info : List all the controller metadata tables.
-	controller-metadata update <qualified-table-segment-name> <key> <new-value-file> <segmentstore-endpoint>: Update the given key in the table with the provided value.
+	controller-metadata update <qualified-table-segment-name> <key> <segmentstore-endpoint> <new-value-file>: Update the given key in the table with the provided value.
 	data-recovery durableLog-recovery : Recovers the state of the DurableLog from the storage.
 	data-recovery durableLog-repair <container-id>: Allows to repair DurableLog damaged/corrupted Operations.
 	data-recovery list-segments : Lists segments from storage with their name, length and sealed status.
@@ -228,11 +228,11 @@ Once the config file is updated, the Pravega Admin CLI will be able to connect t
 
 The following commands are available for dealing with controller metadata:
 ```
-controller-metadata get <qualified-table-segment-name> <key> <segmentstore-endpoint> <json-file[OPTIONAL]>: Get the controller metadata entry for the given key in the table.
+controller-metadata get <qualified-table-segment-name> <key> <segmentstore-endpoint> [json-file]: Get the value for the specified key from the specified controller metadata table.
 controller-metadata list-entries <qualified-table-segment-name> <entry-count> <segmentstore-endpoint>: List at most the required number of entries from the controller metadata table. Unsupported for stream metadata tables.
 controller-metadata list-keys <qualified-table-segment-name> <key-count> <segmentstore-endpoint>: List at most the required number of keys from the controller metadata table.
 controller-metadata tables-info : List all the controller metadata tables.
-controller-metadata update <qualified-table-segment-name> <key> <new-value-file> <segmentstore-endpoint>: Update the given key in the table with the provided value.
+controller-metadata update <qualified-table-segment-name> <key> <segmentstore-endpoint> <new-value-file>: Update the given key in the table with the provided value.
 ```
 
 Information regarding the different types of tables can be obtained by running the `tables-info` command:
@@ -318,7 +318,7 @@ These records/values can be updated using the `update` command. This command tak
 The record can be obtained in JSON format using the `get` command as detailed above, this JSON file can be updated and then fed into the `update` command. 
 Below `test/config.json` was changed to make `minNumSegments` 10. 
 ```
-> controller-metadata update _system/_tables/testScope/testStream/metadata.#.e81e4540-fc82-443d-b04e-fc9b073eaa97 configuration test/config.json localhost
+> controller-metadata update _system/_tables/testScope/testStream/metadata.#.e81e4540-fc82-443d-b04e-fc9b073eaa97 configuration localhost test/config.json
 Successfully updated the key configuration in table _system/_tables/testScope/testStream/metadata.#.e81e4540-fc82-443d-b04e-fc9b073eaa97 with version 1020
 
 > controller-metadata get _system/_tables/testScope/testStream/metadata.#.e81e4540-fc82-443d-b04e-fc9b073eaa97 configuration localhost

--- a/cli/admin/README.md
+++ b/cli/admin/README.md
@@ -83,7 +83,7 @@ Initial configuration:
 
 From that point onwards, you can check the available commands by typing `help`:
 ``` 
-> help 
+> help
 All available commands:
 	bk cleanup : Removes orphan BookKeeper Ledgers that are not used by any BookKeeperLog.
 	bk details <log-id>: Lists metadata details about a BookKeeperLog, including BK Ledger information.
@@ -97,27 +97,28 @@ All available commands:
 	cluster list-instances : Lists all nodes in the Pravega cluster (Controllers, Segment Stores).
 	config list : Lists all configuration set during this session.
 	config set <name=value list>: Sets one or more config values for use during this session.
+	container continuous-recover <number-of-runs> <seconds-between-runs>: Executes a local, non-invasive recovery for all SegmentContainers in the cluster during the specified duration.
 	container flush-to-storage <container-id> <segmentstore-endpoint>: Persist the given Segment Container into Storage.
 	container recover <container-id>: Executes a local, non-invasive recovery for a SegmentContainer.
-	container continuous-recover <container-id>: Executes a local, non-invasive recovery for all SegmentContainers in the cluster during the specified duration.
 	controller describe-readergroup <scope-name> <readergroup-id>: Get the details of a given ReaderGroup in a Scope.
 	controller describe-scope <scope-name>: Get the details of a given Scope.
 	controller describe-stream <scope-name> <stream-name>: Get the details of a given Stream.
 	controller list-readergroups <scope-name>: Lists all the existing ReaderGroups in a given Scope.
 	controller list-scopes : Lists all the existing scopes in the system.
 	controller list-streams <scope-name>: Lists all the existing Streams in a given Scope.
-	controller-metadata get <qualified-table-segment-name> <key> <segmentstore-endpoint>: Get the controller metadata entry for the given key in the table.
+	controller-metadata get <qualified-table-segment-name> <key> <json-file[OPTIONAL]> <segmentstore-endpoint>: Get the controller metadata entry for the given key in the table.
 	controller-metadata list-entries <qualified-table-segment-name> <entry-count> <segmentstore-endpoint>: List at most the required number of entries from the controller metadata table. Unsupported for stream metadata tables.
 	controller-metadata list-keys <qualified-table-segment-name> <key-count> <segmentstore-endpoint>: List at most the required number of keys from the controller metadata table.
 	controller-metadata tables-info : List all the controller metadata tables.
+	controller-metadata update <qualified-table-segment-name> <key> <new-value-file> <segmentstore-endpoint>: Update the given key in the table with the provided value.
+	data-recovery durableLog-recovery : Recovers the state of the DurableLog from the storage.
+	data-recovery durableLog-repair <container-id>: Allows to repair DurableLog damaged/corrupted Operations.
+	data-recovery list-segments : Lists segments from storage with their name, length and sealed status.
 	password create-password-file <filename> <user:passwword:acl>: Generates file with encrypted password using filename and user:password:acl given as argument.
 	segmentstore get-segment-attribute <qualified-segment-name> <attribute-id> <segmentstore-endpoint>: Gets an attribute for a Segment.
 	segmentstore get-segment-info <qualified-segment-name> <segmentstore-endpoint>: Get the details of a given Segment.
 	segmentstore read-segment <qualified-segment-name> <offset> <length> <segmentstore-endpoint> <file-name>: Read a range from a given Segment into given file.
 	segmentstore update-segment-attribute <qualified-segment-name> <attribute-id> <attribute-new-value> <attribute-old-value> <segmentstore-endpoint>: Updates an attribute for a Segment.
-	data-recovery durableLog-recovery : Recovers the state of the DurableLog from the storage.
-    data-recovery durableLog-repair : Allows to repair DurableLog damaged/corrupted Operations.
-    data-recovery list-segments : Lists segments from storage with their name, length and sealed status.
 	table-segment get <qualified-table-segment-name> <key> <segmentstore-endpoint>: Get the entry for the given key in the table.Use the command "table-segment set-serializer <serializer-name>" to use the appropriate serializer before using this command.
 	table-segment get-info <qualified-table-segment-name> <segmentstore-endpoint>: Get the details of a given table.
 	table-segment list-keys <qualified-table-segment-name> <key-count> <segmentstore-endpoint>: List at most the required number of keys from the table segment.
@@ -222,6 +223,173 @@ The following required config values can be found in the logs:
 - `pravegaservice.zk.connect.uri`
 
 Once the config file is updated, the Pravega Admin CLI will be able to connect to your Pravega cluster and run commands.
+
+## `controller-metadata` Commands
+
+The following commands are available for dealing with controller metadata:
+```
+controller-metadata get <qualified-table-segment-name> <key> <json-file[OPTIONAL]> <segmentstore-endpoint>: Get the controller metadata entry for the given key in the table.
+controller-metadata list-entries <qualified-table-segment-name> <entry-count> <segmentstore-endpoint>: List at most the required number of entries from the controller metadata table. Unsupported for stream metadata tables.
+controller-metadata list-keys <qualified-table-segment-name> <key-count> <segmentstore-endpoint>: List at most the required number of keys from the controller metadata table.
+controller-metadata tables-info : List all the controller metadata tables.
+controller-metadata update <qualified-table-segment-name> <key> <new-value-file> <segmentstore-endpoint>: Update the given key in the table with the provided value.
+```
+
+Information regarding the different types of tables can be obtained by running the `tables-info` command:
+```
+> controller-metadata tables-info
+metadata.#.<id> --> Table name format: '_system/_tables/<scope-name>/<stream-name>/metadata.#.<stream-uuid>'.
+Stores stream properties like state, current epoch number, creation time, etc.
+eg: _system/_tables/testScope/testStream/metadata.#.a747afe8-2eb7-4666-bedd-cffe1cac5e25
+
+epochsWithTransactions.#.<id> --> Table name format: '_system/_tables/<scope-name>/<stream-name>/epochsWithTransactions.#.<stream-uuid>'.
+Stores the epoch numbers for transactions.
+eg: _system/_tables/testScope/testStream/epochsWithTransactions.#.cbc7b593-8743-4355-8703-e2c01f27c765
+
+writersPositions.#.<id> --> Table name format: '_system/_tables/<scope-name>/<stream-name>/writersPositions.#.<stream-uuid>'.
+Stores the writers' mark positions during watermarking.
+eg: _system/_tables/testScope/testStream/writersPositions.#.971ca637-cfc9-43c1-b337-25234d104885
+
+transactionsInEpoch-<epoch>.#.<id> --> Table name format: '_system/_tables/<scope-name>/<stream-name>/transactionsInEpoch-<stream-epoch>.#.<stream-uuid>'.
+Stores the set of active transactions in an epoch.
+eg: _system/_tables/testScope/testStream/transactionsInEpoch-1.#.4e3abd3b-9b27-4c18-abb3-1850ed100576
+
+completedTransactionsBatches --> Table name format: '_system/_tables/completedTransactionsBatches'.
+Stores the completed transactions' batch numbers.
+eg: _system/_tables/completedTransactionsBatches
+
+completedTransactionsBatch-<batch> --> Table name format: '_system/_tables/completedTransactionsBatch-<batch>'.
+Stores the set of completed transactions.
+eg: _system/_tables/completedTransactionsBatch-2
+
+deletedStreams --> Table name format: '_system/_tables/deletedStreams'.
+Stores the set of deleted streams and their last segment number.
+eg: _system/_tables/deletedStreams
+```
+
+The records/values can be queried from these tables using the `get` command. This command queries the required key from the table.
+Based on the arguments provided, the record can be either, output to the console as a user-friendly string, or saved to a file in JSON format, i.e., 
+if the optional JSON file argument is provided.
+```
+> controller-metadata get _system/_tables/testScope/testStream/metadata.#.8a9c2559-2f14-431b-85d3-ffa36dd2c6cd epochRecord-0 localhost
+For the given key: epochRecord-0
+EpochRecord metadata info: 
+epoch = 0
+referenceEpoch = 0
+segments = [
+    segmentNumber = 0
+    creationEpoch = 0
+    creationTime = 1638259424440
+    keyStart = 0.0
+    keyEnd = 0.25
+,
+    segmentNumber = 1
+    creationEpoch = 0
+    creationTime = 1638259424440
+    keyStart = 0.25
+    keyEnd = 0.5
+,
+    segmentNumber = 2
+    creationEpoch = 0
+    creationTime = 1638259424440
+    keyStart = 0.5
+    keyEnd = 0.75
+,
+    segmentNumber = 3
+    creationEpoch = 0
+    creationTime = 1638259424440
+    keyStart = 0.75
+    keyEnd = 1.0
+]
+creationTime = 1638259424440
+splits = 0
+merges = 0
+
+> controller-metadata get _system/_tables/testScope/testStream/metadata.#.8a9c2559-2f14-431b-85d3-ffa36dd2c6cd epochRecord-0 test/epoch.json localhost
+For the given key: epochRecord-0
+Successfully wrote the value to test/epoch.json in JSON.
+``` 
+
+where the file `test/epoch.json` contains:
+```
+{
+  "epoch": 0,
+  "referenceEpoch": 0,
+  "segments": [
+    {
+      "segmentNumber": 0,
+      "creationEpoch": 0,
+      "creationTime": 1638259424440,
+      "keyStart": 0.0,
+      "keyEnd": 0.25
+    },
+    {
+      "segmentNumber": 1,
+      "creationEpoch": 0,
+      "creationTime": 1638259424440,
+      "keyStart": 0.25,
+      "keyEnd": 0.5
+    },
+    {
+      "segmentNumber": 2,
+      "creationEpoch": 0,
+      "creationTime": 1638259424440,
+      "keyStart": 0.5,
+      "keyEnd": 0.75
+    },
+    {
+      "segmentNumber": 3,
+      "creationEpoch": 0,
+      "creationTime": 1638259424440,
+      "keyStart": 0.75,
+      "keyEnd": 1.0
+    }
+  ],
+  "creationTime": 1638259424440,
+  "segmentMap": {
+    "0": {
+      "segmentNumber": 0,
+      "creationEpoch": 0,
+      "creationTime": 1638259424440,
+      "keyStart": 0.0,
+      "keyEnd": 0.25
+    },
+    "1": {
+      "segmentNumber": 1,
+      "creationEpoch": 0,
+      "creationTime": 1638259424440,
+      "keyStart": 0.25,
+      "keyEnd": 0.5
+    },
+    "2": {
+      "segmentNumber": 2,
+      "creationEpoch": 0,
+      "creationTime": 1638259424440,
+      "keyStart": 0.5,
+      "keyEnd": 0.75
+    },
+    "3": {
+      "segmentNumber": 3,
+      "creationEpoch": 0,
+      "creationTime": 1638259424440,
+      "keyStart": 0.75,
+      "keyEnd": 1.0
+    }
+  },
+  "splits": 0,
+  "merges": 0
+}
+```
+
+These records/values can be updated using the `update` command. This command takes the updated record as a file in JSON format.
+The record can be obtained in JSON format using the `get` command as detailed above, this JSON file can be updated and then fed into the `update` command. 
+```
+> controller-metadata update _system/_tables/testScope/testStream/metadata.#.8a9c2559-2f14-431b-85d3-ffa36dd2c6cd epochRecord-0 test/epoch.json localhost
+Successfully updated the key epochRecord-0 in table _system/_tables/testScope/testStream/metadata.#.8a9c2559-2f14-431b-85d3-ffa36dd2c6cd with version 1020
+```
+
+Note: This command performs a conditional update on the record. This can fail if the record is updated before the CLI's update request.
+In such cases, the user can retry by running the command once again.
 
 ## Adding `segmentstore` Admin Commands
 

--- a/cli/admin/src/main/java/io/pravega/cli/admin/AdminCLIRunner.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/AdminCLIRunner.java
@@ -188,6 +188,6 @@ public final class AdminCLIRunner {
     }
 
     private static String formatArgName(AdminCommand.ArgDescriptor ad) {
-        return String.format("<%s>", ad.getName());
+        return ad.isOptional() ? String.format("[%s]", ad.getName()) : String.format("<%s>", ad.getName());
     }
 }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
@@ -310,6 +310,13 @@ public abstract class AdminCommand {
     public static class ArgDescriptor {
         private final String name;
         private final String description;
+        private boolean optional = false;
+
+        public ArgDescriptor(String name, String description, boolean optional) {
+            this.name = name;
+            this.description = description;
+            this.optional = optional;
+        }
     }
 
     /**

--- a/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
@@ -41,6 +41,7 @@ import io.pravega.cli.admin.controller.metadata.ControllerMetadataTablesInfoComm
 import io.pravega.cli.admin.controller.metadata.ControllerMetadataGetEntryCommand;
 import io.pravega.cli.admin.controller.metadata.ControllerMetadataListEntriesCommand;
 import io.pravega.cli.admin.controller.metadata.ControllerMetadataListKeysCommand;
+import io.pravega.cli.admin.controller.metadata.ControllerMetadataUpdateEntryCommand;
 import io.pravega.cli.admin.dataRecovery.DurableLogRecoveryCommand;
 import io.pravega.cli.admin.dataRecovery.DurableDataLogRepairCommand;
 import io.pravega.cli.admin.dataRecovery.StorageListSegmentsCommand;
@@ -377,6 +378,7 @@ public abstract class AdminCommand {
                         .put(ControllerMetadataTablesInfoCommand::descriptor, ControllerMetadataTablesInfoCommand::new)
                         .put(ControllerMetadataListKeysCommand::descriptor, ControllerMetadataListKeysCommand::new)
                         .put(ControllerMetadataListEntriesCommand::descriptor, ControllerMetadataListEntriesCommand::new)
+                        .put(ControllerMetadataUpdateEntryCommand::descriptor, ControllerMetadataUpdateEntryCommand::new)
                         .build());
 
         /**

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataGetEntryCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataGetEntryCommand.java
@@ -46,7 +46,7 @@ public class ControllerMetadataGetEntryCommand extends ControllerMetadataCommand
 
         final String tableName = getArg(0);
         final String key = getArg(1);
-        final String segmentStoreHost = getArg(getArgCount() - 1);
+        final String segmentStoreHost = getArg(2);
         @Cleanup
         CuratorFramework zkClient = createZKClient();
         @Cleanup
@@ -59,7 +59,7 @@ public class ControllerMetadataGetEntryCommand extends ControllerMetadataCommand
         val value = serializer.deserialize(getByteBuffer(entry.getValue()));
         output("For the given key: %s", key);
         if (getArgCount() == 4) {
-            final String jsonFile = getArg(2);
+            final String jsonFile = getArg(3);
 
             ControllerMetadataJsonSerializer jsonSerializer = new ControllerMetadataJsonSerializer();
             @Cleanup
@@ -78,8 +78,8 @@ public class ControllerMetadataGetEntryCommand extends ControllerMetadataCommand
                 new ArgDescriptor("qualified-table-segment-name", "Fully qualified name of the table segment to get the entry from. " +
                         "Run \"controller-metadata tables-info\" to get information about the controller metadata tables."),
                 new ArgDescriptor("key", "The key to be queried."),
+                new ArgDescriptor("segmentstore-endpoint", "Address of the Segment Store we want to send this request."),
                 new ArgDescriptor("json-file[OPTIONAL]", "An optional argument which, if provided, will write the value as " +
-                        "JSON into the given file path."),
-                new ArgDescriptor("segmentstore-endpoint", "Address of the Segment Store we want to send this request."));
+                        "JSON into the given file path."));
     }
 }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataGetEntryCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataGetEntryCommand.java
@@ -20,6 +20,7 @@ import io.pravega.cli.admin.CommandArgs;
 import io.pravega.cli.admin.json.ControllerMetadataJsonSerializer;
 import io.pravega.cli.admin.utils.AdminSegmentHelper;
 import io.pravega.cli.admin.serializers.controller.ControllerMetadataSerializer;
+import io.pravega.client.tables.impl.TableSegmentEntry;
 import lombok.Cleanup;
 import lombok.val;
 import org.apache.curator.framework.CuratorFramework;
@@ -51,10 +52,11 @@ public class ControllerMetadataGetEntryCommand extends ControllerMetadataCommand
         @Cleanup
         AdminSegmentHelper adminSegmentHelper = instantiateAdminSegmentHelper(zkClient);
         ControllerMetadataSerializer serializer = new ControllerMetadataSerializer(tableName, key);
-        val value = getTableEntry(tableName, key, segmentStoreHost, serializer, adminSegmentHelper);
-        if (value == null) {
+        TableSegmentEntry entry = getTableEntry(tableName, key, segmentStoreHost, adminSegmentHelper);
+        if (entry == null) {
             return;
         }
+        val value = serializer.deserialize(getByteBuffer(entry.getValue()));
         output("For the given key: %s", key);
         if (getArgCount() == 4) {
             final String jsonFile = getArg(2);

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataGetEntryCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataGetEntryCommand.java
@@ -16,9 +16,8 @@
 package io.pravega.cli.admin.controller.metadata;
 
 import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import io.pravega.cli.admin.CommandArgs;
+import io.pravega.cli.admin.json.ControllerMetadataJsonSerializer;
 import io.pravega.cli.admin.utils.AdminSegmentHelper;
 import io.pravega.cli.admin.serializers.controller.ControllerMetadataSerializer;
 import lombok.Cleanup;
@@ -59,11 +58,13 @@ public class ControllerMetadataGetEntryCommand extends ControllerMetadataCommand
         output("For the given key: %s", key);
         if (getArgCount() == 4) {
             final String jsonFile = getArg(2);
+
+            ControllerMetadataJsonSerializer jsonSerializer = new ControllerMetadataJsonSerializer();
             @Cleanup
             FileWriter writer = new FileWriter(createFileAndDirectory(jsonFile));
+            writer.write(jsonSerializer.toJson(value));
+            writer.flush();
 
-            Gson gson = new GsonBuilder().setPrettyPrinting().serializeNulls().create();
-            gson.toJson(value, writer);
             output("Successfully wrote the value to %s in JSON.", jsonFile);
         } else {
             userFriendlyOutput(value.toString(), serializer.getMetadataType());

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataGetEntryCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataGetEntryCommand.java
@@ -74,12 +74,12 @@ public class ControllerMetadataGetEntryCommand extends ControllerMetadataCommand
     }
 
     public static CommandDescriptor descriptor() {
-        return new CommandDescriptor(COMPONENT, "get", "Get the controller metadata entry for the given key in the table.",
+        return new CommandDescriptor(COMPONENT, "get", "Get the value for the specified key from the specified controller metadata table.",
                 new ArgDescriptor("qualified-table-segment-name", "Fully qualified name of the table segment to get the entry from. " +
                         "Run \"controller-metadata tables-info\" to get information about the controller metadata tables."),
                 new ArgDescriptor("key", "The key to be queried."),
                 new ArgDescriptor("segmentstore-endpoint", "Address of the Segment Store we want to send this request."),
-                new ArgDescriptor("json-file[OPTIONAL]", "An optional argument which, if provided, will write the value as " +
-                        "JSON into the given file path."));
+                new ArgDescriptor("json-file", "An optional argument which, if provided, will write the value as " +
+                        "JSON into the given file path.", true));
     }
 }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataListEntriesCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataListEntriesCommand.java
@@ -56,9 +56,9 @@ public class ControllerMetadataListEntriesCommand extends ControllerMetadataComm
         CuratorFramework zkClient = createZKClient();
         @Cleanup
         AdminSegmentHelper adminSegmentHelper = instantiateAdminSegmentHelper(zkClient);
-        HashTableIteratorItem<TableSegmentEntry> entries  = getIfTableExists(adminSegmentHelper.readTableEntries(tableName,
+        HashTableIteratorItem<TableSegmentEntry> entries  = completeSafely(adminSegmentHelper.readTableEntries(tableName,
                 new PravegaNodeUri(segmentStoreHost, getServiceConfig().getAdminGatewayPort()), entryCount,
-                HashTableIteratorItem.State.EMPTY, super.authHelper.retrieveMasterToken(), 0L), tableName);
+                HashTableIteratorItem.State.EMPTY, super.authHelper.retrieveMasterToken(), 0L), tableName, null);
         if (entries == null) {
             return;
         }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataListKeysCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataListKeysCommand.java
@@ -48,9 +48,9 @@ public class ControllerMetadataListKeysCommand extends ControllerMetadataCommand
         CuratorFramework zkClient = createZKClient();
         @Cleanup
         AdminSegmentHelper adminSegmentHelper = instantiateAdminSegmentHelper(zkClient);
-        HashTableIteratorItem<TableSegmentKey> keys = getIfTableExists(adminSegmentHelper.readTableKeys(tableName,
+        HashTableIteratorItem<TableSegmentKey> keys = completeSafely(adminSegmentHelper.readTableKeys(tableName,
                 new PravegaNodeUri(segmentStoreHost, getServiceConfig().getAdminGatewayPort()), keyCount,
-                HashTableIteratorItem.State.EMPTY, super.authHelper.retrieveMasterToken(), 0L), tableName);
+                HashTableIteratorItem.State.EMPTY, super.authHelper.retrieveMasterToken(), 0L), tableName, null);
         if (keys == null) {
             return;
         }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataUpdateEntryCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataUpdateEntryCommand.java
@@ -51,8 +51,11 @@ public class ControllerMetadataUpdateEntryCommand extends ControllerMetadataComm
         AdminSegmentHelper adminSegmentHelper = instantiateAdminSegmentHelper(zkClient);
         ControllerMetadataSerializer serializer = new ControllerMetadataSerializer(tableName, key);
 
-        JsonReader reader = new JsonReader(new FileReader(newValueFile));
-        ByteBuffer updatedValue = serializer.serialize(new Gson().fromJson(reader, serializer.getMetadataClass()));
+        @Cleanup
+        FileReader reader = new FileReader(newValueFile);
+        JsonReader jsonReader = new JsonReader(reader);
+        jsonReader.setLenient(true);
+        ByteBuffer updatedValue = serializer.serialize(new Gson().fromJson(jsonReader, serializer.getMetadataClass()));
 
         long version = updateTableEntry(tableName, key, updatedValue, segmentStoreHost, serializer, adminSegmentHelper);
         output("Successfully updated the key %s in table %s with version %s", key, tableName, version);

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataUpdateEntryCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataUpdateEntryCommand.java
@@ -46,8 +46,8 @@ public class ControllerMetadataUpdateEntryCommand extends ControllerMetadataComm
 
         final String tableName = getArg(0);
         final String key = getArg(1);
-        final String newValueFile = getArg(2);
-        final String segmentStoreHost = getArg(3);
+        final String newValueFile = getArg(3);
+        final String segmentStoreHost = getArg(2);
         @Cleanup
         CuratorFramework zkClient = createZKClient();
         @Cleanup
@@ -81,7 +81,7 @@ public class ControllerMetadataUpdateEntryCommand extends ControllerMetadataComm
                 new ArgDescriptor("qualified-table-segment-name", "Fully qualified name of the table segment to update. " +
                         "Run \"controller-metadata tables-info\" to get information about the controller metadata tables."),
                 new ArgDescriptor("key", "The key to be updated."),
-                new ArgDescriptor("new-value-file", "The path to the file containing the new value in JSON format."),
-                new ArgDescriptor("segmentstore-endpoint", "Address of the Segment Store we want to send this request."));
+                new ArgDescriptor("segmentstore-endpoint", "Address of the Segment Store we want to send this request."),
+                new ArgDescriptor("new-value-file", "The path to the file containing the new value in JSON format."));
     }
 }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/json/ControllerMetadataJsonSerializer.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/json/ControllerMetadataJsonSerializer.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.json;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * JSON serializer for controller metadata.
+ */
+public class ControllerMetadataJsonSerializer {
+
+    /**
+     * Method to convert JSON string into object of the given type.
+     *
+     * @param jsonValue The JSON string.
+     * @param type      The object's class.
+     * @param <T>       The type of the object.
+     * @return The object embedded in the given JSON string.
+     */
+    public <T> T fromJson(String jsonValue, Class<T> type) {
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(Map.Entry.class, new MapEntrySerializer())
+                .registerTypeAdapter(ImmutableList.class, new ImmutableListDeserializer())
+                .registerTypeAdapter(ImmutableSet.class, new ImmutableSetDeserializer())
+                .registerTypeAdapter(ImmutableMap.class, new ImmutableMapDeserializer())
+                .create();
+        return gson.fromJson(jsonValue, type);
+    }
+
+    /**
+     * Method to convert the given object into a JSON string.
+     *
+     * @param src The Object.
+     * @return A JSON string containing the given object.
+     */
+    public String toJson(Object src) {
+        Gson gson = new GsonBuilder()
+                .setPrettyPrinting()
+                .serializeNulls()
+                .enableComplexMapKeySerialization()
+                .registerTypeAdapter(Map.Entry.class, new MapEntrySerializer())
+                .create();
+        return gson.toJson(src);
+    }
+
+    /**
+     * A custom JSON deserializer for the {@link ImmutableList} type.
+     */
+    private static class ImmutableListDeserializer implements JsonDeserializer<ImmutableList<?>> {
+
+        @Override
+        public ImmutableList<?> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            Type[] typeArguments = ((ParameterizedType) typeOfT).getActualTypeArguments();
+            Type parametrizedType = collectionOf(typeArguments[0]).getType();
+            Collection<?> collection = context.deserialize(json, parametrizedType);
+            return ImmutableList.copyOf(collection);
+        }
+    }
+
+    /**
+     * A custom JSON deserializer for the {@link ImmutableSet} type.
+     */
+    private static class ImmutableSetDeserializer implements JsonDeserializer<ImmutableSet<?>> {
+
+        @Override
+        public ImmutableSet<?> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            Type[] typeArguments = ((ParameterizedType) typeOfT).getActualTypeArguments();
+            Type parametrizedType = collectionOf(typeArguments[0]).getType();
+            Collection<?> collection = context.deserialize(json, parametrizedType);
+            return ImmutableSet.copyOf(collection);
+        }
+    }
+
+    /**
+     * A custom JSON deserializer for the {@link ImmutableMap} type.
+     */
+    private static class ImmutableMapDeserializer implements JsonDeserializer<ImmutableMap<?, ?>> {
+
+        @Override
+        public ImmutableMap<?, ?> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            Type[] typeArguments = ((ParameterizedType) typeOfT).getActualTypeArguments();
+            Type parametrizedType = hashMapOf(typeArguments[0], typeArguments[1]).getType();
+            Map<?, ?> map = context.deserialize(json, parametrizedType);
+            return ImmutableMap.copyOf(map);
+        }
+    }
+
+    /**
+     * A custom JSON serializer and deserializer for the {@link Map.Entry} of two {@link Double}s.
+     */
+    private static class MapEntrySerializer implements JsonSerializer<Map.Entry<Double, Double>>, JsonDeserializer<Map.Entry<Double, Double>> {
+
+        @Override
+        public Map.Entry<Double, Double> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            Map<String, Double> map = context.deserialize(json, Map.class);
+            System.out.println("here: " + map);
+            String k = map.keySet().stream().iterator().next();
+            return Map.entry(Double.parseDouble(k), map.get(k));
+        }
+
+        @Override
+        public JsonElement serialize(Map.Entry<Double, Double> src, Type typeOfSrc, JsonSerializationContext context) {
+            Map<Double, Double> map = new HashMap<>();
+            map.put(src.getKey(), src.getValue());
+            return context.serialize(map);
+        }
+    }
+
+    private static <E> TypeToken<Collection<E>> collectionOf(Type type) {
+        TypeParameter<E> elementTypeParameter = new TypeParameter<E>() {};
+        return new TypeToken<Collection<E>>() {}
+        .where(elementTypeParameter, typeTokenOf(type));
+    }
+
+    private static <K, V> TypeToken<HashMap<K, V>> hashMapOf(Type key, Type value) {
+        TypeParameter<K> keyTypeParameter = new TypeParameter<K>() {};
+        TypeParameter<V> valueTypeParameter = new TypeParameter<V>() {};
+        return new TypeToken<HashMap<K, V>>() {}
+        .where(keyTypeParameter, typeTokenOf(key))
+        .where(valueTypeParameter, typeTokenOf(value));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E> TypeToken<E> typeTokenOf(Type type) {
+        return (TypeToken<E>) TypeToken.of(type);
+    }
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/json/ControllerMetadataJsonSerializer.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/json/ControllerMetadataJsonSerializer.java
@@ -139,16 +139,16 @@ public class ControllerMetadataJsonSerializer {
 
     private static <E> TypeToken<Collection<E>> collectionOf(Type type) {
         // Generate a Collection<E> TypeToken given the Type of the element.
-        TypeParameter<E> elementTypeParameter = new TypeParameter<E>() {};
-        return new TypeToken<Collection<E>>() {}
+        TypeParameter<E> elementTypeParameter = new TypeParameter<E>() { };
+        return new TypeToken<Collection<E>>() { }
         .where(elementTypeParameter, typeTokenOf(type));
     }
 
     private static <K, V> TypeToken<HashMap<K, V>> hashMapOf(Type key, Type value) {
         // Generate a HashMap<K, V> TypeToken given the Types of the key and value.
-        TypeParameter<K> keyTypeParameter = new TypeParameter<K>() {};
-        TypeParameter<V> valueTypeParameter = new TypeParameter<V>() {};
-        return new TypeToken<HashMap<K, V>>() {}
+        TypeParameter<K> keyTypeParameter = new TypeParameter<K>() { };
+        TypeParameter<V> valueTypeParameter = new TypeParameter<V>() { };
+        return new TypeToken<HashMap<K, V>>() { }
         .where(keyTypeParameter, typeTokenOf(key))
         .where(valueTypeParameter, typeTokenOf(value));
     }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/json/ControllerMetadataJsonSerializer.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/json/ControllerMetadataJsonSerializer.java
@@ -138,12 +138,14 @@ public class ControllerMetadataJsonSerializer {
     }
 
     private static <E> TypeToken<Collection<E>> collectionOf(Type type) {
+        // Generate a Collection<E> TypeToken given the Type of the element.
         TypeParameter<E> elementTypeParameter = new TypeParameter<E>() {};
         return new TypeToken<Collection<E>>() {}
         .where(elementTypeParameter, typeTokenOf(type));
     }
 
     private static <K, V> TypeToken<HashMap<K, V>> hashMapOf(Type key, Type value) {
+        // Generate a HashMap<K, V> TypeToken given the Types of the key and value.
         TypeParameter<K> keyTypeParameter = new TypeParameter<K>() {};
         TypeParameter<V> valueTypeParameter = new TypeParameter<V>() {};
         return new TypeToken<HashMap<K, V>>() {}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/ReadSegmentRangeCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/ReadSegmentRangeCommand.java
@@ -26,9 +26,10 @@ import org.apache.curator.framework.CuratorFramework;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+
+import static io.pravega.cli.admin.utils.FileHelper.createFileAndDirectory;
 
 public class ReadSegmentRangeCommand extends SegmentStoreCommand {
 
@@ -64,27 +65,6 @@ public class ReadSegmentRangeCommand extends SegmentStoreCommand {
         SegmentHelper segmentHelper = instantiateSegmentHelper(zkClient);
         readAndWriteSegmentToFile(segmentHelper, segmentStoreHost, fullyQualifiedSegmentName, offset, length, fileName);
         output("\nThe segment data has been successfully written into %s", fileName);
-    }
-
-    /**
-     * Creates the file (and parent directory if required) into which thee segment data is written.
-     *
-     * @param fileName The name of the file to create.
-     * @return A {@link File} object representing the filename provided.
-     * @throws FileAlreadyExistsException if the file already exists, to avoid any accidental overwrites.
-     * @throws IOException if the file/directory creation fails.
-     */
-    private File createFileAndDirectory(String fileName) throws IOException {
-        File f = new File(fileName);
-        // If file exists throw FileAlreadyExistsException, an existing file should not be overwritten with new data.
-        if (f.exists()) {
-            throw new FileAlreadyExistsException("Cannot write segment data into a file that already exists.");
-        }
-        if (!f.getParentFile().exists()) {
-            f.getParentFile().mkdirs();
-        }
-        f.createNewFile();
-        return f;
     }
 
     /**

--- a/cli/admin/src/main/java/io/pravega/cli/admin/serializers/controller/ControllerMetadataSerializer.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/serializers/controller/ControllerMetadataSerializer.java
@@ -163,6 +163,29 @@ public class ControllerMetadataSerializer implements Serializer<Object> {
                     .put(COMPLETED_TXN_RECORD, Map.entry(CompletedTxnRecord::fromBytes, x -> ((CompletedTxnRecord) x).toBytes()))
                     .build();
 
+    private static final Map<String, Class<?>> METADATA_CLASSES =
+            ImmutableMap.<String, Class<?>>builder()
+                    .put(STRING, String.class)
+                    .put(INTEGER, Integer.class)
+                    .put(LONG, Long.class)
+                    .put(EMPTY, Void.class)
+                    .put(STREAM_CONFIGURATION_RECORD, StreamConfigurationRecord.class)
+                    .put(STREAM_TRUNCATION_RECORD, StreamTruncationRecord.class)
+                    .put(STATE_RECORD, StateRecord.class)
+                    .put(EPOCH_TRANSITION_RECORD, EpochTransitionRecord.class)
+                    .put(RETENTION_SET, RetentionSet.class)
+                    .put(STREAM_CUT_RECORD, StreamCutRecord.class)
+                    .put(EPOCH_RECORD, EpochRecord.class)
+                    .put(HISTORY_TIME_SERIES, HistoryTimeSeries.class)
+                    .put(SEALED_SEGMENTS_MAP_SHARD, SealedSegmentsMapShard.class)
+                    .put(COMMITTING_TRANSACTIONS_RECORD, CommittingTransactionsRecord.class)
+                    .put(STREAM_SUBSCRIBER, StreamSubscriber.class)
+                    .put(SUBSCRIBERS, Subscribers.class)
+                    .put(WRITER_MARK, WriterMark.class)
+                    .put(ACTIVE_TXN_RECORD, ActiveTxnRecord.class)
+                    .put(COMPLETED_TXN_RECORD, CompletedTxnRecord.class)
+                    .build();
+
     @Getter
     private final String metadataType;
 
@@ -184,6 +207,15 @@ public class ControllerMetadataSerializer implements Serializer<Object> {
     @Override
     public Object deserialize(ByteBuffer serializedValue) {
         return BYTE_CONVERTERS.get(metadataType).getKey().apply(new ByteArraySegment(serializedValue).getCopy());
+    }
+
+    /**
+     * Method to get the {@link Class} of the metadata associated to the serializer instance.
+     *
+     * @return The class of the metadata.
+     */
+    public Class<?> getMetadataClass() {
+        return METADATA_CLASSES.get(metadataType);
     }
 
     /**

--- a/cli/admin/src/main/java/io/pravega/cli/admin/serializers/controller/ControllerMetadataSerializer.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/serializers/controller/ControllerMetadataSerializer.java
@@ -168,7 +168,8 @@ public class ControllerMetadataSerializer implements Serializer<Object> {
                     .put(STRING, String.class)
                     .put(INTEGER, Integer.class)
                     .put(LONG, Long.class)
-                    .put(EMPTY, Void.class)
+                    // The value returned in the EMPTY case is integer 0.
+                    .put(EMPTY, Integer.class)
                     .put(STREAM_CONFIGURATION_RECORD, StreamConfigurationRecord.class)
                     .put(STREAM_TRUNCATION_RECORD, StreamTruncationRecord.class)
                     .put(STATE_RECORD, StateRecord.class)

--- a/cli/admin/src/main/java/io/pravega/cli/admin/utils/FileHelper.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/utils/FileHelper.java
@@ -29,7 +29,7 @@ public class FileHelper {
      * @throws FileAlreadyExistsException if the file already exists, to avoid any accidental overwrites.
      * @throws IOException if the file/directory creation fails.
      */
-    public static File createFileAndDirectory(String fileName) throws IOException {
+    public static File createFileAndDirectory(String fileName) throws IOException, FileAlreadyExistsException {
         File f = new File(fileName);
         // If file exists throw FileAlreadyExistsException, an existing file should not be overwritten with new data.
         if (f.exists()) {

--- a/cli/admin/src/main/java/io/pravega/cli/admin/utils/FileHelper.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/utils/FileHelper.java
@@ -35,8 +35,10 @@ public class FileHelper {
         if (f.exists()) {
             throw new FileAlreadyExistsException("Cannot write segment data into a file that already exists.");
         }
-        if (!f.getParentFile().exists()) {
-            f.getParentFile().mkdirs();
+        if (f.getParentFile() != null) {
+            if (!f.getParentFile().exists()) {
+                f.getParentFile().mkdirs();
+            }
         }
         f.createNewFile();
         return f;

--- a/cli/admin/src/main/java/io/pravega/cli/admin/utils/FileHelper.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/utils/FileHelper.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+
+public class FileHelper {
+
+    /**
+     * Creates the file (and parent directory if required).
+     *
+     * @param fileName The name of the file to create.
+     * @return A {@link File} object representing the filename provided.
+     * @throws FileAlreadyExistsException if the file already exists, to avoid any accidental overwrites.
+     * @throws IOException if the file/directory creation fails.
+     */
+    public static File createFileAndDirectory(String fileName) throws IOException {
+        File f = new File(fileName);
+        // If file exists throw FileAlreadyExistsException, an existing file should not be overwritten with new data.
+        if (f.exists()) {
+            throw new FileAlreadyExistsException("Cannot write segment data into a file that already exists.");
+        }
+        if (!f.getParentFile().exists()) {
+            f.getParentFile().mkdirs();
+        }
+        f.createNewFile();
+        return f;
+    }
+}

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -104,7 +104,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
         TestUtils.deleteScopeStream(SETUP_UTILS.getController(), scope, stream);
 
         String commandResult = TestUtils.executeCommand("controller-metadata get " + DELETED_STREAMS_TABLE + " " +
-                getScopedStreamName(scope, stream) + " localhost", STATE.get());
+                getScopedStreamName(scope, stream) + " false localhost", STATE.get());
         Assert.assertTrue(commandResult.contains(String.format("For the given key: %s", getScopedStreamName(scope, stream))));
     }
 
@@ -117,7 +117,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
         TestUtils.deleteScopeStream(SETUP_UTILS.getController(), scope, stream);
 
         String commandResult = TestUtils.executeCommand("controller-metadata get " + DELETED_STREAMS_TABLE + " " +
-                getScopedStreamName(scope, dummyStream) + " localhost", STATE.get());
+                getScopedStreamName(scope, dummyStream) + " false localhost", STATE.get());
         Assert.assertTrue(commandResult.contains(String.format("Key not found: %s", getScopedStreamName(scope, dummyStream))));
     }
 
@@ -125,7 +125,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
     public void testGetControllerMetadataEntryCommandTableDoesNotExist() throws Exception {
         String dummyTable = getQualifiedTableName(INTERNAL_SCOPE_NAME,
                 "randScope", "randStream", String.format(METADATA_TABLE, UUID.randomUUID()));
-        String commandResult = TestUtils.executeCommand("controller-metadata get " + dummyTable + " creationTime localhost", STATE.get());
+        String commandResult = TestUtils.executeCommand("controller-metadata get " + dummyTable + " creationTime false localhost", STATE.get());
         Assert.assertTrue(commandResult.contains(String.format("Table not found: %s", dummyTable)));
     }
 

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -104,7 +104,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
         TestUtils.deleteScopeStream(SETUP_UTILS.getController(), scope, stream);
 
         String commandResult = TestUtils.executeCommand("controller-metadata get " + DELETED_STREAMS_TABLE + " " +
-                getScopedStreamName(scope, stream) + " false localhost", STATE.get());
+                getScopedStreamName(scope, stream) + " localhost", STATE.get());
         Assert.assertTrue(commandResult.contains(String.format("For the given key: %s", getScopedStreamName(scope, stream))));
     }
 
@@ -117,7 +117,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
         TestUtils.deleteScopeStream(SETUP_UTILS.getController(), scope, stream);
 
         String commandResult = TestUtils.executeCommand("controller-metadata get " + DELETED_STREAMS_TABLE + " " +
-                getScopedStreamName(scope, dummyStream) + " false localhost", STATE.get());
+                getScopedStreamName(scope, dummyStream) + " localhost", STATE.get());
         Assert.assertTrue(commandResult.contains(String.format("Key not found: %s", getScopedStreamName(scope, dummyStream))));
     }
 
@@ -125,7 +125,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
     public void testGetControllerMetadataEntryCommandTableDoesNotExist() throws Exception {
         String dummyTable = getQualifiedTableName(INTERNAL_SCOPE_NAME,
                 "randScope", "randStream", String.format(METADATA_TABLE, UUID.randomUUID()));
-        String commandResult = TestUtils.executeCommand("controller-metadata get " + dummyTable + " creationTime false localhost", STATE.get());
+        String commandResult = TestUtils.executeCommand("controller-metadata get " + dummyTable + " creationTime localhost", STATE.get());
         Assert.assertTrue(commandResult.contains(String.format("Table not found: %s", dummyTable)));
     }
 

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -125,7 +125,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
         TestUtils.deleteScopeStream(SETUP_UTILS.getController(), scope, stream);
 
         String commandResult = TestUtils.executeCommand("controller-metadata get " + DELETED_STREAMS_TABLE + " " +
-                getScopedStreamName(scope, stream) + " " + filename + " localhost", STATE.get());
+                getScopedStreamName(scope, stream) + " localhost " + filename, STATE.get());
         Assert.assertTrue(commandResult.contains(String.format("For the given key: %s", getScopedStreamName(scope, stream))));
         Assert.assertTrue(commandResult.contains(String.format("Successfully wrote the value to %s in JSON.", filename)));
         File file = new File(filename);

--- a/cli/admin/src/test/java/io/pravega/cli/admin/json/ControllerMetadataJsonSerializerTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/json/ControllerMetadataJsonSerializerTest.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.json;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import io.pravega.client.stream.RetentionPolicy;
+import io.pravega.client.stream.ScalingPolicy;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.controller.store.stream.State;
+import io.pravega.controller.store.stream.TxnStatus;
+import io.pravega.controller.store.stream.records.ActiveTxnRecord;
+import io.pravega.controller.store.stream.records.CommittingTransactionsRecord;
+import io.pravega.controller.store.stream.records.CompletedTxnRecord;
+import io.pravega.controller.store.stream.records.EpochRecord;
+import io.pravega.controller.store.stream.records.EpochTransitionRecord;
+import io.pravega.controller.store.stream.records.HistoryTimeSeries;
+import io.pravega.controller.store.stream.records.HistoryTimeSeriesRecord;
+import io.pravega.controller.store.stream.records.RetentionSet;
+import io.pravega.controller.store.stream.records.SealedSegmentsMapShard;
+import io.pravega.controller.store.stream.records.StateRecord;
+import io.pravega.controller.store.stream.records.StreamConfigurationRecord;
+import io.pravega.controller.store.stream.records.StreamCutRecord;
+import io.pravega.controller.store.stream.records.StreamCutReferenceRecord;
+import io.pravega.controller.store.stream.records.StreamSegmentRecord;
+import io.pravega.controller.store.stream.records.StreamSubscriber;
+import io.pravega.controller.store.stream.records.StreamTruncationRecord;
+import io.pravega.controller.store.stream.records.Subscribers;
+import io.pravega.controller.store.stream.records.WriterMark;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public class ControllerMetadataJsonSerializerTest {
+
+    @Test
+    public void testStreamConfigurationRecord() {
+        StreamConfiguration withScalingAndRetention = StreamConfiguration.builder()
+                .scalingPolicy(ScalingPolicy.fixed(1))
+                .retentionPolicy(RetentionPolicy.bySizeBytes(1L))
+                .build();
+        StreamConfigurationRecord record1 = StreamConfigurationRecord.builder()
+                .streamConfiguration(withScalingAndRetention)
+                .streamName("a")
+                .scope("a")
+                .updating(true)
+                .build();
+        testRecordSerialization(record1, StreamConfigurationRecord.class);
+
+        StreamConfiguration withScalingOnly = StreamConfiguration.builder()
+                .scalingPolicy(ScalingPolicy.fixed(1))
+                .build();
+        StreamConfigurationRecord record2 = StreamConfigurationRecord.builder()
+                .streamConfiguration(withScalingOnly)
+                .streamName("a")
+                .scope("a")
+                .updating(true)
+                .build();
+        testRecordSerialization(record2, StreamConfigurationRecord.class);
+
+        StreamConfiguration withRetentionOnly = StreamConfiguration.builder()
+                .scalingPolicy(null)
+                .retentionPolicy(RetentionPolicy.bySizeBytes(1L))
+                .build();
+        StreamConfigurationRecord record3 = StreamConfigurationRecord.builder()
+                .streamConfiguration(withRetentionOnly)
+                .streamName("a")
+                .scope("a")
+                .updating(true)
+                .build();
+        testRecordSerialization(record3, StreamConfigurationRecord.class);
+    }
+
+    @Test
+    public void testStreamTruncationRecord() {
+        Map<StreamSegmentRecord, Integer> span = new HashMap<>();
+        span.put(StreamSegmentRecord.newSegmentRecord(0, 0, 0L, 0.0, 1.0), 0);
+        span.put(StreamSegmentRecord.newSegmentRecord(1, 0, 0L, 0.0, 1.0), 0);
+        Map<Long, Long> streamCut = new HashMap<>();
+        streamCut.put(0L, 0L);
+        Set<Long> set = new HashSet<>();
+        set.add(0L);
+        StreamTruncationRecord record = new StreamTruncationRecord(ImmutableMap.copyOf(streamCut),
+                ImmutableMap.copyOf(span), ImmutableSet.copyOf(set), ImmutableSet.copyOf(set), 0L, true);
+        testRecordSerialization(record, StreamTruncationRecord.class);
+    }
+
+    @Test
+    public void testStateRecord() {
+        StateRecord record = new StateRecord(State.ACTIVE);
+        testRecordSerialization(record, StateRecord.class);
+    }
+
+    @Test
+    public void testEpochTransitionRecord() {
+        ImmutableSet<Long> segmentsToSeal = ImmutableSet.of(1L, 2L);
+        ImmutableMap<Long, Map.Entry<Double, Double>> newSegmentsWithRange =
+                ImmutableMap.of(3L, Map.entry(0.1, 0.2), 4L, Map.entry(0.3, 0.4));
+        EpochTransitionRecord record = new EpochTransitionRecord(10, 100L,
+                segmentsToSeal, newSegmentsWithRange);
+        testRecordSerialization(record, EpochTransitionRecord.class);
+    }
+
+    @Test
+    public void testRetentionSet() {
+        StreamCutReferenceRecord refRecord1 = StreamCutReferenceRecord.builder().recordingSize(0L).recordingTime(10L).build();
+        StreamCutReferenceRecord refRecord2 = StreamCutReferenceRecord.builder().recordingSize(1L).recordingTime(11L).build();
+        RetentionSet record = new RetentionSet(ImmutableList.of(refRecord1, refRecord2));
+        testRecordSerialization(record, RetentionSet.class);
+    }
+
+    @Test
+    public void testStreamCutRecord() {
+        StreamCutRecord record = new StreamCutRecord(10L, 10L, ImmutableMap.of(1L, 2L, 3L, 4L));
+        testRecordSerialization(record, StreamCutRecord.class);
+    }
+
+    @Test
+    public void testEpochRecord() {
+        List<StreamSegmentRecord> list = Lists.newArrayList(StreamSegmentRecord.newSegmentRecord(1, 0, 10L, 0.0, 1.0));
+        EpochRecord record = new EpochRecord(10, 0, ImmutableList.copyOf(list), 10L,
+                0L, 0L);
+        testRecordSerialization(record, EpochRecord.class);
+    }
+
+    @Test
+    public void testHistoryTimeSeries() {
+        List<StreamSegmentRecord> sealedSegments = Lists.newArrayList(StreamSegmentRecord.newSegmentRecord(0, 0, 0L, 0.0, 1.0));
+        List<StreamSegmentRecord> newSegments = Lists.newArrayList(StreamSegmentRecord.newSegmentRecord(0, 0, 0L, 0.0, 1.0),
+                StreamSegmentRecord.newSegmentRecord(1, 1, 0L, 0.1, 0.2));
+        HistoryTimeSeriesRecord node = new HistoryTimeSeriesRecord(0, 0, ImmutableList.copyOf(sealedSegments),
+                ImmutableList.copyOf(newSegments), 0L);
+        HistoryTimeSeriesRecord node2 = new HistoryTimeSeriesRecord(1, 0,
+                ImmutableList.of(), ImmutableList.of(), 1L);
+        HistoryTimeSeriesRecord node3 = new HistoryTimeSeriesRecord(4, 4,
+                ImmutableList.copyOf(sealedSegments), ImmutableList.copyOf(newSegments), 1L);
+        HistoryTimeSeries record = new HistoryTimeSeries(ImmutableList.of(node, node2, node3));
+        testRecordSerialization(record, HistoryTimeSeries.class);
+    }
+
+    @Test
+    public void testSealedSegmentsMapShard() {
+        Map<Long, Long> map = new HashMap<>();
+        map.put(0L, 0L);
+        map.put(1L, 0L);
+        map.put(2L, 0L);
+        SealedSegmentsMapShard record = SealedSegmentsMapShard.builder().sealedSegmentsSizeMap(map).build();
+        testRecordSerialization(record, SealedSegmentsMapShard.class);
+    }
+
+    @Test
+    public void testCommittingTransactionsRecord() {
+        List<UUID> list = Lists.newArrayList(UUID.randomUUID(), UUID.randomUUID());
+        CommittingTransactionsRecord record0 =
+                new CommittingTransactionsRecord(0, ImmutableList.copyOf(list));
+        testRecordSerialization(record0, CommittingTransactionsRecord.class);
+        CommittingTransactionsRecord record = record0.createRollingTxnRecord(10);
+        testRecordSerialization(record, CommittingTransactionsRecord.class);
+    }
+
+    @Test
+    public void testStreamSubscriber() {
+        StreamSubscriber record = new StreamSubscriber("a", 1L,
+                ImmutableMap.of(1L, 2L, 3L, 4L), 10L);
+        testRecordSerialization(record, StreamSubscriber.class);
+    }
+
+    @Test
+    public void testSubscribers() {
+        Subscribers record = new Subscribers(ImmutableSet.of("a", "b"));
+        testRecordSerialization(record, Subscribers.class);
+    }
+
+    @Test
+    public void testWriterMark() {
+        Map<Long, Long> map = new HashMap<>();
+        map.put(0L, 0L);
+        map.put(1L, 0L);
+        map.put(2L, 0L);
+        WriterMark record = new WriterMark(100L, ImmutableMap.copyOf(map), true);
+        testRecordSerialization(record, WriterMark.class);
+    }
+
+    @Test
+    public void testActiveTxnRecord() {
+        ActiveTxnRecord record = new ActiveTxnRecord(1L, 1L, 1L,
+                TxnStatus.OPEN, "a", 1L, 1L, ImmutableMap.of(1L, 2L, 3L, 4L));
+        testRecordSerialization(record, ActiveTxnRecord.class);
+    }
+
+    @Test
+    public void testCompletedTxnRecord() {
+        CompletedTxnRecord record = new CompletedTxnRecord(1L, TxnStatus.COMMITTED);
+        testRecordSerialization(record, CompletedTxnRecord.class);
+    }
+
+    private static <T> void testRecordSerialization(T record, Class<T> type) {
+        ControllerMetadataJsonSerializer jsonSerializer = new ControllerMetadataJsonSerializer();
+        String jsonString = jsonSerializer.toJson(record);
+        Assert.assertEquals(record, jsonSerializer.fromJson(jsonString, type));
+    }
+}

--- a/cli/admin/src/test/java/io/pravega/cli/admin/json/ControllerMetadataJsonSerializerTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/json/ControllerMetadataJsonSerializerTest.java
@@ -215,6 +215,16 @@ public class ControllerMetadataJsonSerializerTest {
         testRecordSerialization(record, CompletedTxnRecord.class);
     }
 
+    @Test
+    public void testPrimitives() {
+        int record1 = 1;
+        testRecordSerialization(record1, Integer.class);
+        long record2 = 2L;
+        testRecordSerialization(record2, Long.class);
+        String record3 = "testString";
+        testRecordSerialization(record3, String.class);
+    }
+
     private static <T> void testRecordSerialization(T record, Class<T> type) {
         ControllerMetadataJsonSerializer jsonSerializer = new ControllerMetadataJsonSerializer();
         String jsonString = jsonSerializer.toJson(record);

--- a/cli/admin/src/test/java/io/pravega/cli/admin/serializers/controller/ControllerMetadataSerializerTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/serializers/controller/ControllerMetadataSerializerTest.java
@@ -30,7 +30,17 @@ import static io.pravega.cli.admin.serializers.controller.ControllerMetadataSeri
 import static io.pravega.cli.admin.serializers.controller.ControllerMetadataSerializer.isStreamMetadataTableName;
 import static io.pravega.cli.admin.serializers.controller.ControllerMetadataSerializer.isTransactionsInEpochTableName;
 import static io.pravega.cli.admin.serializers.controller.ControllerMetadataSerializer.isWriterPositionsTableName;
-import static io.pravega.shared.NameUtils.*;
+import static io.pravega.shared.NameUtils.COMPLETED_TRANSACTIONS_BATCHES_TABLE;
+import static io.pravega.shared.NameUtils.COMPLETED_TRANSACTIONS_BATCH_TABLE_FORMAT;
+import static io.pravega.shared.NameUtils.CREATION_TIME_KEY;
+import static io.pravega.shared.NameUtils.DELETED_STREAMS_TABLE;
+import static io.pravega.shared.NameUtils.EPOCHS_WITH_TRANSACTIONS_TABLE;
+import static io.pravega.shared.NameUtils.INTERNAL_SCOPE_NAME;
+import static io.pravega.shared.NameUtils.METADATA_TABLE;
+import static io.pravega.shared.NameUtils.STATE_KEY;
+import static io.pravega.shared.NameUtils.TRANSACTIONS_IN_EPOCH_TABLE_FORMAT;
+import static io.pravega.shared.NameUtils.WRITERS_POSITIONS_TABLE;
+import static io.pravega.shared.NameUtils.getQualifiedTableName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/cli/admin/src/test/java/io/pravega/cli/admin/utils/FileHelperTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/utils/FileHelperTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.utils;
+
+import io.pravega.test.common.AssertExtensions;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static io.pravega.cli.admin.utils.FileHelper.createFileAndDirectory;
+
+public class FileHelperTest {
+
+    @Test
+    public void testFileCreationSuccess() throws IOException {
+        Path tempDirPath = Files.createTempDirectory("fileHelperDir");
+        String filename = Paths.get(tempDirPath.toString(), "tmp" + System.currentTimeMillis(), "fileHelperTest.txt").toString();
+        createFileAndDirectory(filename);
+        File file = new File(filename);
+        Assert.assertTrue(file.exists());
+        // Delete file created during the test.
+        Files.deleteIfExists(Paths.get(filename));
+        // Delete the temporary directory.
+        tempDirPath.toFile().deleteOnExit();
+    }
+
+    @Test
+    public void testFileCreationFailureFileAlreadyExists() throws IOException {
+        Path tempDirPath = Files.createTempDirectory("fileHelperFailDir");
+        String filename = Paths.get(tempDirPath.toString(), "tmp" + System.currentTimeMillis(), "fileHelperTest.txt").toString();
+        createFileAndDirectory(filename);
+        File file = new File(filename);
+        Assert.assertTrue(file.exists());
+        AssertExtensions.assertThrows(FileAlreadyExistsException.class, () -> createFileAndDirectory(filename));
+        // Delete file created during the test.
+        Files.deleteIfExists(Paths.get(filename));
+        // Delete the temporary directory.
+        tempDirPath.toFile().deleteOnExit();
+    }
+}

--- a/cli/admin/src/test/java/io/pravega/cli/admin/utils/FileHelperTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/utils/FileHelperTest.java
@@ -44,6 +44,19 @@ public class FileHelperTest {
     }
 
     @Test
+    public void testFileCreationSuccessNoParentCase() throws IOException {
+        Path tempDirPath = Files.createTempDirectory("fileHelperDir");
+        String filename = Paths.get(tempDirPath.toString(), "fileHelperTest.txt").toString();
+        createFileAndDirectory(filename);
+        File file = new File(filename);
+        Assert.assertTrue(file.exists());
+        // Delete file created during the test.
+        Files.deleteIfExists(Paths.get(filename));
+        // Delete the temporary directory.
+        tempDirPath.toFile().deleteOnExit();
+    }
+
+    @Test
     public void testFileCreationFailureFileAlreadyExists() throws IOException {
         Path tempDirPath = Files.createTempDirectory("fileHelperFailDir");
         String filename = Paths.get(tempDirPath.toString(), "tmp" + System.currentTimeMillis(), "fileHelperTest.txt").toString();


### PR DESCRIPTION
**Change log description**  
Implements the following command:
- `controller-metadata update <table-name> <key> <new-value-json-file> <segmentstore-endpoint>`

An update to an existing one:
- `controller-metadata get <table-name> <key> <[OPTIONAL] json-file> <segmentstore-endpoint>`

**Purpose of the change**  
Fixes #6406

**What the code does**  
***Commands***
- For the `update` command.
    - Added a new class for the `update` command.
    - The command attempts a conditional update by querying the current version and then performing the update to the table using that.
    - The new value to be updated in the table is provided as a JSON file of the record.
    - The necessary segmentstore calls are made through the `AdminSegmentHelper`.
- For the `get` command.
    - The `get` command is now updated to have an optional file argument. If given, the queried record is stored in JSON format at the provided location, else the queried record is printed to the console in a user friendly manner.
    - This is to make sure that the user can generate JSON's to be used in the `update`. The user only need to tweak the JSON and pass it into `update`.

***JSON serializers***
- Added a new class `ControllerMetadataJsonSerializer` to deal with converting the records to and from JSON.
- This contains internal classes used as `TypeAdaptor`s to help deal with specific data types such as `ImmutableMap`, `ImmutableList`, `ImmutableSet` and `Map.Entry<Double, Double>`.

***Minor changes***
- The `createFileAndDirectory` method was moved from the `ReadSegmentRangeCommand` class to its own tested `FileHelper` class for general use.

**How to verify it**  
All tests must pass.
