### PR TITLE
Issue 6520: CLI command to list chunks from metadata for a given segment

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/utils/AdminSegmentHelper.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/utils/AdminSegmentHelper.java
@@ -85,7 +85,7 @@ public class AdminSegmentHelper extends SegmentHelper implements AutoCloseable {
      * @param qualifiedName   StreamSegmentName
      * @param uri             The uri of the Segment Store instance.
      * @param delegationToken The token to be presented to the Segment Store.
-     * @return A CompletableFuture that will return the table segment info as a WireCommand
+     * @return A CompletableFuture that will return the table segment info as a WireCommand.
      */
     public CompletableFuture<WireCommands.TableSegmentInfo> getTableSegmentInfo(String qualifiedName, PravegaNodeUri uri, String delegationToken) {
         final WireCommandType type = WireCommandType.GET_TABLE_SEGMENT_INFO;
@@ -100,6 +100,29 @@ public class AdminSegmentHelper extends SegmentHelper implements AutoCloseable {
                     handleReply(requestId, r, connection, qualifiedName, WireCommands.GetTableSegmentInfo.class, type);
                     assert r instanceof WireCommands.TableSegmentInfo;
                     return (WireCommands.TableSegmentInfo) r;
+                });
+    }
+
+    /**
+     * This methods sends a WireCommand to get the list of storage chunks under the given segment name.
+     *
+     * @param qualifiedName   StreamSegmentName
+     * @param uri             The uri of the Segment Store instance.
+     * @param delegationToken The token to be presented to the Segment Store.
+     * @return A CompletableFuture that return the list of storage chunks as a WireCommand.
+     */
+    public CompletableFuture<WireCommands.StorageChunksListed> listStorageChunks(String qualifiedName, PravegaNodeUri uri, String delegationToken) {
+        final WireCommandType type = WireCommandType.LIST_STORAGE_CHUNKS;
+        RawClient connection = new RawClient(uri, connectionPool);
+        final long requestId = connection.getFlow().asLong();
+
+        WireCommands.ListStorageChunks request = new WireCommands.ListStorageChunks(qualifiedName, delegationToken, requestId);
+
+        return sendRequest(connection, requestId, request)
+                .thenApply(r -> {
+                    handleReply(requestId, r, connection, qualifiedName, WireCommands.ListStorageChunks.class, type);
+                    assert r instanceof WireCommands.StorageChunksListed;
+                    return (WireCommands.StorageChunksListed) r;
                 });
     }
 

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ExtendedChunkInfo.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/ExtendedChunkInfo.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.contracts;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+
+/**
+ * Extended information about the chunk.
+ */
+@Builder
+@Data
+public class ExtendedChunkInfo {
+    /**
+     * Length of the chunk in metadata.
+     */
+    private volatile long lengthInMetadata;
+
+    /**
+     * Length of the chunk in storage.
+     */
+    private volatile long lengthInStorage;
+
+    /**
+     * startOffset of chunk in segment.
+     */
+    private volatile long startOffset;
+
+    /**
+     * Name of the chunk.
+     */
+    @NonNull
+    private final String chunkName;
+
+    /**
+     * Whether chunk exists in storage.
+     */
+    private volatile boolean existsInStorage;
+}

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentApi.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentApi.java
@@ -241,5 +241,13 @@ public interface SegmentApi {
      */
     CompletableFuture<Void> truncateStreamSegment(String streamSegmentName, long offset, Duration timeout);
 
-    CompletableFuture<List<SegmentProperties>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout);
+    /**
+     * Lists all the storage chunks for the given StreamSegment.
+     *
+     * @param streamSegmentName The name of the StreamSegment.
+     * @param bufferSize        The size of the buffer maintained when transferring data from storage.
+     * @param timeout           Timeout for the operation.
+     * @return
+     */
+    CompletableFuture<List<ExtendedChunkInfo>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout);
 }

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentApi.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentApi.java
@@ -19,6 +19,7 @@ import io.pravega.common.util.BufferView;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -239,4 +240,6 @@ public interface SegmentApi {
      * failed, the future will be failed with the causing exception.
      */
     CompletableFuture<Void> truncateStreamSegment(String streamSegmentName, long offset, Duration timeout);
+
+    CompletableFuture<List<SegmentProperties>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout);
 }

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AdminRequestProcessorImpl.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AdminRequestProcessorImpl.java
@@ -120,5 +120,18 @@ public class AdminRequestProcessorImpl extends PravegaRequestProcessor implement
                 .exceptionally(ex -> handleException(flushToStorage.getRequestId(), null, operation, ex));
     }
 
