### PR TITLE
Issue 6469: Remove redundant keywords on method declaration in few interface definitions.

### DIFF
--- a/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
+++ b/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
@@ -40,7 +40,7 @@ public interface ReaderGroupManager extends AutoCloseable {
      * @param controllerUri The Controller URI.
      * @return Instance of Stream Manager implementation.
      */
-    public static ReaderGroupManager withScope(String scope, URI controllerUri) {
+    static ReaderGroupManager withScope(String scope, URI controllerUri) {
         return withScope(scope, ClientConfig.builder().controllerURI(controllerUri).build());
     }
 
@@ -51,7 +51,7 @@ public interface ReaderGroupManager extends AutoCloseable {
      * @param clientConfig Configuration for the client.
      * @return Instance of Stream Manager implementation.
      */
-    public static ReaderGroupManager withScope(String scope, ClientConfig clientConfig) {
+    static ReaderGroupManager withScope(String scope, ClientConfig clientConfig) {
         // Change the max number of number of allowed connections to the segment store to 1.
         val updatedClientConfig = clientConfig.toBuilder()
                 .maxConnectionsPerSegmentStore(1)

--- a/client/src/main/java/io/pravega/client/admin/StreamManager.java
+++ b/client/src/main/java/io/pravega/client/admin/StreamManager.java
@@ -36,7 +36,7 @@ public interface StreamManager extends AutoCloseable {
      * @param controller The Controller URI.
      * @return Instance of Stream Manager implementation.
      */
-    public static StreamManager create(URI controller) {
+    static StreamManager create(URI controller) {
         return create(ClientConfig.builder().controllerURI(controller).build());
     }
 
@@ -46,7 +46,7 @@ public interface StreamManager extends AutoCloseable {
      * @param clientConfig Configuration for the client connection to Pravega.
      * @return Instance of Stream Manager implementation.
      */
-    public static StreamManager create(ClientConfig clientConfig) {
+    static StreamManager create(ClientConfig clientConfig) {
         return new StreamManagerImpl(clientConfig);
     }
 

--- a/client/src/main/java/io/pravega/client/stream/StreamCut.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamCut.java
@@ -32,7 +32,7 @@ public interface StreamCut extends Serializable {
      * This is used represents an unbounded StreamCut. This is used when the user wants to refer to the current HEAD
      * of the stream or the current TAIL of the stream.
      */
-    public static final StreamCut UNBOUNDED = new StreamCut() {
+    StreamCut UNBOUNDED = new StreamCut() {
         private static final long serialVersionUID = 1L;
 
         @Override

--- a/shared/cluster/src/main/java/io/pravega/common/cluster/Cluster.java
+++ b/shared/cluster/src/main/java/io/pravega/common/cluster/Cluster.java
@@ -29,21 +29,21 @@ public interface Cluster extends AutoCloseable {
      *
      * @param host Host to be part of cluster.
      */
-    public void registerHost(final Host host);
+    void registerHost(final Host host);
 
     /**
      * De-register a Host from a cluster.
      *
      * @param host Host to be removed from cluster.
      */
-    public void deregisterHost(final Host host);
+    void deregisterHost(final Host host);
 
     /**
      * Add Listeners.
      *
      * @param listener Cluster event listener.
      */
-    public void addListener(final ClusterListener listener);
+    void addListener(final ClusterListener listener);
 
     /**
      * Add Listeners with an executor to run the listener on.
@@ -51,19 +51,19 @@ public interface Cluster extends AutoCloseable {
      * @param listener Cluster event listener.
      * @param executor Executor to run listener on.
      */
-    public void addListener(final ClusterListener listener, final Executor executor);
+    void addListener(final ClusterListener listener, final Executor executor);
 
     /**
      * Get the current cluster members.
      *
      * @return List of cluster members.
      */
-    public Set<Host> getClusterMembers();
+    Set<Host> getClusterMembers();
 
     /**
      * Get the health status.
      *
      * @return true/false.
      */
-    public boolean isHealthy();
+    boolean isHealthy();
 }

--- a/test/system/src/main/java/io/pravega/test/system/framework/services/Service.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/Service.java
@@ -31,38 +31,38 @@ public interface Service {
      *
      *  @param wait true indicates that it is a blocking call.
      */
-    public void start(final boolean wait);
+    void start(final boolean wait);
 
     /**
      * Stop a service.
      */
-    public void stop();
+    void stop();
 
     /**
      * Clean the service.
      */
-    public void clean();
+    void clean();
 
     /**
      * Return the ID of the service.
      *
      * @return ID of the service.
      */
-    public String getID();
+    String getID();
 
     /**
      * Check if the service is up and running.
      *
      *  @return true if the service is running.
      */
-    public boolean isRunning();
+    boolean isRunning();
 
     /**
      * Get the list of Host:port URIs where the service is running.
      *
      *  @return List of {@link URI}s where the service is running.
      */
-    public List<URI> getServiceDetails();
+    List<URI> getServiceDetails();
 
     /**
      * Scale service to the new instance count.
@@ -75,5 +75,5 @@ public interface Service {
      * @return A future representing the status of scale service operation.
      *
      */
-    public CompletableFuture<Void> scaleService(final int instanceCount);
+    CompletableFuture<Void> scaleService(final int instanceCount);
 }


### PR DESCRIPTION

**Change log description**  
Remove redundant keywords on method declaration in few interface definitions.
- client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
- client/src/main/java/io/pravega/client/admin/StreamManager.java
- client/src/main/java/io/pravega/client/stream/StreamCut.java
- shared/cluster/src/main/java/io/pravega/common/cluster/Cluster.java
- test/system/src/main/java/io/pravega/test/system/framework/services/Service.java

**Purpose of the change**  
Fixes #6469
- Improve code style
- Remove redundant keywords on method declaration in few interface definitions.

**What the code does**  
- Improve code style

**How to verify it**  
There is already test cases for the relevant part.
