### PR TITLE
Issue 6311 : Admin CLI Commands to view Reader Information in zookeeper for a specific Controller host

### DIFF
--- a/cli/admin/README.md
+++ b/cli/admin/README.md
@@ -111,6 +111,7 @@ All available commands:
 	controller-metadata list-keys <qualified-table-segment-name> <key-count> <segmentstore-endpoint>: List at most the required number of keys from the controller metadata table.
 	controller-metadata tables-info : List all the controller metadata tables.
 	controller-metadata update <qualified-table-segment-name> <key> <segmentstore-endpoint> <new-value-file>: Update the given key in the table with the provided value.
+	controller-metadata get-reader <host-id> <reader-group-name> <reader-id>: Get the reader metadata of reader belonging to internal reader group for a particular controller host
 	data-recovery durableLog-recovery : Recovers the state of the DurableLog from the storage.
 	data-recovery durableLog-repair <container-id>: Allows to repair DurableLog damaged/corrupted Operations.
 	data-recovery list-segments : Lists segments from storage with their name, length and sealed status.

--- a/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
@@ -42,6 +42,7 @@ import io.pravega.cli.admin.controller.metadata.ControllerMetadataGetEntryComman
 import io.pravega.cli.admin.controller.metadata.ControllerMetadataListEntriesCommand;
 import io.pravega.cli.admin.controller.metadata.ControllerMetadataListKeysCommand;
 import io.pravega.cli.admin.controller.metadata.ControllerMetadataUpdateEntryCommand;
+import io.pravega.cli.admin.controller.metadata.ControllerMetadataViewReaderInfoCommand;
 import io.pravega.cli.admin.dataRecovery.DurableLogRecoveryCommand;
 import io.pravega.cli.admin.dataRecovery.DurableDataLogRepairCommand;
 import io.pravega.cli.admin.dataRecovery.StorageListSegmentsCommand;
@@ -392,6 +393,7 @@ public abstract class AdminCommand {
                         .put(ControllerMetadataListEntriesCommand::descriptor, ControllerMetadataListEntriesCommand::new)
                         .put(ParseReaderGroupStreamCommand::descriptor, ParseReaderGroupStreamCommand::new)
                         .put(ControllerMetadataUpdateEntryCommand::descriptor, ControllerMetadataUpdateEntryCommand::new)
+                        .put(ControllerMetadataViewReaderInfoCommand::descriptor, ControllerMetadataViewReaderInfoCommand::new)
                         .build());
 
         /**

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataCommand.java
@@ -193,12 +193,12 @@ public abstract class ControllerMetadataCommand extends ControllerCommand {
     /**
      * Method to get path of reader in a particular controller instance.
      *
-     * @param process Host id of controller instance
+     * @param hostId Host id of controller instance
      * @param readerGroup name of the readerGroup
      * @param readerId Id of reader
      * @return Full path of reader
      */
-    protected String getReaderPath(String process, String readerGroup, String readerId) {
-        return String.format("/%s/%s/%s/%s", ROOT, process, readerGroup, readerId);
+    protected String getReaderPath(String hostId, String readerGroup, String readerId) {
+        return String.format("/%s/%s/%s/%s", ROOT, hostId, readerGroup, readerId);
     }
 }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataCommand.java
@@ -42,6 +42,7 @@ import static io.pravega.cli.admin.serializers.controller.ControllerMetadataSeri
 public abstract class ControllerMetadataCommand extends ControllerCommand {
     static final String COMPONENT = "controller-metadata";
     static final ControllerKeySerializer KEY_SERIALIZER = new ControllerKeySerializer();
+    private static final String ROOT = "eventProcessors";
 
     protected final GrpcAuthHelper authHelper;
 
@@ -186,5 +187,18 @@ public abstract class ControllerMetadataCommand extends ControllerCommand {
         final int readerIndex = byteBuf.readerIndex();
         byteBuf.getBytes(readerIndex, bytes);
         return ByteBuffer.wrap(bytes);
+    }
+
+
+    /**
+     * Method to get path of reader in a particular controller instance.
+     *
+     * @param process Host id of controller instance
+     * @param readerGroup name of the readerGroup
+     * @param readerId Id of reader
+     * @return Full path of reader
+     */
+    protected String getReaderPath(String process, String readerGroup, String readerId) {
+        return String.format("/%s/%s/%s/%s", ROOT, process, readerGroup, readerId);
     }
 }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataViewReaderInfoCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataViewReaderInfoCommand.java