+    @Override
+    public void listStorageChunks(WireCommands.ListStorageChunks listStorageChunks) {
+        final String operation = "ListStorageChunks";
+        final String segment = listStorageChunks.getSegment();
+
+        if (!verifyToken(segment, listStorageChunks.getRequestId(), listStorageChunks.getDelegationToken(), operation)) {
+            return;
+        }
+
+        long trace = LoggerHelpers.traceEnter(log, operation, listStorageChunks);
+        getSegmentStore().listStorageChunks(segment, 128, TIMEOUT);
+    }
+
     //endregion
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -88,6 +88,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -721,6 +723,13 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
     public CompletableFuture<Void> flushToStorage(Duration timeout) {
         LogFlusher flusher = new LogFlusher(this.metadata.getContainerId(), this.durableLog, this.writer, this.metadataCleaner, this.executor);
         return flusher.flushToStorage(timeout);
+    }
+
+    @SneakyThrows
+    @Override
+    public CompletableFuture<List<SegmentProperties>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout) {
+        Iterator<SegmentProperties> segments = storage.listSegments();
+        return null;
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -27,19 +27,7 @@ import io.pravega.common.concurrent.Services;
 import io.pravega.common.util.BufferView;
 import io.pravega.common.util.Retry;
 import io.pravega.common.util.Retry.RetryAndThrowConditionally;
-import io.pravega.segmentstore.contracts.AttributeId;
-import io.pravega.segmentstore.contracts.AttributeUpdate;
-import io.pravega.segmentstore.contracts.AttributeUpdateCollection;
-import io.pravega.segmentstore.contracts.AttributeUpdateType;
-import io.pravega.segmentstore.contracts.Attributes;
-import io.pravega.segmentstore.contracts.BadAttributeUpdateException;
-import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
-import io.pravega.segmentstore.contracts.ReadResult;
-import io.pravega.segmentstore.contracts.SegmentProperties;
-import io.pravega.segmentstore.contracts.SegmentType;
-import io.pravega.segmentstore.contracts.StreamSegmentMergedException;
-import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
-import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
+import io.pravega.segmentstore.contracts.*;
 import io.pravega.segmentstore.server.AttributeIndex;
 import io.pravega.segmentstore.server.AttributeIterator;
 import io.pravega.segmentstore.server.ContainerEventProcessor;
@@ -81,6 +69,7 @@ import io.pravega.segmentstore.storage.StorageFactory;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorage;
 import io.pravega.segmentstore.storage.chunklayer.SnapshotInfo;
 import io.pravega.segmentstore.storage.chunklayer.SnapshotInfoStore;
+import io.pravega.segmentstore.storage.chunklayer.UtilsWrapper;
 import io.pravega.segmentstore.storage.metadata.TableBasedMetadataStore;
 import io.pravega.shared.NameUtils;
 import java.time.Duration;
@@ -88,7 +77,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -727,9 +715,8 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
 
     @SneakyThrows
     @Override
-    public CompletableFuture<List<SegmentProperties>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout) {
-        Iterator<SegmentProperties> segments = storage.listSegments();
-        return null;
+    public CompletableFuture<List<ExtendedChunkInfo>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout) {
+        return storage.listStorageChunks(streamSegmentName, bufferSize, timeout);
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentService.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentService.java
@@ -28,6 +28,7 @@ import io.pravega.segmentstore.server.SegmentContainerRegistry;
 import io.pravega.shared.segment.SegmentToContainerMapper;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
@@ -92,6 +93,14 @@ public class StreamSegmentService extends SegmentContainerCollection implements 
                 containerId,
                 container -> container.flushToStorage(timeout),
                 "flushToStorage");
