### PR TITLE
Issue 6448: pravega version change to 0.10.2 on r0.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,7 @@ jjwtVersion=0.9.1
 bouncyCastleVersion=1.69
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.10.2-SNAPSHOT
+pravegaVersion=0.10.2
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
Change the pravegaVersion on branch `r0.10` from `0.10.2-SNAPSHOT` to `0.10.2`

**Purpose of the change**  
Fixes #6448
