### PR TITLE
Issue 6453 Revert PR 6282 that causes Zookeeper related tests fail on Github actions

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketManager.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketManager.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
-@SuppressWarnings("deprecation")
 @Slf4j
 public class ZooKeeperBucketManager extends BucketManager {
     private final ZookeeperBucketStore bucketStore;

--- a/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketService.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/ZooKeeperBucketService.java
@@ -28,7 +28,6 @@ import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
-@SuppressWarnings("deprecation")
 @Slf4j
 public class ZooKeeperBucketService extends BucketService {
     private final ZookeeperBucketStore bucketStore;

--- a/controller/src/main/java/io/pravega/controller/store/ZKStoreHelper.java
+++ b/controller/src/main/java/io/pravega/controller/store/ZKStoreHelper.java
@@ -40,7 +40,6 @@ import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 
-@SuppressWarnings("deprecation")
 @Slf4j
 public class ZKStoreHelper {
     @Getter(AccessLevel.PUBLIC)

--- a/controller/src/main/java/io/pravega/controller/store/host/ZKHostStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/host/ZKHostStore.java
@@ -38,7 +38,6 @@ import javax.annotation.concurrent.GuardedBy;
 /**
  * Zookeeper based implementation of the HostControllerStore.
  */
-@SuppressWarnings("deprecation")
 @Slf4j
 public class ZKHostStore implements HostControllerStore {
 

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZKGarbageCollector.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZKGarbageCollector.java
@@ -50,7 +50,6 @@ import org.apache.curator.framework.recipes.cache.NodeCacheListener;
  * The current batch is identified by a znode. All controller instances register a watch on this znode. And whenever batch
  * is updated, all watchers receive the latest update.
  */
-@SuppressWarnings("deprecation")
 @Slf4j
 class ZKGarbageCollector extends AbstractService {
     private static final String GC_ROOT = "/garbagecollection/%s";

--- a/controller/src/main/java/io/pravega/controller/store/stream/ZookeeperBucketStore.java
+++ b/controller/src/main/java/io/pravega/controller/store/stream/ZookeeperBucketStore.java
@@ -34,7 +34,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
-@SuppressWarnings("deprecation")
 @Slf4j
 public class ZookeeperBucketStore implements BucketStore {
     private static final String ROOT_PATH = "/";

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
@@ -74,7 +74,7 @@ import static org.mockito.Mockito.spy;
 public class ZkStreamTest {
     private static final String SCOPE = "scope";
     @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+    public Timeout globalTimeout = new Timeout(90, TimeUnit.SECONDS);
     private TestingServer zkTestServer;
     private CuratorFramework cli;
     private StreamMetadataStore storePartialMock;

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,8 +22,8 @@ org.gradle.jvmargs=-Xms1g
 #3rd party Versions
 apacheCommonsCsvVersion=1.5
 apacheCommonsCompressVersion=1.21
-apacheCuratorVersion=5.2.0
-apacheZookeeperVersion=3.6.3
+apacheCuratorVersion=4.0.1
+apacheZookeeperVersion=3.5.9
 awsSdkVersion=2.17.43
 checkstyleToolVersion=8.23
 bookKeeperVersion=4.14.1

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/ZKSegmentContainerMonitor.java
@@ -58,7 +58,6 @@ import org.apache.curator.utils.ZKPaths;
  * and starts or stops appropriate segment containers locally. Any start failures are periodically retried until
  * the desired ownership state is achieved.
  */
-@SuppressWarnings("deprecation")
 @Slf4j
 public class ZKSegmentContainerMonitor implements AutoCloseable {
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
@@ -47,7 +47,6 @@ import org.apache.bookkeeper.util.IOUtils;
 import org.apache.bookkeeper.util.LocalBookKeeper;
 import org.apache.commons.io.FileUtils;
 import org.apache.zookeeper.server.NettyServerCnxnFactory;
-import org.apache.zookeeper.server.ServerCnxn;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZKDatabase;
 import org.apache.zookeeper.server.ZooKeeperServer;
@@ -110,7 +109,7 @@ public class ZooKeeperServiceRunner implements AutoCloseable {
         this.serverFactory.set(NettyServerCnxnFactory.createFactory());
         val address = LOOPBACK_ADDRESS + ":" + this.zkPort;
         log.info("Starting Zookeeper server at " + address + " ...");
-        this.serverFactory.get().configure(new InetSocketAddress(LOOPBACK_ADDRESS, this.zkPort), 1000, 1000, secureZK);
+        this.serverFactory.get().configure(new InetSocketAddress(LOOPBACK_ADDRESS, this.zkPort), 1000, secureZK);
         this.serverFactory.get().startup(s);
 
         if (!waitForServerUp(this.zkPort, this.secureZK, this.keyStore, this.keyStorePasswordPath, this.trustStore,
@@ -123,7 +122,7 @@ public class ZooKeeperServiceRunner implements AutoCloseable {
         try {
             ServerCnxnFactory sf = this.serverFactory.getAndSet(null);
             if (sf != null) {
-                sf.closeAll(ServerCnxn.DisconnectReason.CLOSE_ALL_CONNECTIONS_FORCED);
+                sf.closeAll();
                 sf.shutdown();
             }
         } catch (Throwable e) {

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/zkImpl/ClusterZKImpl.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/zkImpl/ClusterZKImpl.java
@@ -55,7 +55,6 @@ import static io.pravega.common.cluster.ClusterListener.EventType.HOST_REMOVED;
  * - Ephemeral Node is valid until a session timeout, default session timeout is 60 seconds.
  * System property "curator-default-session-timeout" can be used to change it.
  */
-@SuppressWarnings("deprecation")
 @Slf4j
 public class ClusterZKImpl implements Cluster {
 


### PR DESCRIPTION
**Change log description**  
Revert PR 6282 that causes Zookeeper related tests fail on Github actions and increase timeout for tests in class ZKStreamTest that fail due to test timeout

**Purpose of the change**  
Fixes #6453

**What the code does**  
Revert PR PR 6282
Increase test timeout to 90 secs for ZKStreamTest

**How to verify it**  
Build should pass on GA
