### PR TITLE
Issue 6465: Removing Rule annotation for global timeout from Controller tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -153,7 +153,7 @@ jobs:
             ${{github.ref}}-${{github.run_id}}
             ${{github.ref}}
       - name: Controller Unit tests
-        run: ./gradlew controller:test shared:controller-api:test ${{env.GRADLE_OPTS}}
+        run: ./gradlew controller:test shared:controller-api:test --parallel ${{env.GRADLE_OPTS}}
       - name: Tar Reports
         run: tar --use-compress-program zstd -cf reports-${{github.job}}.tzst `echo ${{env.REPORTS_LOCATIONS}}`
       - name: Upload Reports

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -153,7 +153,7 @@ jobs:
             ${{github.ref}}-${{github.run_id}}
             ${{github.ref}}
       - name: Controller Unit tests
-        run: ./gradlew controller:test shared:controller-api:test --parallel ${{env.GRADLE_OPTS}}
+        run: ./gradlew controller:test shared:controller-api:test ${{env.GRADLE_OPTS}}
       - name: Tar Reports
         run: tar --use-compress-program zstd -cf reports-${{github.job}}.tzst `echo ${{env.REPORTS_LOCATIONS}}`
       - name: Upload Reports

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/CheckpointStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/CheckpointStoreTests.java
@@ -23,9 +23,7 @@ import io.pravega.test.common.AssertExtensions;
 import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -33,15 +31,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Checkpoint store test.
  */
 public abstract class CheckpointStoreTests {
 
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     protected CheckpointStore checkpointStore;
 
     @Before
@@ -70,7 +65,7 @@ public abstract class CheckpointStoreTests {
         checkpointStore.removeReaderGroup(process1, readerGroup1);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void folderOperationTests() throws CheckpointStoreException {
 
         final String process1 = "process1";

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ConcurrentEventProcessorTest.java
@@ -39,17 +39,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ConcurrentEventProcessorTest {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     @Data
     @AllArgsConstructor

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/EventProcessorTest.java
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Cleanup;
@@ -63,9 +62,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -233,8 +230,6 @@ public class EventProcessorTest {
         }
     }
 
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     private ScheduledExecutorService executor;
     
     @Before

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/SerializedRequestHandlerTest.java
@@ -24,9 +24,7 @@ import io.pravega.test.common.ThreadPooledTestSuite;
 import lombok.Data;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -37,7 +35,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -49,8 +46,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class SerializedRequestHandlerTest extends ThreadPooledTestSuite {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     @Test(timeout = 10000)
     public void testProcessEvent() throws InterruptedException, ExecutionException {

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZKCheckpointStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZKCheckpointStoreTests.java
@@ -58,7 +58,7 @@ public class ZKCheckpointStoreTests extends CheckpointStoreTests {
         zkServer.close();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void failingTests() {
         final String process1 = UUID.randomUUID().toString();
         final String readerGroup1 = UUID.randomUUID().toString();
@@ -95,7 +95,7 @@ public class ZKCheckpointStoreTests extends CheckpointStoreTests {
                 () -> checkpointStore.removeReaderGroup(process1, readerGroup1), predicate);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testRemoveProcess() throws Exception {
         final String process1 = "process1";
         final String readerGroup1 = "rg1";
@@ -144,7 +144,7 @@ public class ZKCheckpointStoreTests extends CheckpointStoreTests {
         });
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void readerWithoutCheckpointTest() throws Exception {
         final String process1 = "process1";
         final String readerGroup1 = "rg1";

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZkCheckpointStoreConnectivityTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZkCheckpointStoreConnectivityTest.java
@@ -25,19 +25,14 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 public class ZkCheckpointStoreConnectivityTest {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     private CuratorFramework cli;
     private CheckpointStore checkpointStore;
@@ -54,7 +49,7 @@ public class ZkCheckpointStoreConnectivityTest {
         cli.close();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void connectivityFailureTests() throws IOException {
         final String process1 = UUID.randomUUID().toString();
         final String readerGroup1 = UUID.randomUUID().toString();

--- a/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZkCheckpointStoreConnectivityTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventProcessor/impl/ZkCheckpointStoreConnectivityTest.java
@@ -25,14 +25,19 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 public class ZkCheckpointStoreConnectivityTest {
+    @Rule
+    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     private CuratorFramework cli;
     private CheckpointStore checkpointStore;
@@ -49,7 +54,7 @@ public class ZkCheckpointStoreConnectivityTest {
         cli.close();
     }
 
-    @Test(timeout = 30000)
+    @Test
     public void connectivityFailureTests() throws IOException {
         final String process1 = UUID.randomUUID().toString();
         final String readerGroup1 = UUID.randomUUID().toString();

--- a/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
@@ -42,12 +42,9 @@ import io.pravega.test.common.AssertExtensions;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -61,8 +58,6 @@ import static org.mockito.Mockito.times;
 
 @Slf4j
 public class EventProcessorGroupTest {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     private ScheduledExecutorService executor;
     private ScheduledExecutorService rebalanceExecutor;
     private EventProcessorGroup<ControllerEvent> requestEventProcessors;

--- a/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
@@ -113,6 +113,8 @@ public class EventProcessorGroupTest {
 
     @After
     public void tearDown() {
+        requestEventProcessors.stopAsync();
+        requestEventProcessors.awaitTerminated();
         ExecutorServiceHelpers.shutdown(executor);
         ExecutorServiceHelpers.shutdown(rebalanceExecutor);
     }

--- a/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
+++ b/controller/src/test/java/io/pravega/controller/eventprocessor/EventProcessorGroupTest.java
@@ -113,8 +113,8 @@ public class EventProcessorGroupTest {
 
     @After
     public void tearDown() {
-        executor.shutdownNow();
-        rebalanceExecutor.shutdownNow();
+        ExecutorServiceHelpers.shutdown(executor);
+        ExecutorServiceHelpers.shutdown(rebalanceExecutor);
     }
 
     @Test(timeout = 10000)

--- a/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/ControllerClusterListenerTest.java
@@ -49,10 +49,8 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 import org.junit.Assert;
 
 import static org.junit.Assert.assertEquals;
@@ -74,8 +72,6 @@ public class ControllerClusterListenerTest {
 
     @ClassRule
     public static final PravegaZkCuratorResource PRAVEGA_ZK_CURATOR_RESOURCE = new PravegaZkCuratorResource();
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     private ScheduledExecutorService executor;
     private ClusterZKImpl clusterZK;

--- a/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/SegmentContainerMonitorTest.java
@@ -29,10 +29,8 @@ import io.pravega.controller.store.host.impl.HostMonitorConfigImpl;
 import io.pravega.controller.util.Config;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 
 import java.util.Arrays;
 import java.util.List;
@@ -51,10 +49,6 @@ public class SegmentContainerMonitorTest {
     @ClassRule
     public static final PravegaZkCuratorResource PRAVEGA_ZK_CURATOR_RESOURCE = new PravegaZkCuratorResource();
     private static final String CLUSTER_NAME = "testcluster";
-
-    //Ensure each test completes within 30 seconds.
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     private Cluster cluster;
 
@@ -89,7 +83,7 @@ public class SegmentContainerMonitorTest {
         testMonitor(hostStore, latches);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testMonitorWithInMemoryStore() throws Exception {
         HostMonitorConfig config = HostMonitorConfigImpl.builder()
                 .hostMonitorEnabled(false)

--- a/controller/src/test/java/io/pravega/controller/fault/UniformContainerBalancerTest.java
+++ b/controller/src/test/java/io/pravega/controller/fault/UniformContainerBalancerTest.java
@@ -17,15 +17,12 @@ package io.pravega.controller.fault;
 
 import io.pravega.common.cluster.Host;
 import io.pravega.controller.util.Config;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -34,11 +31,7 @@ import static org.junit.Assert.assertTrue;
 
 public class UniformContainerBalancerTest {
 
-    //Ensure test completes within 5 seconds.
-    @Rule
-    public Timeout globalTimeout = new Timeout(5, TimeUnit.SECONDS);
-
-    @Test
+    @Test(timeout = 5000)
     public void testRebalancer() {
         UniformContainerBalancer balancer = new UniformContainerBalancer();
 

--- a/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
@@ -25,12 +25,9 @@ import io.pravega.client.stream.RetentionPolicy;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import static io.pravega.controller.server.rest.ModelHelper.encodeStreamResponse;
 import static io.pravega.controller.server.rest.ModelHelper.getCreateStreamConfig;
@@ -41,11 +38,7 @@ import static io.pravega.controller.server.rest.ModelHelper.getUpdateStreamConfi
  */
 public class ModelHelperTest {
 
-    //Ensure each test completes within 10 seconds.
-    @Rule
-    public Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
-
-    @Test
+    @Test(timeout = 10000)
     public void testGetCreateStreamConfig() {
         ScalingConfig scalingConfig = new ScalingConfig();
         scalingConfig.setType(ScalingConfig.TypeEnum.FIXED_NUM_SEGMENTS);
@@ -202,7 +195,7 @@ public class ModelHelperTest {
 
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testGetUpdateStreamConfig() {
         ScalingConfig scalingConfig = new ScalingConfig();
         scalingConfig.setType(ScalingConfig.TypeEnum.FIXED_NUM_SEGMENTS);
@@ -260,7 +253,7 @@ public class ModelHelperTest {
         Assert.assertEquals(12345L * 1024 * 1024, streamConfig.getRetentionPolicy().getRetentionParam());
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testEncodeStreamResponse() {
         StreamConfiguration streamConfig = StreamConfiguration.builder()
                 .scalingPolicy(ScalingPolicy.fixed(1))

--- a/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/PingTest.java
@@ -24,7 +24,6 @@ import io.pravega.test.common.SecurityConfigDefaults;
 import io.pravega.test.common.TestUtils;
 import java.net.URI;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
@@ -34,20 +33,13 @@ import javax.ws.rs.core.UriBuilder;
 import org.glassfish.jersey.SslConfigurator;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
-
 import static org.junit.Assert.assertEquals;
 
 /**
  * Test for ping API.
  */
 public abstract class PingTest {
-
-    //Ensure each test completes within 30 seconds.
-    @Rule
-    public final Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
 
     private RESTServerConfig serverConfig;
     private RESTServer restServer;
@@ -74,7 +66,7 @@ public abstract class PingTest {
         restServer.awaitTerminated();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void test() {
         URI streamResourceURI = UriBuilder.fromPath("//localhost:" + serverConfig.getPort() + "/ping")
                                           .scheme(getURLScheme()).build();

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -62,7 +62,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
@@ -74,9 +73,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static io.pravega.shared.NameUtils.getStreamForReaderGroup;
 import static org.junit.Assert.assertEquals;
@@ -97,10 +94,6 @@ import static org.mockito.Mockito.times;
  */
 @Slf4j
 public class StreamMetaDataTests {
-
-    //Ensure each test completes within 30 seconds.
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     protected final String scope1 = "scope1";
     protected final CreateStreamRequest createStreamRequest = new CreateStreamRequest();
@@ -327,7 +320,7 @@ public class StreamMetaDataTests {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    @Test
+    @Test(timeout = 30000)
     public void testCreateStream() throws ExecutionException, InterruptedException {
         String streamResourceURI = getURI() + "v1/scopes/" + scope1 + "/streams";
 
@@ -390,7 +383,7 @@ public class StreamMetaDataTests {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    @Test
+    @Test(timeout = 30000)
     public void testUpdateStream() throws ExecutionException, InterruptedException {
         String resourceURI = getURI() + "v1/scopes/" + scope1 + "/streams/" + stream1;
 
@@ -440,7 +433,7 @@ public class StreamMetaDataTests {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    @Test
+    @Test(timeout = 30000)
     public void testGetStream() throws ExecutionException, InterruptedException {
         String resourceURI = getURI() + "v1/scopes/" + scope1 + "/streams/" + stream1;
         String resourceURI2 = getURI() + "v1/scopes/" + scope1 + "/streams/" + stream2;
@@ -508,7 +501,7 @@ public class StreamMetaDataTests {
      *
      * @throws Exception
      */
-    @Test
+    @Test(timeout = 30000)
     public void testDeleteStream() throws Exception {
         final String resourceURI = getURI() + "v1/scopes/scope1/streams/stream1";
 
@@ -546,7 +539,7 @@ public class StreamMetaDataTests {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    @Test
+    @Test(timeout = 30000)
     public void testCreateScope() throws ExecutionException, InterruptedException {
         final CreateScopeRequest createScopeRequest = new CreateScopeRequest().scopeName(scope1);
         final String resourceURI = getURI() + "v1/scopes/";
@@ -588,7 +581,7 @@ public class StreamMetaDataTests {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    @Test
+    @Test(timeout = 30000)
     public void testDeleteScope() throws ExecutionException, InterruptedException {
         final String resourceURI = getURI() + "v1/scopes/scope1";
 
@@ -627,7 +620,7 @@ public class StreamMetaDataTests {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    @Test
+    @Test(timeout = 30000)
     public void testGetScope() throws ExecutionException, InterruptedException {
         final String resourceURI = getURI() + "v1/scopes/scope1";
         final String resourceURI2 = getURI() + "v1/scopes/scope2";
@@ -661,7 +654,7 @@ public class StreamMetaDataTests {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    @Test
+    @Test(timeout = 30000)
     public void testlistScopes() throws ExecutionException, InterruptedException {
         final String resourceURI = getURI() + "v1/scopes";
 
@@ -698,7 +691,7 @@ public class StreamMetaDataTests {
      * @throws ExecutionException
      * @throws InterruptedException
      */
-    @Test
+    @Test(timeout = 30000)
     public void testListStreams() throws ExecutionException, InterruptedException {
         final String resourceURI = getURI() + "v1/scopes/scope1/streams";
 
@@ -818,7 +811,7 @@ public class StreamMetaDataTests {
     /**
      * Test for updateStreamState REST API.
      */
-    @Test
+    @Test(timeout = 30000)
     public void testUpdateStreamState() throws Exception {
         final String resourceURI = getURI() + "v1/scopes/scope1/streams/stream1/state";
 
@@ -858,7 +851,7 @@ public class StreamMetaDataTests {
     /**
      * Test for getScalingEvents REST API.
      */
-    @Test
+    @Test(timeout = 30000)
     public void testGetScalingEvents() throws Exception {
         String resourceURI = getURI() + "v1/scopes/scope1/streams/stream1/scaling-events";
         List<ScaleMetadata> scaleMetadataList = new ArrayList<>();
@@ -981,7 +974,7 @@ public class StreamMetaDataTests {
     /**
      * Test for listReaderGroups REST API.
      */
-    @Test
+    @Test(timeout = 30000)
     public void testListReaderGroups() {
         final String resourceURI = getURI() + "v1/scopes/scope1/readergroups";
 
@@ -1046,7 +1039,7 @@ public class StreamMetaDataTests {
         response.close();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testGetReaderGroup() {
         final String resourceURI = getURI() + "v1/scopes/scope1/readergroups/readergroup1";
 

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceStarterTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceStarterTest.java
@@ -35,24 +35,19 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 /**
  * ControllerServiceStarter tests.
  */
 @Slf4j
 public abstract class ControllerServiceStarterTest {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     protected StoreClientConfig storeClientConfig;
     protected StoreClient storeClient;
     protected final int grpcPort;
@@ -74,7 +69,7 @@ public abstract class ControllerServiceStarterTest {
     @After
     public abstract void tearDown() throws Exception;
 
-    @Test
+    @Test(timeout = 30000)
     public void testStartStop() throws URISyntaxException {
         Assert.assertNotNull(storeClient);
         @Cleanup

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithKVTableTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithKVTableTest.java
@@ -51,15 +51,12 @@ import io.pravega.controller.task.Stream.StreamMetadataTasks;
 import io.pravega.controller.task.Stream.StreamTransactionMetadataTasks;
 import java.net.URI;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.mockito.Mockito.spy;
@@ -72,8 +69,7 @@ public abstract class ControllerServiceWithKVTableTest {
     @ClassRule
     public static final PravegaZkCuratorResource PRAVEGA_ZK_CURATOR_RESOURCE = new PravegaZkCuratorResource();
     private static final String SCOPE = "scope";
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+
     protected final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
     protected SegmentHelper segmentHelperMock;
 

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithStreamTest.java
@@ -71,7 +71,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
@@ -80,9 +79,7 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
@@ -103,8 +100,7 @@ public abstract class ControllerServiceWithStreamTest {
     private static final String SCOPE = "scope";
     private static final String STREAM = "stream";
     private static final String STREAM1 = "stream1";
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+
     protected final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
     protected CuratorFramework zkClient;
 

--- a/controller/src/test/java/io/pravega/controller/server/bucket/BucketServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/BucketServiceTest.java
@@ -38,21 +38,17 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public abstract class BucketServiceTest {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+
     StreamMetadataStore streamMetadataStore;
     BucketStore bucketStore;
     BucketManager retentionService;

--- a/controller/src/test/java/io/pravega/controller/server/bucket/WatermarkWorkflowTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/WatermarkWorkflowTest.java
@@ -57,7 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -68,10 +67,8 @@ import lombok.Synchronized;
 import org.apache.curator.RetryPolicy;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -90,8 +87,6 @@ public class WatermarkWorkflowTest {
     private static final RetryPolicy RETRY_POLICY = (r, e, s) -> false;
     @ClassRule
     public static final PravegaZkCuratorResource PRAVEGA_ZK_CURATOR_RESOURCE = new PravegaZkCuratorResource(10000, 1000, RETRY_POLICY);
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     StreamMetadataStore streamMetadataStore;
     BucketStore bucketStore;

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorTest.java
@@ -68,7 +68,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
@@ -78,10 +77,8 @@ import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -96,9 +93,6 @@ public abstract class ControllerEventProcessorTest {
     public static final PravegaZkCuratorResource PRAVEGA_ZK_CURATOR_RESOURCE = new PravegaZkCuratorResource(RETRY_POLICY);
     private static final String SCOPE = "scope";
     private static final String STREAM = "stream";
-
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     protected CuratorFramework zkClient;
     protected ScheduledExecutorService executor;

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
@@ -66,9 +66,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.listen.Listenable;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -89,8 +87,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 
 public class ControllerEventProcessorsTest extends ThreadPooledTestSuite {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     @Override
     public int getThreadPoolSize() {

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -50,16 +50,13 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;
@@ -78,9 +75,6 @@ import static org.mockito.Mockito.when;
 @Slf4j
 public class LocalControllerTest extends ThreadPooledTestSuite {
 
-    //Ensure each test completes within 10 seconds.
-    @Rule
-    public Timeout globalTimeout = new Timeout(10, TimeUnit.SECONDS);
     boolean authEnabled = false;
 
     private ControllerService mockControllerService;
@@ -97,7 +91,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
         this.testController = new LocalController(this.mockControllerService, authEnabled, "secret");
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testListScopes() {
         when(this.mockControllerService.listScopes(any(), anyInt(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(new ImmutablePair<>(Lists.newArrayList("a", "b", "c"),
@@ -111,7 +105,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
         Assert.assertNull(iterator.getNext().join());
     }
     
-    @Test
+    @Test(timeout = 10000)
     public void testCreateScope() throws ExecutionException, InterruptedException {
         when(this.mockControllerService.createScope(any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.CreateScopeStatus.newBuilder()
@@ -153,7 +147,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testDeleteScope() throws ExecutionException, InterruptedException {
         when(this.mockControllerService.deleteScope(any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteScopeStatus.newBuilder()
@@ -187,7 +181,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testCreateStream() throws ExecutionException, InterruptedException {
         when(this.mockControllerService.createStream(any(), any(), any(), anyLong(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
@@ -235,7 +229,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testUpdateStream() throws ExecutionException, InterruptedException {
         when(this.mockControllerService.updateStream(any(), any(), any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
@@ -271,7 +265,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testCreateReaderGroup() throws ExecutionException, InterruptedException {
         final Segment seg0 = new Segment("scope", "stream1", 0L);
         final Segment seg1 = new Segment("scope", "stream1", 1L);
@@ -339,7 +333,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testGetReaderGroupConfig() throws ExecutionException, InterruptedException {
         final String scope = "scope";
         final String streamName = "stream1";
@@ -397,7 +391,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testDeleteReaderGroup() throws ExecutionException, InterruptedException {
         final  UUID someUUID = UUID.randomUUID();
         when(this.mockControllerService.deleteReaderGroup(anyString(), anyString(), any(), anyLong())).thenReturn(
@@ -432,7 +426,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testUpdateReaderGroup() throws ExecutionException, InterruptedException {
         final Segment seg0 = new Segment("scope", "stream1", 0L);
         final Segment seg1 = new Segment("scope", "stream1", 1L);
@@ -484,7 +478,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testUpdateSubscriberStreamCut() throws ExecutionException, InterruptedException {
         UUID someId = UUID.randomUUID();
         StreamCut streamCut = new StreamCutImpl(new StreamImpl("scope", "stream"), Collections.emptyMap());
@@ -528,7 +522,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof IllegalArgumentException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testListSubscribers() throws ExecutionException, InterruptedException {
         List<String> subscriberList = new ArrayList<>(3);
         subscriberList.add("sub1");
@@ -563,7 +557,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
 
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testSealStream() throws ExecutionException, InterruptedException {
         when(this.mockControllerService.sealStream(any(), any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
@@ -599,7 +593,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testDeleteStream() throws ExecutionException, InterruptedException {
         when(this.mockControllerService.deleteStream(any(), any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteStreamStatus.newBuilder()
@@ -633,7 +627,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testScaleStream() throws ExecutionException, InterruptedException {
         when(this.mockControllerService.checkScale(anyString(), anyString(), anyInt(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.ScaleStatusResponse.newBuilder()
@@ -667,7 +661,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testGetSegmentsBetween() throws ExecutionException, InterruptedException {
         List<StreamSegmentRecord> list = new ArrayList<>();
         when(this.mockControllerService.getSegmentsBetweenStreamCuts(any(), anyLong())).thenReturn(
@@ -676,7 +670,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 new StreamCutImpl(new StreamImpl("scope", "stream"), Collections.emptyMap()))));
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testCreateKeyValueTable() {
         val kvtConfig = KeyValueTableConfiguration.builder().partitionCount(1).primaryKeyLength(4).secondaryKeyLength(4).build();
         when(this.mockControllerService.createKeyValueTable(any(), any(), any(), anyLong(), anyLong())).thenReturn(
@@ -724,7 +718,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testGetCurrentSegmentsKeyValueTable() throws Exception {
         Controller.StreamInfo info = Controller.StreamInfo.newBuilder().setScope("scope").setStream("kvtable").build();
         Controller.SegmentId segment1 = Controller.SegmentId.newBuilder().setSegmentId(1).setStreamInfo(info).build();
@@ -746,7 +740,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
         assertEquals(3, segments.getSegments().size());
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testListKeyValueTable() throws Exception {
         List<String> tablelist = new ArrayList<String>();
         tablelist.add("kvtable1");
@@ -757,7 +751,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
         assertEquals("kvtable1", info.getKeyValueTableName());
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testGetKeyValueTableConfiguration() {
         KeyValueTableConfiguration config = KeyValueTableConfiguration.builder().partitionCount(2).primaryKeyLength(4).secondaryKeyLength(4).build();
         when(this.mockControllerService.getKeyValueTableConfiguration(any(), any(), anyLong())).thenReturn(
@@ -791,7 +785,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testDeleteKeyValueTable() throws ExecutionException, InterruptedException {
         when(this.mockControllerService.deleteKeyValueTable(any(), any(), anyLong())).thenReturn(
                 CompletableFuture.completedFuture(Controller.DeleteKVTableStatus.newBuilder()
@@ -818,7 +812,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
                 ex -> ex instanceof ControllerFailureException);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testGetOrRefreshDelegationToken() {
         String token = this.testController.getOrRefreshDelegationTokenFor("scope", "stream", null).join();
          if (this.authEnabled) {
@@ -828,7 +822,7 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
          }
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testGetCurrentSegments() {
         Controller.StreamInfo info = Controller.StreamInfo.newBuilder().setScope("scope").setStream("stream").build();
         Controller.SegmentId segment1 = Controller.SegmentId.newBuilder().setSegmentId(1).setStreamInfo(info).build();

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -78,7 +78,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.NotImplementedException;
@@ -88,9 +87,7 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static io.pravega.shared.NameUtils.computeSegmentId;
 import static org.junit.Assert.assertEquals;
@@ -109,8 +106,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public abstract class ScaleRequestHandlerTest {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     protected ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
     protected CuratorFramework zkClient;
     protected StreamMetadataStore streamStore;

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestProcessorTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/requesthandlers/StreamRequestProcessorTest.java
@@ -26,15 +26,12 @@ import io.pravega.shared.controller.event.RequestProcessor;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import lombok.Data;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
@@ -45,8 +42,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public abstract class StreamRequestProcessorTest extends ThreadPooledTestSuite {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     @Override
     public int getThreadPoolSize() {

--- a/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/rpc/auth/ControllerGrpcAuthFocusedTest.java
@@ -97,7 +97,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -105,7 +104,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
 
 import static io.pravega.auth.AuthFileUtils.credentialsAndAclAsString;
 
@@ -132,12 +130,6 @@ public class ControllerGrpcAuthFocusedTest {
     private final static File AUTH_FILE = createAuthFile();
 
     private final static String DEFAULT_PASSWORD = "1111_aaaa";
-
-    /**
-     * This rule makes sure that the tests in this class run in 10 seconds or less.
-     */
-    @Rule
-    public final Timeout globalTimeout = new Timeout(20, TimeUnit.SECONDS);
 
     /**
      * This rule is used later to expect both the exception class and the message.
@@ -263,7 +255,7 @@ public class ControllerGrpcAuthFocusedTest {
         TransactionMetrics.reset();
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void createScopeSucceedsForPrivilegedUser() {
         //Arrange
         ControllerServiceGrpc.ControllerServiceBlockingStub blockingStub =
@@ -276,7 +268,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(CreateScopeStatus.Status.SUCCESS, status.getStatus());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void createScopeFailsForUnauthorizedUser() {
         //Arrange
         ControllerServiceGrpc.ControllerServiceBlockingStub blockingStub =
@@ -290,7 +282,7 @@ public class ControllerGrpcAuthFocusedTest {
         blockingStub.createScope(Controller.ScopeInfo.newBuilder().setScope("dummy").build());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void createScopeFailsForNonExistentUser() {
         //Arrange
         ControllerServiceBlockingStub blockingStub =
@@ -304,7 +296,7 @@ public class ControllerGrpcAuthFocusedTest {
         blockingStub.createScope(Controller.ScopeInfo.newBuilder().setScope("dummy").build());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void createReaderGroupSucceedsForPrivilegedUserInStrictCase() {
         //Arrange
         String scope = "scope1";
@@ -321,7 +313,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, status.getStatus());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void createReaderGroupSucceedsForLowerPrivilegedUser() {
         //Arrange
         String scope = "scope1";
@@ -338,7 +330,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(Controller.CreateReaderGroupResponse.Status.SUCCESS, status.getStatus());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void createReaderGroupFailsForLowerPrivilegedUserInStrictCase() {
         //Arrange
         String scope = "scope1";
@@ -356,7 +348,7 @@ public class ControllerGrpcAuthFocusedTest {
         Controller.CreateReaderGroupResponse status = blockingStub.createReaderGroup(config);
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void createReaderGroupFailsForUnauthorizedUser() {
         //Arrange
         String scope = "test";
@@ -374,7 +366,7 @@ public class ControllerGrpcAuthFocusedTest {
         Controller.CreateReaderGroupResponse status = blockingStub.createReaderGroup(config);
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void createReaderGroupFailsForNonExistentUser() {
         //Arrange
         String scope = "test";
@@ -392,7 +384,7 @@ public class ControllerGrpcAuthFocusedTest {
         Controller.CreateReaderGroupResponse status = blockingStub.createReaderGroup(config);
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void deleteReaderGroupSucceedsForPrivilegedUserInStrictCase() {
         //Arrange
         String scope = "scope1";
@@ -413,7 +405,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(Controller.DeleteReaderGroupStatus.Status.SUCCESS, status.getStatus());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void deleteReaderGroupSucceedsForLowerPrivilegedUser() {
         //Arrange
         String scope = "scope1";
@@ -434,7 +426,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(Controller.DeleteReaderGroupStatus.Status.SUCCESS, status.getStatus());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void deleteReaderGroupFailsForLowerPrivilegedUserInStrictCase() {
         //Arrange
         String scope = "scope1";
@@ -452,7 +444,7 @@ public class ControllerGrpcAuthFocusedTest {
                 "group", UUID.randomUUID().toString(), 0));
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void deleteReaderGroupFailsForUnauthorizedUser() {
         //Arrange
         String scope = "test";
@@ -470,7 +462,7 @@ public class ControllerGrpcAuthFocusedTest {
                 "group", UUID.randomUUID().toString(), 0));
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void deleteReaderGroupFailsForNonExistentUser() {
         //Arrange
         String scope = "test";
@@ -488,7 +480,7 @@ public class ControllerGrpcAuthFocusedTest {
                 "group", UUID.randomUUID().toString(), 0));
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void updateReaderGroupSucceedsForPrivilegedUserInStrictCase() {
         //Arrange
         String scope = "scope1";
@@ -514,7 +506,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(Controller.UpdateReaderGroupResponse.Status.SUCCESS, status.getStatus());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void updateReaderGroupSucceedsForLowerPrivilegedUser() {
         //Arrange
         String scope = "scope1";
@@ -541,7 +533,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(Controller.UpdateReaderGroupResponse.Status.SUCCESS, status.getStatus());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void updateReaderGroupFailsForLowerPrivilegedUserInStrictCase() {
         //Arrange
         String scope = "scope1";
@@ -563,7 +555,7 @@ public class ControllerGrpcAuthFocusedTest {
         Controller.UpdateReaderGroupResponse status = blockingStub.updateReaderGroup(config);
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void updateReaderGroupFailsForUnauthorizedUser() {
         //Arrange
         String scope = "test";
@@ -582,7 +574,7 @@ public class ControllerGrpcAuthFocusedTest {
         Controller.UpdateReaderGroupResponse status = blockingStub.updateReaderGroup(config);
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void updateReaderGroupFailsForNonExistentUser() {
         //Arrange
         String scope = "test";
@@ -601,7 +593,7 @@ public class ControllerGrpcAuthFocusedTest {
         Controller.UpdateReaderGroupResponse status = blockingStub.updateReaderGroup(config);
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void getUriSucceedsForPrivilegedUser() {
         String scope = "scope1";
         String stream = "stream1";
@@ -622,7 +614,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(12345, nodeUri2.getPort());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void getUriFailsForNonExistentUser() {
         String scope = "scope1";
         String stream = "stream1";
@@ -639,7 +631,7 @@ public class ControllerGrpcAuthFocusedTest {
         NodeUri nodeUri1 = stub.getURI(segmentId(scope, stream, 0));
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void isSegmentValidSucceedsForAuthorizedUser() {
         String scope = "scope1";
         String stream = "stream1";
@@ -650,7 +642,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertFalse(stub.isSegmentValid(segmentId(scope, stream, 3)).getResponse());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void isSegmentValidFailsForUnauthorizedUser() {
         String scope = "scope1";
         String stream = "stream1";
@@ -667,7 +659,7 @@ public class ControllerGrpcAuthFocusedTest {
         stub.isSegmentValid(segmentId(scope, stream, 0));
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void pingTransactionSucceedsForAuthorizedUser() {
         String scope = "scope1";
         String stream = "stream1";
@@ -685,7 +677,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(PingTxnStatus.Status.OK, status.getStatus());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void pingTransactionFailsForUnAuthorizedUser() {
         String scope = "scope1";
         String stream = "stream1";
@@ -706,7 +698,7 @@ public class ControllerGrpcAuthFocusedTest {
                 .build());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void listScopes() {
         // Arrange
         ControllerServiceBlockingStub stub =
@@ -741,7 +733,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals("3", response.getContinuationToken().getToken());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void listStreamsReturnsAllWhenUserHasWildCardAccessUsingBlockingStub() {
         // Arrange
         String scopeName = "scope1";
@@ -761,7 +753,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(2, response.getStreamsList().size());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void listStreamsReturnsAllWhenUserHasWildCardAccessUsingAsyncStub() {
         // Arrange
         String scopeName = "scope1";
@@ -782,7 +774,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(2, streamsInResponse.size());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void listStreamReturnsEmptyResultWhenUserHasNoAccessToStreams() {
         // Arrange
         createScopeAndStreams("scope1", Arrays.asList("stream1", "stream2", "stream3"),
@@ -800,7 +792,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(0, response.getStreamsList().size());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void listStreamFiltersResultWhenUserHasAccessToSubsetOfStreams() {
         // Arrange
         String scope = "scope1";
@@ -831,7 +823,7 @@ public class ControllerGrpcAuthFocusedTest {
         assertEquals(2, response.getStreamsList().size());
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void listStreamThrowsExceptionWhenUserHasNoAccessToScope() {
         // Arrange
         createScopeAndStreams("scope1", Arrays.asList("stream1", "stream2", "stream3"),
@@ -849,7 +841,7 @@ public class ControllerGrpcAuthFocusedTest {
                 e -> e.getMessage().contains("PERMISSION_DENIED"));
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void listStreamThrowsExceptionWhenUserIsNonExistent() {
         // Arrange
         createScopeAndStreams("scope1", Arrays.asList("stream1", "stream2", "stream3"),
@@ -867,7 +859,7 @@ public class ControllerGrpcAuthFocusedTest {
                 e -> e.getMessage().contains("UNAUTHENTICATED"));
     }
 
-    @Test
+    @Test(timeout = 20000)
     public void listKVTFiltersResultWhenUserHasAccessToSubsetOfTables() {
         // Arrange
         String scope = "scope1";

--- a/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/v1/ControllerServiceTest.java
@@ -62,15 +62,12 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -91,8 +88,6 @@ public class ControllerServiceTest {
     @ClassRule
     public static final PravegaZkCuratorResource PRAVEGA_ZK_CURATOR_RESOURCE = new PravegaZkCuratorResource();
     private static final String SCOPE = "scope";
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     private final String stream1 = "stream1";
     private final String stream2 = "stream2";

--- a/controller/src/test/java/io/pravega/controller/store/ZKStoreHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/ZKStoreHelperTest.java
@@ -28,14 +28,11 @@ import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -44,9 +41,6 @@ import static org.junit.Assert.assertTrue;
  * Unit tests for ZKStoreHelper.
  */
 public class ZKStoreHelperTest {
-    //Ensure each test completes within 30 seconds.
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     private TestingServer zkServer;
     private CuratorFramework cli;
@@ -68,7 +62,7 @@ public class ZKStoreHelperTest {
         zkServer.close();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testAddNode() throws ExecutionException, InterruptedException, IOException {
         Assert.assertNull(zkStoreHelper.addNode("/test/test1").get());
         AssertExtensions.assertFutureThrows("Should throw NodeExistsException", zkStoreHelper.addNode("/test/test1"),
@@ -78,7 +72,7 @@ public class ZKStoreHelperTest {
                 e -> e instanceof StoreException.StoreConnectionException);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testDeleteNode() throws ExecutionException, InterruptedException, IOException {
         Assert.assertNull(zkStoreHelper.addNode("/test/test1").get());
 
@@ -96,7 +90,7 @@ public class ZKStoreHelperTest {
                 e -> e instanceof StoreException.StoreConnectionException);
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void testDeleteConditionally() {
         String path = "/test/test/deleteConditionally";
         zkStoreHelper.createZNode(path, new byte[0]).join();
@@ -107,7 +101,7 @@ public class ZKStoreHelperTest {
                 e -> Exceptions.unwrap(e) instanceof StoreException.WriteConflictException);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testEphemeralNode() {
         CuratorFramework cli2 = CuratorFrameworkFactory.newClient(zkServer.getConnectString(), new RetryNTimes(0, 0));
         cli2.start();
@@ -123,7 +117,7 @@ public class ZKStoreHelperTest {
                 e -> e instanceof StoreException.DataNotFoundException);
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void testGetChildren() {
         zkStoreHelper.createZNodeIfNotExist("/1").join();
         zkStoreHelper.createZNodeIfNotExist("/1/1").join();
@@ -141,7 +135,7 @@ public class ZKStoreHelperTest {
                 e -> e instanceof StoreException.DataNotFoundException);
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void testSync() {
         String path = "/path";
         byte[] entry = new byte[1];

--- a/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
@@ -21,7 +21,6 @@ import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -30,13 +29,10 @@ import org.apache.curator.test.TestingServer;
 import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 public class StoreClientFactoryTest extends ThreadPooledTestSuite {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+
     TestingServer zkServer;
 
     @Override
@@ -60,7 +56,7 @@ public class StoreClientFactoryTest extends ThreadPooledTestSuite {
      * create a new Zookeeper client and, in fact, we close the existing one to force the restart of the Controller.
      * During the Controller restart, a new Zookeeper client will be created with the new parameters.
      */
-    @Test
+    @Test(timeout = 30000)
     public void testZkSessionExpiryWithChangedParameters() throws Exception {
         final String testZNode = "/test";
 

--- a/controller/src/test/java/io/pravega/controller/store/index/ZkHostIndexTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/index/ZkHostIndexTest.java
@@ -22,16 +22,13 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.retry.RetryOneTime;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -45,8 +42,6 @@ public class ZkHostIndexTest {
     private static final RetryPolicy RETRY_POLICY = new RetryOneTime(2000);
     @ClassRule
     public static final PravegaZkCuratorResource PRAVEGA_ZK_CURATOR_RESOURCE = new PravegaZkCuratorResource(RETRY_POLICY);
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     protected final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
 
     @Before
@@ -59,7 +54,7 @@ public class ZkHostIndexTest {
         ExecutorServiceHelpers.shutdown(executor);
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void testSync() {
         ZKHostIndex index = spy(new ZKHostIndex(PRAVEGA_ZK_CURATOR_RESOURCE.client, "/hostRequestIndex", executor));
         String hostId = "hostId";

--- a/controller/src/test/java/io/pravega/controller/store/kvtable/KVTableMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/kvtable/KVTableMetadataStoreTest.java
@@ -25,13 +25,10 @@ import io.pravega.controller.stream.api.grpc.v1.Controller;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
@@ -42,10 +39,6 @@ import static org.junit.Assert.assertTrue;
  * Stream metadata test.
  */
 public abstract class KVTableMetadataStoreTest {
-
-    //Ensure each test completes within 10 seconds.
-    @Rule 
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     protected KVTableMetadataStore store;
     protected StreamMetadataStore streamStore;
     protected final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
@@ -68,7 +61,7 @@ public abstract class KVTableMetadataStoreTest {
 
     abstract Controller.CreateScopeStatus createScope(String scopeName) throws Exception;
 
-    @Test
+    @Test(timeout = 30000)
     public void testKVTableMetadataStore() throws Exception {
         Controller.CreateScopeStatus scopeCreateStatus = createScope(scope);
         assertTrue(scopeCreateStatus.getStatus().equals(Controller.CreateScopeStatus.Status.SUCCESS)
@@ -97,7 +90,7 @@ public abstract class KVTableMetadataStoreTest {
         // endregion
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void listTablesInScope() throws Exception {
         // list KeyValueTables in scope
         Controller.CreateScopeStatus scopeCreateStatus = createScope(scope);
@@ -136,7 +129,7 @@ public abstract class KVTableMetadataStoreTest {
         }
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void deleteKeyValueTableTest() throws Exception {
         final String scopeName = "ScopeDelete";
         final String kvtName = "KVTableDelete";

--- a/controller/src/test/java/io/pravega/controller/store/kvtable/PravegaTablesKVTMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/kvtable/PravegaTablesKVTMetadataStoreTest.java
@@ -81,7 +81,7 @@ public class PravegaTablesKVTMetadataStoreTest extends KVTableMetadataStoreTest 
         return streamStore.createScope(scopeName, null, executor).get();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testInvalidOperation() throws Exception {
         // Test operation when stream is not in active state
         streamStore.createScope(scope, null, executor).get();
@@ -95,7 +95,7 @@ public class PravegaTablesKVTMetadataStoreTest extends KVTableMetadataStoreTest 
                 (Throwable t) -> t instanceof StoreException.IllegalStateException);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testPartiallyDeletedScope() throws Exception {
         final String scopeName = "partialScope";
 

--- a/controller/src/test/java/io/pravega/controller/store/kvtable/ZookeeperKVTMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/kvtable/ZookeeperKVTMetadataStoreTest.java
@@ -54,7 +54,7 @@ public class ZookeeperKVTMetadataStoreTest extends KVTableMetadataStoreTest {
         return streamStore.createScope(scopeName, null, executor).get();
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void testInvalidOperation() throws Exception {
         // Test operation when stream is not in active state
         streamStore.createScope(scope, null, executor).get();

--- a/controller/src/test/java/io/pravega/controller/store/stream/BucketStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/BucketStoreTest.java
@@ -23,22 +23,17 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public abstract class BucketStoreTest {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     BucketStore bucketStore;
     ScheduledExecutorService executorService;
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/HostStoreTest.java
@@ -33,15 +33,12 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.test.TestingServer;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
@@ -50,14 +47,12 @@ import static org.junit.Assert.assertEquals;
  */
 @Slf4j
 public class HostStoreTest {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     private final String host = "localhost";
     private final int controllerPort = 9090;
     private final int containerCount = 4;
 
-    @Test
+    @Test(timeout = 30000)
     public void inMemoryStoreTests() {
         HostMonitorConfig hostMonitorConfig = HostMonitorConfigImpl.builder()
                 .hostMonitorEnabled(false)

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -1684,7 +1684,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(beforeRef.getRecordingTime(), streamCut4.getRecordingTime());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void sizeTest() throws Exception {
         final String scope = "ScopeSize";
         final String stream = "StreamSize";

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamMetadataStoreTest.java
@@ -67,15 +67,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static io.pravega.shared.NameUtils.computeSegmentId;
 import static org.junit.Assert.assertEquals;
@@ -94,9 +91,6 @@ import static org.mockito.Mockito.spy;
  */
 public abstract class StreamMetadataStoreTest {
 
-    //Ensure each test completes within 30 seconds.
-    @Rule 
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     protected TestStore store;
     protected BucketStore bucketStore;
     protected final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
@@ -119,7 +113,7 @@ public abstract class StreamMetadataStoreTest {
         ExecutorServiceHelpers.shutdown(executor);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testStreamMetadataStore() throws InterruptedException, ExecutionException {
 
         // region createStream
@@ -229,7 +223,7 @@ public abstract class StreamMetadataStoreTest {
         // endregion
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void listScopesPaginated() throws Exception {
         // list stream in scope
         String scope = "scopeList";
@@ -250,7 +244,7 @@ public abstract class StreamMetadataStoreTest {
         assertFalse(Strings.isNullOrEmpty(scopes.getValue()));
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void listStreamsInScope() throws Exception {
         // list stream in scope
         store.createScope("Scope", null, executor).get();
@@ -275,7 +269,7 @@ public abstract class StreamMetadataStoreTest {
         }
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void listStreamsInScopePaginated() throws Exception {
         // list stream in scope
         String scope = "scopeList";
@@ -314,7 +308,7 @@ public abstract class StreamMetadataStoreTest {
         assertFalse(Strings.isNullOrEmpty(streamInScope.getValue()));
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void partialStreamsInScope() throws Exception {
         // list stream in scope
         store.createScope("Scope", null, executor).get();
@@ -354,7 +348,7 @@ public abstract class StreamMetadataStoreTest {
         assertFalse("List streams in scope", streamInScope.containsKey(partial));
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void listScopes() throws Exception {
         // list scopes test
         List<String> list = store.listScopes(executor, 0L).get();
@@ -378,7 +372,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals("List Scopes size", 2, list.size());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void getScopeTest() throws Exception {
         final String scope1 = "Scope1";
         final String scope2 = "Scope2";
@@ -395,7 +389,7 @@ public abstract class StreamMetadataStoreTest {
                 (Throwable t) -> t instanceof StoreException.DataNotFoundException);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void txnHostIndexTest() {
         String host1 = "host1";
         String host2 = "host2";
@@ -453,7 +447,7 @@ public abstract class StreamMetadataStoreTest {
         Assert.assertEquals(version, store.getTxnVersionFromIndex(host, txnResource).join());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void scaleTest() throws Exception {
         final String scope = "ScopeScale";
         final String stream = "StreamScale";
@@ -611,7 +605,7 @@ public abstract class StreamMetadataStoreTest {
         // endregion
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void concurrentStartScaleTest() throws Exception {
         final String scope = "ScopeScale";
         final String stream = "StreamScale1";
@@ -712,7 +706,7 @@ public abstract class StreamMetadataStoreTest {
         // endregion
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void updateTest() throws Exception {
         final String scope = "ScopeUpdate";
         final String stream = "StreamUpdate";
@@ -752,7 +746,7 @@ public abstract class StreamMetadataStoreTest {
         store.setState(scope, stream, State.ACTIVE, null, executor).join();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void deleteTest() throws Exception {
         final String scope = "ScopeDelete";
         final String stream = "StreamDelete";
@@ -772,7 +766,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(status.getStatus(), DeleteScopeStatus.Status.SUCCESS);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void scaleWithTxTest() throws Exception {
         final String scope = "ScopeScaleWithTx";
         final String stream = "StreamScaleWithTx";
@@ -918,7 +912,7 @@ public abstract class StreamMetadataStoreTest {
         // endregion
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void scaleWithTxnForInconsistentScanerios() throws Exception {
         final String scope = "ScopeScaleWithTx";
         final String stream = "StreamScaleWithTx1";
@@ -984,7 +978,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(State.ACTIVE, stateVal);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void txnOrderTest() throws Exception {
         final String scope = "txnOrder";
         final String stream = "txnOrder";
@@ -1157,7 +1151,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(positions.get(3L), tx02);
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void txnCommitBatchLimitTest() throws Exception {
         final String scope = "txnCommitBatch";
         final String stream = "txnCommitBatch";
@@ -1213,7 +1207,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(tx02, orderedRecords.get(0).getId());
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void txnCommitBatchLimitMaxLimitExceedingTest() throws Exception {
         final String scope = "txnCommitBatchMax";
         final String stream = "txnCommitBatchMax";
@@ -1258,7 +1252,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(tx01, ordered.get(1).getId());
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void txnCommitBatchLimitOrderTest() throws Exception {
         final String scope = "txnCommitBatch2";
         final String stream = "txnCommitBatch2";
@@ -1341,7 +1335,7 @@ public abstract class StreamMetadataStoreTest {
         store.setState(scope, stream, State.ACTIVE, null, executor).join();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void truncationTest() throws Exception {
         final String scope = "ScopeTruncate";
         final String stream = "ScopeTruncate";
@@ -1385,7 +1379,7 @@ public abstract class StreamMetadataStoreTest {
         store.setState(scope, stream, State.ACTIVE, null, executor).join();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void streamCutTest() throws Exception {
         final String scope = "ScopeStreamCut";
         final String stream = "StreamCut";
@@ -1418,7 +1412,7 @@ public abstract class StreamMetadataStoreTest {
         assertFalse(store.isStreamCutValid(scope, stream, invalid, null, executor).join());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void retentionSetTest() throws Exception {
         final String scope = "ScopeRetain";
         final String stream = "StreamRetain";
@@ -1482,7 +1476,7 @@ public abstract class StreamMetadataStoreTest {
         assertTrue(!streams.contains(String.format("%s/%s", scope, stream)));
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void strictlyGreaterThanTest() throws Exception {
         final String scope = "ScopeRetain3";
         final String stream = "StreamRetain";
@@ -1526,7 +1520,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(store.compareStreamCut(scope, stream, streamCut, map1, null, executor).join(), StreamCutComparison.EqualOrAfter);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void streamCutReferenceRecordBeforeTest() throws Exception {
         final String scope = "ScopeRetain2";
         final String stream = "StreamRetain";
@@ -1781,7 +1775,7 @@ public abstract class StreamMetadataStoreTest {
         // endregion
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void getSafeStartingSegmentNumberForTest() {
         final String scope = "RecreationScope";
         final String stream = "RecreatedStream";
@@ -1802,7 +1796,7 @@ public abstract class StreamMetadataStoreTest {
         }
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void recordLastStreamSegmentTest() {
         final String scope = "RecreationScope2";
         final String stream = "RecreatedStream2";
@@ -1814,7 +1808,7 @@ public abstract class StreamMetadataStoreTest {
         }
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void deletePartiallyCreatedStreamTest() {
         final String scopeName = "RecreationScopePartial";
         final String streamName = "RecreatedStreamPartial";
@@ -1860,7 +1854,7 @@ public abstract class StreamMetadataStoreTest {
         // endregion
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void testWriterMark() {
         String stream = "mark";
         store.createScope(scope, null, executor).join();
@@ -1919,7 +1913,7 @@ public abstract class StreamMetadataStoreTest {
         assertTrue(marks.containsKey(writer4));
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testMarkOnTransactionCommit() {
         // create txn
         // seal txn with committing
@@ -1954,7 +1948,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(mark.getPosition().get(0L).longValue(), 1L);
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void testHistoryTimeSeriesChunk() throws Exception {
         String scope = "history";
         String stream = "history";
@@ -1963,7 +1957,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(chunk.getLatestRecord().getEpoch(), 2);
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void testSealedSegmentSizeMapShard() throws Exception {
         String scope = "sealedMap";
         String stream = "sealedMap";
@@ -1974,7 +1968,7 @@ public abstract class StreamMetadataStoreTest {
         assertNull(shard.getSize(NameUtils.computeSegmentId(2, 2)));
     }
     
-    @Test
+    @Test(timeout = 30000)
     public void testSegmentSealedEpoch() throws Exception {
         String scope = "sealedMap";
         String stream = "sealedMap";
@@ -1990,7 +1984,7 @@ public abstract class StreamMetadataStoreTest {
         assertEquals(epoch, -1);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testReaderGroups() throws Exception {
         final String scopeRGTest = "scopeRGTest";
         final String streamRGTest = "streamRGTest";

--- a/controller/src/test/java/io/pravega/controller/store/stream/StreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/StreamTest.java
@@ -40,7 +40,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
@@ -48,10 +47,8 @@ import org.apache.curator.RetryPolicy;
 import org.apache.curator.retry.RetryOneTime;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -62,8 +59,6 @@ public class StreamTest extends ThreadPooledTestSuite {
     private static final RetryPolicy RETRY_POLICY = new RetryOneTime(2000);
     @ClassRule
     public static final PravegaZkCuratorResource PRAVEGA_ZK_CURATOR_RESOURCE = new PravegaZkCuratorResource(RETRY_POLICY);
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     private ZkOrderedStore orderer;
 
     @Override

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZKCounterTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZKCounterTest.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -33,9 +32,7 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -50,8 +47,6 @@ import static org.mockito.Mockito.verify;
  * Zookeeper based counter tests.
  */
 public class ZKCounterTest {
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     private TestingServer zkServer;
     private CuratorFramework cli;
     private ScheduledExecutorService executor;
@@ -74,7 +69,7 @@ public class ZKCounterTest {
         ExecutorServiceHelpers.shutdown(executor);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testCounter() throws Exception {
         ZKStoreHelper storeHelper = spy(new ZKStoreHelper(cli, executor));
         storeHelper.createZNodeIfNotExist("/store/scope").join();
@@ -136,7 +131,7 @@ public class ZKCounterTest {
         assertEquals(Long.MAX_VALUE - 99, newCounter2.getLsb());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testCounterConcurrentUpdates() {
         ZKStoreHelper storeHelper = spy(new ZKStoreHelper(cli, executor));
         storeHelper.createZNodeIfNotExist("/store/scope").join();

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkGarbageCollectorTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkGarbageCollectorTest.java
@@ -26,7 +26,6 @@ import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -34,16 +33,12 @@ import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 
 public class ZkGarbageCollectorTest extends ThreadPooledTestSuite {
 
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     private TestingServer zkServer;
     private CuratorFramework cli;
 

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkOrderedStoreTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkOrderedStoreTest.java
@@ -23,16 +23,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -43,9 +40,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 public class ZkOrderedStoreTest {
-    //Ensure each test completes within 30 seconds.
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     private TestingServer zkServer;
     private CuratorFramework cli;
@@ -67,7 +61,7 @@ public class ZkOrderedStoreTest {
         zkServer.close();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testStore() {
         String test = "test";
         String scope = "test";
@@ -141,7 +135,7 @@ public class ZkOrderedStoreTest {
         assertFalse(store.isDeleted(scope, stream, 2).join());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testSync() {
         String test = "test";
         String scope = "test";

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
@@ -73,8 +73,6 @@ import static org.mockito.Mockito.spy;
 
 public class ZkStreamTest {
     private static final String SCOPE = "scope";
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     private TestingServer zkTestServer;
     private CuratorFramework cli;
     private StreamMetadataStore storePartialMock;
@@ -98,7 +96,7 @@ public class ZkStreamTest {
         storePartialMock.close();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testZkConnectionLoss() throws Exception {
         final ScalingPolicy policy = ScalingPolicy.fixed(5);
 
@@ -116,7 +114,7 @@ public class ZkStreamTest {
         zkTestServer.start();
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testCreateStreamState() throws Exception {
         final ScalingPolicy policy = ScalingPolicy.fixed(5);
 
@@ -139,7 +137,7 @@ public class ZkStreamTest {
         store.deleteScope(SCOPE, null, executor);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testZkCreateScope() throws Exception {
 
         // create new scope test
@@ -174,7 +172,7 @@ public class ZkStreamTest {
         assertTrue("Name of stream at index one", listOfStreams.containsKey("Stream2"));
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testZkDeleteScope() throws Exception {
         // create new scope
         @Cleanup
@@ -205,7 +203,7 @@ public class ZkStreamTest {
                 deleteScopeStatus3.get().getStatus());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testGetScope() throws Exception {
         @Cleanup
         final StreamMetadataStore store = new ZKStreamMetadataStore(cli, executor);
@@ -226,7 +224,7 @@ public class ZkStreamTest {
         }
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testZkListScope() throws Exception {
         // list scope test
         @Cleanup
@@ -243,7 +241,7 @@ public class ZkStreamTest {
         assertEquals("List Scopes ", 2, listScopes.size());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testZkStream() throws Exception {
         double keyChunk = 1.0 / 5;
         final ScalingPolicy policy = ScalingPolicy.fixed(5);
@@ -574,7 +572,7 @@ public class ZkStreamTest {
                 .get().equals(TxnStatus.UNKNOWN);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 30000)
     public void testGetActiveTxn() throws Exception {
         ZKStoreHelper storeHelper = spy(new ZKStoreHelper(cli, executor));
         ZkOrderedStore orderer = new ZkOrderedStore("txn", storeHelper, executor);
@@ -612,7 +610,7 @@ public class ZkStreamTest {
         assertEquals(1, result.size());
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 30000)
     public void testStreamRecreation() {
         // We will first create stream. Verify that its metadata is present in the cache.  
         ZKStoreHelper storeHelper = new ZKStoreHelper(cli, executor);

--- a/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/stream/ZkStreamTest.java
@@ -44,7 +44,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
@@ -55,9 +54,7 @@ import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 import org.mockito.Mockito;
 
 import static io.pravega.shared.NameUtils.computeSegmentId;

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.Data;
 import lombok.Getter;
@@ -54,9 +53,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -66,8 +63,6 @@ import static org.mockito.Mockito.spy;
 public abstract class TableMetadataTasksTest {
 
     protected static final String SCOPE = "taskscope";
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     protected StreamMetadataStore streamStore;
     protected KVTableMetadataStore kvtStore;
     protected TableMetadataTasks kvtMetadataTasks;

--- a/controller/src/test/java/io/pravega/controller/task/Stream/IntermittentCnxnFailureTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/IntermittentCnxnFailureTest.java
@@ -55,16 +55,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
@@ -82,8 +79,7 @@ public class IntermittentCnxnFailureTest {
     @ClassRule
     public static final PravegaZkCuratorResource PRAVEGA_ZK_CURATOR_RESOURCE = new PravegaZkCuratorResource();
     private static final String SCOPE = "scope";
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+
     private final String stream1 = "stream1";
     private final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
 
@@ -149,7 +145,7 @@ public class IntermittentCnxnFailureTest {
         ExecutorServiceHelpers.shutdown(executor);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void failedScopeOperationsTest() throws ExecutionException, InterruptedException {
         final String testScope = "testScope2";
 
@@ -169,7 +165,7 @@ public class IntermittentCnxnFailureTest {
         assertEquals(1, (long) MetricRegistryUtils.getCounter(MetricsNames.DELETE_SCOPE_FAILED).count());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void createStreamTest() throws Exception {
         final ScalingPolicy policy1 = ScalingPolicy.fixed(2);
         final StreamConfiguration configuration1 = StreamConfiguration.builder().scalingPolicy(policy1).build();

--- a/controller/src/test/java/io/pravega/controller/task/Stream/RequestSweeperTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/RequestSweeperTest.java
@@ -50,17 +50,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.retry.RetryOneTime;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -79,8 +76,6 @@ public abstract class RequestSweeperTest {
     @ClassRule
     public static final PravegaZkCuratorResource PRAVEGA_ZK_CURATOR_RESOURCE = new PravegaZkCuratorResource(RETRY_POLICY);
 
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     protected final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
 
     private final String stream1 = "stream1";

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -153,8 +153,6 @@ import static org.mockito.Mockito.*;
 public abstract class StreamMetadataTasksTest {
 
     private static final String SCOPE = "scope";
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     protected final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
     protected boolean authEnabled = false;
     protected CuratorFramework zkClient;
@@ -2591,7 +2589,7 @@ public abstract class StreamMetadataTasksTest {
         assertFalse(streamStorePartialMock.checkStreamExists(SCOPE, stream, null, executor).join());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void deletePartiallyCreatedStreamTest() throws InterruptedException {
         WriterMock requestEventWriter = new WriterMock(streamMetadataTasks, executor);
         streamMetadataTasks.setRequestEventWriter(requestEventWriter);

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -120,7 +120,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -136,9 +135,7 @@ import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 import org.mockito.Mock;
 
 import static io.pravega.shared.NameUtils.computeSegmentId;

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -88,7 +88,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -106,9 +105,7 @@ import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -134,8 +131,6 @@ import static org.mockito.Mockito.verify;
 public class StreamTransactionMetadataTasksTest {
     private static final String SCOPE = "scope";
     private static final String STREAM = "stream1";
-    @Rule
-    public Timeout globalTimeout = new Timeout(1, TimeUnit.MINUTES);
 
     boolean authEnabled = false;
     private final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");

--- a/controller/src/test/java/io/pravega/controller/task/TaskMetadataStoreTests.java
+++ b/controller/src/test/java/io/pravega/controller/task/TaskMetadataStoreTests.java
@@ -22,9 +22,7 @@ import io.pravega.controller.store.task.TaskMetadataStore;
 import io.pravega.controller.store.task.UnlockFailedException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -32,7 +30,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -45,8 +42,6 @@ import static org.junit.Assert.assertTrue;
  */
 public abstract class TaskMetadataStoreTests {
 
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
     protected TaskMetadataStore taskMetadataStore;
 
     private final Resource resource = new Resource("scope", "stream1");

--- a/controller/src/test/java/io/pravega/controller/task/TaskTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/TaskTest.java
@@ -52,7 +52,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.Data;
@@ -65,9 +64,7 @@ import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -80,8 +77,7 @@ import static org.junit.Assert.assertTrue;
 public abstract class TaskTest {
     private static final String HOSTNAME = "host-1234";
     private static final String SCOPE = "scope";
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
+
     protected final ScheduledExecutorService executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
     protected CuratorFramework cli;
 
@@ -176,7 +172,7 @@ public abstract class TaskTest {
         ExecutorServiceHelpers.shutdown(executor);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testMethods() throws InterruptedException, ExecutionException {
         CreateStreamStatus.Status status = streamMetadataTasks.createStream(SCOPE, stream1, configuration1, 
                 System.currentTimeMillis(), 0L).join();
@@ -187,7 +183,7 @@ public abstract class TaskTest {
         assertEquals(result, CreateStreamStatus.Status.SUCCESS);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testTaskSweeper() throws ExecutionException, InterruptedException {
         final String deadHost = "deadHost";
         final String deadThreadId = UUID.randomUUID().toString();
@@ -262,7 +258,7 @@ public abstract class TaskTest {
         assertFalse(child.isPresent());
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void parallelTaskSweeperTest() throws InterruptedException, ExecutionException {
         final String deadHost = "deadHost";
         final String deadThreadId1 = UUID.randomUUID().toString();
@@ -326,7 +322,7 @@ public abstract class TaskTest {
         assertEquals(config2, config);
     }
 
-    @Test
+    @Test(timeout = 30000)
     public void testLocking() throws Exception {
         @Cleanup
         TestTasks testTasks = new TestTasks(taskMetadataStore, executor, HOSTNAME);

--- a/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/timeout/TimeoutServiceTest.java
@@ -65,10 +65,8 @@ import org.apache.curator.retry.RetryOneTime;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.ClassRule;
-import org.junit.rules.Timeout;
 import org.mockito.Mock;
 
 /**
@@ -85,8 +83,6 @@ public abstract class TimeoutServiceTest {
 
     private final static long LEASE = 2000;
     private final static int RETRY_DELAY = 1000;
-    @Rule
-    public Timeout globalTimeout = new Timeout(30, TimeUnit.SECONDS);
 
     protected ScheduledExecutorService executor;
     protected CuratorFramework client;


### PR DESCRIPTION
Signed-off-by: pbelgundi <prajakta.belgundi@emc.com>

**Change log description**  
Remove global timeout rule from Controller test classes and replace with timeout per test.
Note that when both are present the lower timeout value is what gets considered : https://github.com/junit-team/junit4/issues/1126

**Purpose of the change**  
Fixes #6465

**What the code does**  
Global Timeout rule has been removed and replaced with test specific timeouts Controller test files.

**How to verify it**  
All tests should pass.
