### PR TITLE
Issue 6499: Update java version to 11 in manual-install.md

### DIFF
--- a/documentation/src/docs/deployment/manual-install.md
+++ b/documentation/src/docs/deployment/manual-install.md
@@ -34,7 +34,7 @@ where /mnt/tier2 is replaced with your nfs share and FILESYSTEM is a keyword.
 
 ### Java
 
-Install the latest Java 8 from [java.oracle.com](http://java.oracle.com). Packages are available
+Install the latest Java 11 from [java.oracle.com](http://java.oracle.com). Packages are available
 for all major operating systems.
 
 ### Zookeeper


### PR DESCRIPTION
**Change log description**  
Pravega needs to be compiled in the Java 11 environment, but the manual-install.md document describes Java 8

**Purpose of the change**  
Fixes #6499 

**What the code does**  
manual-install.md

**How to verify it**  
Modify the Java version mentioned in the document