### PR TITLE
Issue 6078: LTS update config

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -666,7 +666,7 @@ extendeds3.connect.config.uri=http://localhost:9020?identity=user&secretKey=pass
 # of how it was configured via the API (if at all). Use this setting if you need to meet some hardware limitation with
 # the underlying Storage implementation (i.e., maximum file size).
 # Valid values: Positive number.
-#writer.rollover.size.bytes.max=9223372036854775807
+#writer.rollover.size.bytes.max=1099511627776
 
 ##endregion
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterConfig.java
@@ -40,7 +40,7 @@ public class WriterConfig {
     public static final Property<Long> FLUSH_TIMEOUT_MILLIS = Property.named("flush.timeout.milliseconds", 60 * 1000L, "flushTimeoutMillis");
     public static final Property<Long> ACK_TIMEOUT_MILLIS = Property.named("ack.timeout.milliseconds", 15 * 1000L, "ackTimeoutMillis");
     public static final Property<Long> SHUTDOWN_TIMEOUT_MILLIS = Property.named("shutDown.timeout.milliseconds", 10 * 1000L, "shutdownTimeoutMillis");
-    public static final Property<Long> MAX_ROLLOVER_SIZE = Property.named("rollover.size.bytes.max", SegmentRollingPolicy.NO_ROLLING.getMaxLength(), "maxRolloverSizeBytes");
+    public static final Property<Long> MAX_ROLLOVER_SIZE = Property.named("rollover.size.bytes.max", 1099511627776L, "maxRolloverSizeBytes");
     private static final String COMPONENT_CODE = "writer";
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/writer/WriterConfig.java
@@ -19,7 +19,6 @@ import io.pravega.common.util.ConfigBuilder;
 import io.pravega.common.util.ConfigurationException;
 import io.pravega.common.util.Property;
 import io.pravega.common.util.TypedProperties;
-import io.pravega.segmentstore.storage.SegmentRollingPolicy;
 import java.time.Duration;
 import lombok.Getter;
 


### PR DESCRIPTION
Signed-off-by: Aditi Jadhav Aditi.Jadhav@dell.com

**Change log description** 
The current default value of **writer.rollover.size.bytes.max** is max long and which exceeds the maximum supported size of a single file/object in most of storage systems out there. So setting the default value to **1 TB**.

**Purpose of the change**  
Fixes issue #6078

**What the code does**  
Updates the default config value

**How to verify it**  
All tests should pass