+    }
+
+    @Override
+    public CompletableFuture<List<SegmentProperties>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout) {
+        return invoke(
+                streamSegmentName,
+                container -> container.listStorageChunks(streamSegmentName, bufferSize, timeout),
+                "", streamSegmentName, bufferSize);
     }
 
     @Override

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentService.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/StreamSegmentService.java
@@ -16,15 +16,9 @@
 package io.pravega.segmentstore.server.store;
 
 import io.pravega.common.util.BufferView;
-import io.pravega.segmentstore.contracts.AttributeId;
-import io.pravega.segmentstore.contracts.AttributeUpdate;
-import io.pravega.segmentstore.contracts.AttributeUpdateCollection;
-import io.pravega.segmentstore.contracts.MergeStreamSegmentResult;
-import io.pravega.segmentstore.contracts.ReadResult;
-import io.pravega.segmentstore.contracts.SegmentProperties;
-import io.pravega.segmentstore.contracts.SegmentType;
-import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.segmentstore.contracts.*;
 import io.pravega.segmentstore.server.SegmentContainerRegistry;
+import io.pravega.segmentstore.storage.chunklayer.UtilsWrapper;
 import io.pravega.shared.segment.SegmentToContainerMapper;
 import java.time.Duration;
 import java.util.Collection;
@@ -96,7 +90,7 @@ public class StreamSegmentService extends SegmentContainerCollection implements 
     }
 
     @Override