@@ -40,7 +40,7 @@ public class ControllerMetadataViewReaderInfoCommand extends ControllerMetadataC
 
         try {
             ZKHelper zkHelper = ZKHelper.create(getServiceConfig().getZkURL(), getServiceConfig().getClusterName());
-            output("reader-metadata", zkHelper.getMetaDataForReader(getReaderPath(hostId, readerGroupName, readerId)));
+            output("reader-metadata: \n %s", zkHelper.getMetaDataForReader(getReaderPath(hostId, readerGroupName, readerId)));
         } catch (Exception e) {
             output("Exception accessing to reader metadata : " + e.getMessage());
         }

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataViewReaderInfoCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataViewReaderInfoCommand.java
@@ -17,12 +17,7 @@
 package io.pravega.cli.admin.controller.metadata;
 
 import io.pravega.cli.admin.CommandArgs;
-import io.pravega.client.stream.Position;
-import io.pravega.client.stream.impl.PositionImpl;
-import lombok.Cleanup;
-import org.apache.curator.framework.CuratorFramework;
-
-import java.nio.ByteBuffer;
+import io.pravega.cli.admin.utils.ZKHelper;
 
 public class ControllerMetadataViewReaderInfoCommand extends ControllerMetadataCommand {
 
@@ -43,15 +38,8 @@ public class ControllerMetadataViewReaderInfoCommand extends ControllerMetadataC
         final String readerGroupName = getArg(1);
         final String readerId = getArg(2);
 
-        @Cleanup
-        CuratorFramework zkClient = createZKClient();
-        byte[] data = zkClient.getData().forPath(getReaderPath(hostId, readerGroupName, readerId));
-        if (data != null && data.length > 0) {
-            PositionImpl position = (PositionImpl) Position.fromBytes(ByteBuffer.wrap(data)).asImpl();
-            output(position.toString());
-        } else {
-            output("get-reader", "No metadata found");
-        }
+        ZKHelper zkHelper = ZKHelper.create(getServiceConfig().getZkURL(), getServiceConfig().getClusterName());
+        output("get-reader", zkHelper.getMetaDataForReader(getReaderPath(hostId, readerGroupName, readerId)));
 
     }
 

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataViewReaderInfoCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataViewReaderInfoCommand.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright Pravega Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.pravega.cli.admin.controller.metadata;
+
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.client.stream.Position;
+import io.pravega.client.stream.impl.PositionImpl;
+import lombok.Cleanup;
+import org.apache.curator.framework.CuratorFramework;
+
+import java.nio.ByteBuffer;
+
+public class ControllerMetadataViewReaderInfoCommand extends ControllerMetadataCommand {
+
+    /**
+     * Creates a new instance of the Command class.
+     *
+     * @param args The arguments for the command.
+     */
+    public ControllerMetadataViewReaderInfoCommand(CommandArgs args) {
+        super(args);
+    }
+
+    @Override
+    public void execute() throws Exception {
+        ensureArgCount(3);
+
+        final String hostId = getArg(0);
+        final String readerGroupName = getArg(1);
+        final String readerId = getArg(2);
+
+        @Cleanup
+        CuratorFramework zkClient = createZKClient();
+        byte[] data = zkClient.getData().forPath(getReaderPath(hostId, readerGroupName, readerId));
+        if (data != null && data.length > 0) {
+            PositionImpl position = (PositionImpl) Position.fromBytes(ByteBuffer.wrap(data)).asImpl();
+            output(position.toString());
+        } else {
+            output("get-reader", "No metadata found");
+        }
+
+    }
+
+    public static CommandDescriptor descriptor() {
+        return new CommandDescriptor(COMPONENT, "get-reader", "Get the reader metadata of reader belonging to internal reader group for a particular controller host",
+                new ArgDescriptor("host-id", "Id of controller host"),
+                new ArgDescriptor("reader-group-name", "Name of the ReaderGroup"),
+                new ArgDescriptor("reader-id", "Id of reader to view reader information"));
+    }
+
+
+}

