### PR TITLE
Issue 6451: ContainerKeyIndex may be throttling updates to system critical segments

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -742,10 +742,9 @@ class ContainerKeyIndex implements AutoCloseable {
         @GuardedBy("this")
         private final HashMap<Long, AsyncSemaphore> throttlers = new HashMap<>();
 
-        // Only throttle segments that are not internal, system critical.
+        // Only throttle segments that are not system-critical.
         private final Predicate<DirectSegmentAccess> canThrottle = d -> !d.getInfo().getType().isCritical()
-                && !d.getInfo().getType().isSystem()
-                && !d.getInfo().getType().isInternal();
+                && !d.getInfo().getType().isSystem();
 
         @Override
         public void close() {
@@ -848,7 +847,7 @@ class ContainerKeyIndex implements AutoCloseable {
          * result of toExecute, otherwise it will be a different Future which will be completed when toExecute completes.
          */
         <T> CompletableFuture<T> throttleIfNeeded(DirectSegmentAccess segment, Supplier<CompletableFuture<T>> toExecute, int updateSize) {
-            // Apply credit-based throttling only for segments that are not internal, system-critical.
+            // Apply credit-based throttling only for segments that are not system-critical.
             long totalCredits = canThrottle.test(segment) ? config.getMaxUnindexedLength() : Long.MAX_VALUE;
             AsyncSemaphore throttler;
             synchronized (this) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -860,7 +860,9 @@ class ContainerKeyIndex implements AutoCloseable {
                     this.throttlers.put(segment.getSegmentId(), throttler);
                 }
             }
-
+            if (isSystemCriticalSegment.test(segment) && throttler.getUsedCredits() + updateSize > totalCredits) {
+                log.warn("{}: System-critical TableSegment {} is blocked due to reaching max unindexed size.", traceObjectId, segment.getSegmentId());
+            }
             return throttler.run(toExecute, updateSize, false); // No need to force anything at this time.
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableExtensionConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/TableExtensionConfig.java
@@ -43,6 +43,7 @@ public class TableExtensionConfig {
     public static final Property<Integer> MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE = Property.named("preindex.batch.bytes.max", EntrySerializer.MAX_BATCH_SIZE * 4);
     public static final Property<Integer> RECOVERY_TIMEOUT = Property.named("recovery.timeout.millis", 60000);
     public static final Property<Integer> MAX_UNINDEXED_LENGTH = Property.named("unindexed.bytes.max", EntrySerializer.MAX_BATCH_SIZE * 4);
+    public static final Property<Integer> SYSTEM_CRITICAL_MAX_UNINDEXED_LENGTH = Property.named("systemcritical.unindexed.bytes.max", EntrySerializer.MAX_BATCH_SIZE * 8);
     public static final Property<Integer> MAX_COMPACTION_SIZE = Property.named("compaction.bytes.max", EntrySerializer.MAX_SERIALIZATION_LENGTH * 4);
     public static final Property<Integer> COMPACTION_FREQUENCY = Property.named("compaction.frequency.millis", 30000);
     public static final Property<Integer> DEFAULT_MIN_UTILIZATION = Property.named("utilization.min", 75);
@@ -70,6 +71,13 @@ public class TableExtensionConfig {
      * to allow it to proceed.
      */
     private final int maxUnindexedLength;
+
+    /**
+     * Same as {@link #maxUnindexedLength}, but it applies specifically to system-critical Segments. This allows us to
+     * tune with more precision the amount of unindexed data for system-critical Segments, which are key to the
+     * operation of the system.
+     */
+    private final int systemCriticalMaxUnindexedLength;
 
     /**
      * The default value to supply to a {@link WriterTableProcessor} to indicate how big compactions need to be.
@@ -111,6 +119,7 @@ public class TableExtensionConfig {
         this.maxTailCachePreIndexLength = properties.getPositiveLong(MAX_TAIL_CACHE_PREINDEX_LENGTH);
         this.maxTailCachePreIndexBatchLength = properties.getPositiveInt(MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE);
         this.maxUnindexedLength = properties.getPositiveInt(MAX_UNINDEXED_LENGTH);
+        this.systemCriticalMaxUnindexedLength = properties.getPositiveInt(SYSTEM_CRITICAL_MAX_UNINDEXED_LENGTH);
         this.maxCompactionSize = properties.getPositiveInt(MAX_COMPACTION_SIZE);
         this.compactionFrequency = properties.getDuration(COMPACTION_FREQUENCY, ChronoUnit.MILLIS);
         this.defaultMinUtilization = properties.getNonNegativeInt(DEFAULT_MIN_UTILIZATION);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -15,6 +15,7 @@
  */
 package io.pravega.segmentstore.server.tables;
 
+import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.TimeoutTimer;
 import io.pravega.common.concurrent.Futures;
@@ -812,6 +813,9 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         segmentTracker.throttleIfNeeded(mockSegment, () -> CompletableFuture.completedFuture(null), updateSize).join();
         Assert.assertEquals(segmentTracker.getUnindexedSizeBytes(1L),
                 TableExtensionConfig.SYSTEM_CRITICAL_MAX_UNINDEXED_LENGTH.getDefaultValue() - 1);
+        // Now, we do another update and check that the Segment has no credit.
+        AssertExtensions.assertThrows(TimeoutException.class, () -> segmentTracker.throttleIfNeeded(mockSegment,
+                () -> CompletableFuture.completedFuture(null), updateSize).get(10, TimeUnit.MILLISECONDS));
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -20,6 +20,7 @@ import io.pravega.common.TimeoutTimer;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.util.BufferView;
 import io.pravega.common.util.ByteArraySegment;
+import io.pravega.segmentstore.contracts.SegmentType;
 import io.pravega.segmentstore.contracts.tables.BadKeyVersionException;
 import io.pravega.segmentstore.contracts.tables.KeyNotExistsException;
 import io.pravega.segmentstore.contracts.tables.TableAttributes;
@@ -28,6 +29,8 @@ import io.pravega.segmentstore.contracts.tables.TableKey;
 import io.pravega.segmentstore.contracts.tables.TableSegmentNotEmptyException;
 import io.pravega.segmentstore.server.CacheManager;
 import io.pravega.segmentstore.server.CachePolicy;
+import io.pravega.segmentstore.server.DirectSegmentAccess;
+import io.pravega.segmentstore.server.SegmentMetadata;
 import io.pravega.segmentstore.server.SegmentMock;
 import io.pravega.segmentstore.storage.cache.CacheStorage;
 import io.pravega.segmentstore.storage.cache.DirectMemoryCache;
@@ -785,6 +788,52 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         expectedUnindexedBytes = updateBatch4.getLength();
         Assert.assertEquals("Unexpected unindexed bytes after writing update4.",
                 expectedUnindexedBytes, context.index.getUnindexedSizeBytes(context.segment.getSegmentId()));
+    }
+
+    /**
+     * Tests that system-critical Segments get the right amount of credits.
+     */
+    @Test
+    public void testCriticalSegmentThrottling() {
+        @Cleanup
+        val context = new TestContext();
+        @Cleanup
+        ContainerKeyIndex.SegmentTracker segmentTracker = context.index.new SegmentTracker();
+        DirectSegmentAccess mockSegment = Mockito.mock(DirectSegmentAccess.class);
+        SegmentMetadata mockSegmentMetadata = Mockito.mock(SegmentMetadata.class);
+        // System critical segment.
+        SegmentType segmentType = SegmentType.builder().critical().system().build();
+        Mockito.when(mockSegmentMetadata.getType()).thenReturn(segmentType);
+
+        Mockito.when(mockSegment.getInfo()).thenReturn(mockSegmentMetadata);
+        Mockito.when(mockSegment.getSegmentId()).thenReturn(1L);
+        // Update size is 1 byte smaller than the limit, so it should not block.
+        int updateSize = TableExtensionConfig.SYSTEM_CRITICAL_MAX_UNINDEXED_LENGTH.getDefaultValue() - 1;
+        segmentTracker.throttleIfNeeded(mockSegment, () -> CompletableFuture.completedFuture(null), updateSize).join();
+        Assert.assertEquals(segmentTracker.getUnindexedSizeBytes(1L),
+                TableExtensionConfig.SYSTEM_CRITICAL_MAX_UNINDEXED_LENGTH.getDefaultValue() - 1);
+    }
+
+    /**
+     * Tests that regular Segments get the right amount of credits.
+     */
+    @Test
+    public void testRegularSegmentThrottling() {
+        @Cleanup
+        val context = new TestContext();
+        @Cleanup
+        ContainerKeyIndex.SegmentTracker segmentTracker = context.index.new SegmentTracker();
+        DirectSegmentAccess mockSegment = Mockito.mock(DirectSegmentAccess.class);
+        SegmentMetadata mockSegmentMetadata = Mockito.mock(SegmentMetadata.class);
+        // Regular segment.
+        SegmentType segmentType = SegmentType.builder().build();
+        Mockito.when(mockSegmentMetadata.getType()).thenReturn(segmentType);
+
+        Mockito.when(mockSegment.getInfo()).thenReturn(mockSegmentMetadata);
+        Mockito.when(mockSegment.getSegmentId()).thenReturn(1L);
+        int updateSize = TableExtensionConfig.MAX_UNINDEXED_LENGTH.getDefaultValue() - 1;
+        segmentTracker.throttleIfNeeded(mockSegment, () -> CompletableFuture.completedFuture(null), updateSize).join();
+        Assert.assertEquals(segmentTracker.getUnindexedSizeBytes(1L), TableExtensionConfig.MAX_UNINDEXED_LENGTH.getDefaultValue() - 1);
     }
 
     private void checkKeyOffsets(List<UUID> allHashes, Map<UUID, KeyWithOffset> offsets, Map<UUID, Long> bucketOffsets) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -15,7 +15,6 @@
  */
 package io.pravega.segmentstore.server.tables;
 
-import io.pravega.common.Exceptions;
 import io.pravega.common.ObjectClosedException;
 import io.pravega.common.TimeoutTimer;
 import io.pravega.common.concurrent.Futures;

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableExtensionConfigTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/TableExtensionConfigTests.java
@@ -34,6 +34,7 @@ public class TableExtensionConfigTests {
         Assert.assertEquals(EntrySerializer.MAX_BATCH_SIZE * 4, defaultConfig.getMaxTailCachePreIndexBatchLength());
         Assert.assertEquals(Duration.ofSeconds(60), defaultConfig.getRecoveryTimeout());
         Assert.assertEquals(EntrySerializer.MAX_BATCH_SIZE * 4, defaultConfig.getMaxUnindexedLength());
+        Assert.assertEquals(EntrySerializer.MAX_BATCH_SIZE * 8, defaultConfig.getSystemCriticalMaxUnindexedLength());
         Assert.assertEquals(EntrySerializer.MAX_SERIALIZATION_LENGTH * 4, defaultConfig.getMaxCompactionSize());
         Assert.assertEquals(Duration.ofSeconds(30), defaultConfig.getCompactionFrequency());
         Assert.assertEquals(75, defaultConfig.getDefaultMinUtilization());
@@ -56,6 +57,7 @@ public class TableExtensionConfigTests {
         b.with(TableExtensionConfig.COMPACTION_FREQUENCY, 15);
         b.with(TableExtensionConfig.DEFAULT_ROLLOVER_SIZE, 16L);
         b.with(TableExtensionConfig.MAX_BATCH_SIZE, 17);
+        b.with(TableExtensionConfig.SYSTEM_CRITICAL_MAX_UNINDEXED_LENGTH, 18);
 
         val c = b.build();
         Assert.assertEquals(10, c.getDefaultMinUtilization());
@@ -67,5 +69,6 @@ public class TableExtensionConfigTests {
         Assert.assertEquals(Duration.ofMillis(15), c.getCompactionFrequency());
         Assert.assertEquals(16, c.getDefaultRolloverSize());
         Assert.assertEquals(17, c.getMaxBatchSize());
+        Assert.assertEquals(18, c.getSystemCriticalMaxUnindexedLength());
     }
 }


### PR DESCRIPTION
**Change log description**  
Adds a new property for KVTables named "systemcritical.unindexed.bytes.max" that defines the amount of unindexed data we allow to system-critical KVTable Segments (defaulted to 256MB, 2x the amount of unindexed data we allow to regular segments).

**Purpose of the change**  
Fixes #6451 .

**What the code does**  
In some cases, when LTS is faulty or unavailable for some time, a single Segment Container can accumulate around 1M Operations before the throttler starts inducing max delays. However, we have seen that, in practice, this can lead to an accumulation of a lot of updates on KVTable Segments, and specially on system-critical ones. If the system gets to this state, it may happen that the `StorageWriter` cannot start upon a container recovery, as during its initialization it may be necessary to perform updates on some system-critical KVTables. 

This PR essentially does two things to mitigate this problem:
- First, in a similar spirit to what the ingestion path does by not throttling system-critical Segments, we provide by default a higher (2x) throttling threshold (i.e., unindexed data length) to system-critical KVTable Segments. This should prevent up to some extent to get into the issue that motivates this PR.
- Second, the unindexed data length that we allow to system-critical Segments is now defined by a configuration parameter, namely `systemcritical.unindexed.bytes.max`. This will allow us, in the case we find the same issue, to increase the credit only in the relevant KVTable Segments, instead on the whole system (which may lead to high memory pressure).

**How to verify it**  
Added new tests to validate that system-critical and regular segments get the right amount of credits.