-    public CompletableFuture<List<SegmentProperties>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout) {
+    public CompletableFuture<List<ExtendedChunkInfo>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout) {
         return invoke(
                 streamSegmentName,
                 container -> container.listStorageChunks(streamSegmentName, bufferSize, timeout),

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
@@ -195,7 +195,7 @@ public interface Storage extends ReadOnlyStorage, AutoCloseable {
      * @return Iterator that can be used to enumerate and retrieve properties of all the segments.
      * @throws IOException if exception occurred while listing segments.
      */
-    Iterator<SegmentProperties> listSegments() throws IOException;
+    Iterator<SegmentProperties> listSegments(String streamSegmentName, int bufferSize, Duration timeout) throws IOException;
 
     @Override
     void close();

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
@@ -15,11 +15,15 @@
  */
 package io.pravega.segmentstore.storage;
 
+import io.pravega.segmentstore.contracts.ExtendedChunkInfo;
 import io.pravega.segmentstore.contracts.SegmentProperties;
+import io.pravega.segmentstore.storage.chunklayer.UtilsWrapper;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -195,7 +199,18 @@ public interface Storage extends ReadOnlyStorage, AutoCloseable {
      * @return Iterator that can be used to enumerate and retrieve properties of all the segments.
      * @throws IOException if exception occurred while listing segments.
      */
-    Iterator<SegmentProperties> listSegments(String streamSegmentName, int bufferSize, Duration timeout) throws IOException;
+    Iterator<SegmentProperties> listSegments() throws IOException;
+
+    /**
+     * Lists all the storage chunks assigned under the given segment.
+     *
+     * @param streamSegmentName The segment name.
+     * @param bufferSize        The size of the buffer maintained when transferring data from storage.
+     * @param timeout           Timeout for the operation.
+     * @return A CompletableFuture that when completed, will provide the list of chunks where in each chunk is
+     * is wrapped into an {@link io.pravega.segmentstore.storage.chunklayer.UtilsWrapper.ExtendedChunkInfo} object.
+     */
+    CompletableFuture<List<ExtendedChunkInfo>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout);
 
     @Override
     void close();

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -601,8 +601,9 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
     }
 
     @Override
-    public Iterator<SegmentProperties> listSegments() {
-        throw new UnsupportedOperationException("listSegments is not yet supported");
+    public Iterator<SegmentProperties> listSegments(String streamSegmentName, int bufferSize, Duration timeout) {
+        UtilsWrapper wrapper = new UtilsWrapper(this, bufferSize, timeout);
+        wrapper.getExtendedChunkInfoList(streamSegmentName, true).;
     }
 
     @Override

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -23,11 +23,7 @@ import io.pravega.common.Timer;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.common.concurrent.MultiKeySequentialProcessor;
 import io.pravega.common.util.ImmutableDate;
-import io.pravega.segmentstore.contracts.SegmentProperties;
-import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
-import io.pravega.segmentstore.contracts.StreamSegmentInformation;
-import io.pravega.segmentstore.contracts.StreamSegmentNotExistsException;
-import io.pravega.segmentstore.contracts.StreamSegmentSealedException;
+import io.pravega.segmentstore.contracts.*;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.SegmentRollingPolicy;
 import io.pravega.segmentstore.storage.Storage;
@@ -44,6 +40,7 @@ import io.pravega.shared.NameUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.glassfish.jersey.message.internal.Utils;
 
 import javax.annotation.concurrent.GuardedBy;
 import java.io.InputStream;
@@ -601,9 +598,14 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
     }
 
     @Override
-    public Iterator<SegmentProperties> listSegments(String streamSegmentName, int bufferSize, Duration timeout) {
+    public Iterator<SegmentProperties> listSegments() {
+        throw new UnsupportedOperationException("listSegments is not yet supported");
+    }
+
+    @Override
+    public CompletableFuture<List<ExtendedChunkInfo>> listStorageChunks(String streamSegmentName, int bufferSize, Duration timeout) {
         UtilsWrapper wrapper = new UtilsWrapper(this, bufferSize, timeout);
-        wrapper.getExtendedChunkInfoList(streamSegmentName, true).;
+        return wrapper.getExtendedChunkInfoList(streamSegmentName, true);
     }
 
     @Override

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
@@ -17,11 +17,11 @@ package io.pravega.segmentstore.storage.chunklayer;
 
 import com.google.common.base.Preconditions;
 import io.pravega.common.concurrent.Futures;
+import io.pravega.segmentstore.contracts.ExtendedChunkInfo;
 import io.pravega.segmentstore.storage.metadata.BaseMetadataStore;
 
 import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -254,36 +254,36 @@ public class UtilsWrapper {
                 chunkedSegmentStorage.getExecutor()), streamSegmentName);
     }
 
-    /**
-     * Extended information about the chunk.
-     */
-    @Builder
-    @Data
-    static class ExtendedChunkInfo {
-        /**
-         * Length of the chunk in metadata.
-         */
-        private volatile long lengthInMetadata;
-
-        /**
-         * Length of the chunk in storage.
-         */
-        private volatile long lengthInStorage;
-
-        /**
-         * startOffset of chunk in segment.
-         */
-        private volatile long startOffset;
-
-        /**
-         * Name of the chunk.
-         */
-        @NonNull
-        private final String chunkName;
-
-        /**
-         * Whether chunk exists in storage.
-         */
-        private volatile boolean existsInStorage;
-    }
+//    /**
+//     * Extended information about the chunk.
+//     */
+//    @Builder
+//    @Data
+//    public static class ExtendedChunkInfo {
+//        /**
+//         * Length of the chunk in metadata.
+//         */
+//        private volatile long lengthInMetadata;
+//
+//        /**
+//         * Length of the chunk in storage.
+//         */
+//        private volatile long lengthInStorage;
+//
+//        /**
+//         * startOffset of chunk in segment.
+//         */
+//        private volatile long startOffset;
+//
+//        /**
+//         * Name of the chunk.
+//         */
+//        @NonNull
+//        private final String chunkName;
+//
+//        /**
+//         * Whether chunk exists in storage.
+//         */
+//        private volatile boolean existsInStorage;
+//    }
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AdminRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/AdminRequestProcessor.java
@@ -21,4 +21,6 @@ package io.pravega.shared.protocol.netty;
 public interface AdminRequestProcessor extends RequestProcessor {
 
     void flushToStorage(WireCommands.FlushToStorage flushToStorage);
+
+    void listStorageChunks(WireCommands.ListStorageChunks listStorageChunks);
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -50,6 +50,8 @@ public interface ReplyProcessor {
 
     void storageFlushed(WireCommands.StorageFlushed storageFlushed);
 
+    void storageChunksListed(WireCommands.StorageChunksListed storageChunksListed);
+
     void segmentRead(WireCommands.SegmentRead segmentRead);
     
     void segmentAttributeUpdated(WireCommands.SegmentAttributeUpdated segmentAttributeUpdated);

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -35,6 +35,9 @@ public enum WireCommandType {
     FLUSH_TO_STORAGE(-3, WireCommands.FlushToStorage::readFrom),
     FLUSHED_TO_STORAGE(-4, WireCommands.StorageFlushed::readFrom),
 
+    LIST_STORAGE_CHUNKS(-5, WireCommands.ListStorageChunks::readFrom),
+    STORAGE_CHUNKS_LISTED(-6, WireCommands.StorageChunksListed::readFrom),
+
     EVENT(0, null), // Is read manually.
 
     SETUP_APPEND(1, WireCommands.SetupAppend::readFrom),

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -836,6 +836,58 @@ public final class WireCommands {
     }
 
     @Data
+    public static final class ListStorageChunks implements Request, WireCommand {
+        final WireCommandType type = WireCommandType.LIST_STORAGE_CHUNKS;
+        final String segment;
+        @ToString.Exclude
+        final String delegationToken;
+        final long requestId;
+
+        @Override
+        public void process(RequestProcessor cp) {
+            ((AdminRequestProcessor) cp).listStorageChunks(this);
+        }
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeUTF(segment);
+            out.writeUTF(delegationToken == null ? "" : delegationToken);
+            out.writeLong(requestId);
+        }
+
+        public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
+            String segment = in.readUTF();
+            String delegationToken = in.readUTF();
+            long requestId = in.readLong();
+            return new ListStorageChunks(segment, delegationToken, requestId);
+        }
+    }
+
+    @Data
+    public static final class StorageChunksListed implements Reply, WireCommand {
+        final WireCommandType type = WireCommandType.STORAGE_CHUNKS_LISTED;
+        final String segment;
+        final long requestId;
+
+        @Override
+        public void process(ReplyProcessor cp) {
+            cp.storageChunksListed(this);
+        }
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeUTF(segment);
+            out.writeLong(requestId);
+        }
+
+        public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
+            String segment = in.readUTF();
+            long requestId = in.readLong();
+            return new StorageFlushed(requestId);
+        }
+    }
+
+    @Data
     public static final class ReadSegment implements Request, WireCommand {
         final WireCommandType type = WireCommandType.READ_SEGMENT;
         final String segment;


### PR DESCRIPTION
**Change log description**  
Exposes the `getExtendedChunkInfoList` method through the admin CLI. The command allows the user to list all the storage chunks present under a given segment name. The new command is as follows:
```
> storage list-chunks <segment-name>
```
The API is implemented on the admin gateway.

**Purpose of the change**  
Fixes #6520 

**What the code does**  
***Segment Store changes***
- Added new classes to the `WireCommands`. `ListStorageChunks` and `StorageChunksListed` corresponding to the request and reply of the API respectively. Another class `ChunkInfo` has been added to help transfer the result on the wire.
- Moved the `ExtendedChunkInfo` class from `UtilsWrapper` to the `contracts` package, making it more accessible across the segment store.
- The required updates to the `SegmentApi` and `Storage` interfaces and its implementations have also been made.
- The above are implemented in the `AdminRequestProcessorImpl` class through the `AdminRequestProcessor` interface.

***CLI changes***


**How to verify it**  
All tests must pass.