--- a/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataViewReaderInfoCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/controller/metadata/ControllerMetadataViewReaderInfoCommand.java
@@ -38,8 +38,12 @@ public class ControllerMetadataViewReaderInfoCommand extends ControllerMetadataC
         final String readerGroupName = getArg(1);
         final String readerId = getArg(2);
 
-        ZKHelper zkHelper = ZKHelper.create(getServiceConfig().getZkURL(), getServiceConfig().getClusterName());
-        output("get-reader", zkHelper.getMetaDataForReader(getReaderPath(hostId, readerGroupName, readerId)));
+        try {
+            ZKHelper zkHelper = ZKHelper.create(getServiceConfig().getZkURL(), getServiceConfig().getClusterName());
+            output("reader-metadata", zkHelper.getMetaDataForReader(getReaderPath(hostId, readerGroupName, readerId)));
+        } catch (Exception e) {
+            output("Exception accessing to reader metadata : " + e.getMessage());
+        }
 
     }
 

--- a/cli/admin/src/main/java/io/pravega/cli/admin/utils/ZKHelper.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/utils/ZKHelper.java
@@ -181,13 +181,7 @@ public class ZKHelper implements AutoCloseable {
      * @return checkPointStore
      */
     public CheckpointStore getCheckPointStore() {
-        CheckpointStore checkpointStore = null;
-        try {
-            checkpointStore = CheckpointStoreFactory.createZKStore(zkClient);
-        } catch (Exception e) {
-            System.err.println("An error occurred executing getCheckPointStore against Zookeeper: " + e.getMessage());
-        }
-        return checkpointStore;
+        return CheckpointStoreFactory.createZKStore(zkClient);
     }
 
     /**

--- a/cli/admin/src/main/java/io/pravega/cli/admin/utils/ZKHelper.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/utils/ZKHelper.java
@@ -120,10 +120,11 @@ public class ZKHelper implements AutoCloseable {
     /**
      * Get the metadata information of reader for a given path.
      * @param readerPath path of reader
+     * @throws Exception if unable to get the znode for readerpath.
      * @return detailed metadata information of reader
      */
-    public String getMetaDataForReader(String readerPath) {
-        byte[] data = getData(readerPath);
+    public String getMetaDataForReader(String readerPath) throws Exception {
+        byte[] data = zkClient.getData().forPath(readerPath);
         if (data != null && data.length > 0) {
             PositionImpl position = (PositionImpl) Position.fromBytes(ByteBuffer.wrap(data)).asImpl();
             return position.toString();

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -15,14 +15,17 @@
  */
 package io.pravega.cli.admin.controller;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonSyntaxException;
 import io.pravega.cli.admin.AdminCommandState;
 import io.pravega.cli.admin.utils.TestUtils;
 import io.pravega.cli.admin.utils.ZKHelper;
 import io.pravega.client.ClientConfig;
+import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.Position;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.PositionImpl;
+import io.pravega.client.stream.impl.SegmentWithRange;
 import io.pravega.controller.store.checkpoint.CheckpointStore;
 import io.pravega.shared.security.auth.DefaultCredentials;
 import io.pravega.test.common.AssertExtensions;
@@ -40,7 +43,6 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -321,10 +323,11 @@ public abstract class AbstractControllerMetadataCommandsTest {
         CheckpointStore checkpointStore = zkHelper.getCheckPointStore();
         checkpointStore.addReaderGroup(process, readerGroup);
         checkpointStore.addReader(process, readerGroup, reader);
-        Position position = new PositionImpl(Collections.emptyMap());
+        Position position = new PositionImpl(ImmutableMap.of(new SegmentWithRange(Segment.fromScopedName("testScope/testStream/0"), 0, 0.5), 9999999L,
+                new SegmentWithRange(Segment.fromScopedName("testScope/testStream/1"), 0.5, 1.0), -1L));
         checkpointStore.setPosition(process, readerGroup, reader, position);
         String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
-        Assert.assertTrue(commandResult.contains("reader-metadata"));
+        Assert.assertTrue(commandResult.contains("testScope/testStream"));
     }
 
     @Test

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -328,7 +328,6 @@ public abstract class AbstractControllerMetadataCommandsTest {
         checkpointStore.setPosition(process, readerGroup, reader, position);
         String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
         Assert.assertTrue(commandResult.contains("testScope/testStream"));
-        zkHelper.close();
     }
 
     @Test
@@ -341,7 +340,6 @@ public abstract class AbstractControllerMetadataCommandsTest {
         checkpointStore.addReaderGroup(process, readerGroup);
         String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
         Assert.assertTrue(commandResult.contains("Exception accessing to reader metadata"));
-        zkHelper.close();
     }
 
     @After

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -336,7 +336,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
         CheckpointStore checkpointStore = zkHelper.getCheckPointStore();
         checkpointStore.addReaderGroup(process, readerGroup);
         String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
-        Assert.assertTrue(commandResult.contains("Exception accessing to reader metadata."));
+        Assert.assertTrue(commandResult.contains("Exception accessing to reader metadata"));
     }
 
     @After

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -324,7 +324,19 @@ public abstract class AbstractControllerMetadataCommandsTest {
         Position position = new PositionImpl(Collections.emptyMap());
         checkpointStore.setPosition(process, readerGroup, reader, position);
         String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
-        Assert.assertTrue(commandResult.contains("get-reader"));
+        Assert.assertTrue(commandResult.contains("reader-metadata"));
+    }
+
+    @Test
+    public void testControllerMetadataViewReaderInfoCommandWithException() throws Exception {
+        final String process = UUID.randomUUID().toString();
+        final String readerGroup = UUID.randomUUID().toString();
+        final String reader = UUID.randomUUID().toString();
+        ZKHelper zkHelper = ZKHelper.create(SETUP_UTILS.getZkTestServer().getConnectString(), "pravega-cluster");
+        CheckpointStore checkpointStore = zkHelper.getCheckPointStore();
+        checkpointStore.addReaderGroup(process, readerGroup);
+        String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
+        Assert.assertTrue(commandResult.contains("Exception accessing to reader metadata."));
     }
 
     @After

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -15,14 +15,17 @@
  */
 package io.pravega.cli.admin.controller;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonSyntaxException;
 import io.pravega.cli.admin.AdminCommandState;
 import io.pravega.cli.admin.utils.TestUtils;
 import io.pravega.cli.admin.utils.ZKHelper;
 import io.pravega.client.ClientConfig;
+import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.Position;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.PositionImpl;
+import io.pravega.client.stream.impl.SegmentWithRange;
 import io.pravega.controller.store.checkpoint.CheckpointStore;
 import io.pravega.shared.security.auth.DefaultCredentials;
 import io.pravega.test.common.AssertExtensions;
@@ -40,7 +43,6 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -77,6 +79,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
         pravegaProperties.setProperty("pravegaservice.zk.connect.uri", SETUP_UTILS.getZkTestServer().getConnectString());
         pravegaProperties.setProperty("pravegaservice.container.count", String.valueOf(1));
         pravegaProperties.setProperty("pravegaservice.admin.gateway.port", String.valueOf(SETUP_UTILS.getAdminPort()));
+        pravegaProperties.setProperty("pravegaservice.clusterName", "pravega-cluster");
 
         if (enableAuth) {
             clientConfigBuilder = clientConfigBuilder.credentials(new DefaultCredentials(SecurityConfigDefaults.AUTH_ADMIN_PASSWORD,
@@ -321,10 +324,11 @@ public abstract class AbstractControllerMetadataCommandsTest {
         CheckpointStore checkpointStore = zkHelper.getCheckPointStore();
         checkpointStore.addReaderGroup(process, readerGroup);
         checkpointStore.addReader(process, readerGroup, reader);
-        Position position = new PositionImpl(Collections.emptyMap());
+        Position position = new PositionImpl(ImmutableMap.of(new SegmentWithRange(Segment.fromScopedName("testScope/testStream/0"), 0, 0.5), 9999999L,
+                new SegmentWithRange(Segment.fromScopedName("testScope/testStream/1"), 0.5, 1.0), -1L));
         checkpointStore.setPosition(process, readerGroup, reader, position);
         String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
-        Assert.assertTrue(commandResult.contains("reader-metadata"));
+        Assert.assertTrue(commandResult.contains("testScope/testStream"));
     }
 
     @Test

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -328,6 +328,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
         checkpointStore.setPosition(process, readerGroup, reader, position);
         String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
         Assert.assertTrue(commandResult.contains("testScope/testStream"));
+        zkHelper.close();
     }
 
     @Test
@@ -340,6 +341,7 @@ public abstract class AbstractControllerMetadataCommandsTest {
         checkpointStore.addReaderGroup(process, readerGroup);
         String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
         Assert.assertTrue(commandResult.contains("Exception accessing to reader metadata"));
+        zkHelper.close();
     }
 
     @After

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -18,8 +18,12 @@ package io.pravega.cli.admin.controller;
 import com.google.gson.JsonSyntaxException;
 import io.pravega.cli.admin.AdminCommandState;
 import io.pravega.cli.admin.utils.TestUtils;
+import io.pravega.cli.admin.utils.ZKHelper;
 import io.pravega.client.ClientConfig;
+import io.pravega.client.stream.Position;
 import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.impl.PositionImpl;
+import io.pravega.controller.store.checkpoint.CheckpointStore;
 import io.pravega.shared.security.auth.DefaultCredentials;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.SecurityConfigDefaults;
@@ -36,6 +40,7 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -305,6 +310,21 @@ public abstract class AbstractControllerMetadataCommandsTest {
 
         // Delete the temporary directory.
         tempDirPath.toFile().deleteOnExit();
+    }
+
+    @Test
+    public void testControllerMetadataViewReaderInfoCommand() throws Exception {
+        final String process = UUID.randomUUID().toString();
+        final String readerGroup = UUID.randomUUID().toString();
+        final String reader = UUID.randomUUID().toString();
+        ZKHelper zkHelper = ZKHelper.create(SETUP_UTILS.getZkTestServer().getConnectString(), "pravega-cluster");
+        CheckpointStore checkpointStore = zkHelper.getCheckPointStore();
+        checkpointStore.addReaderGroup(process, readerGroup);
+        checkpointStore.addReader(process, readerGroup, reader);
+        Position position = new PositionImpl(Collections.emptyMap());
+        checkpointStore.setPosition(process, readerGroup, reader, position);
+        String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
+        Assert.assertTrue(commandResult.contains("get-reader"));
     }
 
     @After

--- a/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/controller/AbstractControllerMetadataCommandsTest.java
@@ -15,17 +15,14 @@
  */
 package io.pravega.cli.admin.controller;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonSyntaxException;
 import io.pravega.cli.admin.AdminCommandState;
 import io.pravega.cli.admin.utils.TestUtils;
 import io.pravega.cli.admin.utils.ZKHelper;
 import io.pravega.client.ClientConfig;
-import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.Position;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.impl.PositionImpl;
-import io.pravega.client.stream.impl.SegmentWithRange;
 import io.pravega.controller.store.checkpoint.CheckpointStore;
 import io.pravega.shared.security.auth.DefaultCredentials;
 import io.pravega.test.common.AssertExtensions;
@@ -43,6 +40,7 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -323,11 +321,10 @@ public abstract class AbstractControllerMetadataCommandsTest {
         CheckpointStore checkpointStore = zkHelper.getCheckPointStore();
         checkpointStore.addReaderGroup(process, readerGroup);
         checkpointStore.addReader(process, readerGroup, reader);
-        Position position = new PositionImpl(ImmutableMap.of(new SegmentWithRange(Segment.fromScopedName("testScope/testStream/0"), 0, 0.5), 9999999L,
-                new SegmentWithRange(Segment.fromScopedName("testScope/testStream/1"), 0.5, 1.0), -1L));
+        Position position = new PositionImpl(Collections.emptyMap());
         checkpointStore.setPosition(process, readerGroup, reader, position);
         String commandResult = TestUtils.executeCommand("controller-metadata get-reader " + process + " " + readerGroup + " " + reader, STATE.get() );
-        Assert.assertTrue(commandResult.contains("testScope/testStream"));
+        Assert.assertTrue(commandResult.contains("reader-metadata"));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Bhupender-Y <Bhupender.Y@dell.com>

**Change log description**  
Add a command `controller-metadata getReader <host-id> <reader-group> <reader-id>` in admin-cli to view metadata of reader of a particular controller instance.

**Purpose of the change**  
Fixes #6311

**What the code does**  
 Created  `controller-metadata getReader <host-id> <reader-group> <reader-id>`  command in admin cli to view reader metadata.

**How to verify it**  
- Navigate to pravega-admin cli.
- Use `controller-metadata getReader <host-id> <reader-group> <reader-id>`. It should print reader metadata.
