### PR TITLE
Issue 6523: ContainerEventProcessor internal segment continuous truncations prevent StorageWriter batching

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -30,8 +30,7 @@ plugins.withId('java') {
                 "-Xlint:overrides",
                 "-Xlint:path",
                 "-Xlint:unchecked",
-                "-Werror",
-                getDefaultJavaVersion()
+                "-Werror"
         ])
     }
 
@@ -42,8 +41,7 @@ plugins.withId('java') {
                 "-Xlint:finally",
                 "-Xlint:overrides",
                 "-Xlint:path",
-                "-Werror",
-                getDefaultJavaVersion()])
+                "-Werror")
     }
 
     archivesBaseName = "pravega" + project.path.replace(':', '-')

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -31,7 +31,6 @@ plugins.withId('java') {
                 "-Xlint:path",
                 "-Xlint:unchecked",
                 "-Werror",
-                "--release",
                 getDefaultJavaVersion()
         ])
     }
@@ -44,7 +43,6 @@ plugins.withId('java') {
                 "-Xlint:overrides",
                 "-Xlint:path",
                 "-Werror",
-                "--release",
                 getDefaultJavaVersion()])
     }
 

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -30,7 +30,9 @@ plugins.withId('java') {
                 "-Xlint:overrides",
                 "-Xlint:path",
                 "-Xlint:unchecked",
-                "-Werror"
+                "-Werror",
+                "--release",
+                getDefaultJavaVersion()
         ])
     }
 
@@ -41,7 +43,9 @@ plugins.withId('java') {
                 "-Xlint:finally",
                 "-Xlint:overrides",
                 "-Xlint:path",
-                "-Werror"])
+                "-Werror",
+                "--release",
+                getDefaultJavaVersion()])
     }
 
     archivesBaseName = "pravega" + project.path.replace(':', '-')

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -41,7 +41,7 @@ plugins.withId('java') {
                 "-Xlint:finally",
                 "-Xlint:overrides",
                 "-Xlint:path",
-                "-Werror")
+                "-Werror"])
     }
 
     archivesBaseName = "pravega" + project.path.replace(':', '-')

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerEventProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerEventProcessor.java
@@ -96,6 +96,11 @@ public interface ContainerEventProcessor extends AutoCloseable {
          * Maximum number of outstanding bytes that can be accumulated for a given {@link EventProcessor}.
          */
         private final long maxProcessorOutstandingBytes;
+
+        /**
+         * Amount of data to be accumulated in the internal Segment to truncate it.
+         */
+        private final long segmentTruncationSizeInBytes;
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerEventProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/ContainerEventProcessor.java
@@ -98,9 +98,9 @@ public interface ContainerEventProcessor extends AutoCloseable {
         private final long maxProcessorOutstandingBytes;
 
         /**
-         * Amount of data to be accumulated in the internal Segment to truncate it.
+         * Amount of processed data to be accumulated to truncate the internal Segment.
          */
-        private final long segmentTruncationSizeInBytes;
+        private final long processedDataTruncationSizeInBytes;
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentMetadata.java
@@ -73,7 +73,7 @@ public interface SegmentMetadata extends SegmentProperties {
     /**
      * Gets a value indicating whether this instance of the SegmentMetadata is still active. As long as the Segment is
      * registered in the ContainerMetadata, this will return true. If this returns false, it means this SegmentMetadata
-     * instance has been evicted from the ContainerMetadata (for whatever reasons) and is should be considered stale.
+     * instance has been evicted from the ContainerMetadata (for whatever reasons) and should be considered stale.
      *
      * @return Whether this instance of the SegmentMetadata is active or not.
      */

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerConfig.java
@@ -38,7 +38,7 @@ public class ContainerConfig {
     public static final Property<Integer> MAX_ACTIVE_SEGMENT_COUNT = Property.named("segment.active.count.max", 25000, "maxActiveSegmentCount");
     public static final Property<Integer> MAX_CONCURRENT_SEGMENT_EVICTION_COUNT = Property.named("segment.eviction.concurrent.count.max", 2500, "maxConcurrentSegmentEvictionCount");
     public static final Property<Integer> MAX_CACHED_EXTENDED_ATTRIBUTE_COUNT = Property.named("extended.attribute.cached.count.max", 4096, "maxCachedExtendedAttributeCount");
-    public static final Property<Integer> EVENT_PROCESSOR_ITERATION_DELAY_MS = Property.named("eventprocessor.iteration.delay.ms", 100);
+    public static final Property<Integer> EVENT_PROCESSOR_ITERATION_DELAY_MS = Property.named("eventprocessor.iteration.delay.ms", 1000);
     public static final Property<Integer> EVENT_PROCESSOR_OPERATION_TIMEOUT_MS = Property.named("eventprocessor.operation.timeout.ms", 5000);
     public static final Property<Integer> TRANSIENT_SEGMENT_DELETE_TIMEOUT_MS = Property.named("segment.transient.delete.timeout.ms", 30000);
     private static final String COMPONENT_CODE = "containers";

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -429,7 +429,7 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
                                 "Processed offset = {}, Failed iteration = {}).", this.traceObjectId, this.name,
                                 this.segmentStartOffset.get(), this.processedUpToOffset.get(), this.failedIteration.get());
                         return null;
-                    });
+                    }, this.executor);
         }
 
         /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -514,7 +514,7 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
         }
 
         private boolean shouldTruncate() {
-            return this.processedUpToOffset.get() - this.lastTruncationOffset.get() >= this.config.getSegmentTruncationSizeInBytes();
+            return this.processedUpToOffset.get() - this.lastTruncationOffset.get() >= this.config.getProcessedDataTruncationSizeInBytes();
         }
 
         private CompletableFuture<Void> doTruncateInternalSegment() {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -520,7 +520,7 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
                     }, this.executor)
                     // Only do the actual truncation if the internal Segment has accumulated the configured amount of data.
                     // Note that a restart will induce re-processing of the non-truncated tasks, but this is fine as this class
-                    // ensured at-lest-one processing guarantees
+                    // ensured at-least-once processing guarantees
                     .thenCompose(v -> shouldTruncate() ? doTruncateInternalSegment() : CompletableFuture.completedFuture(null))
                     // Report latency metrics upon complete processing iteration (irrespective of if truncation happened or not).
                     .thenAccept(v -> this.metrics.batchProcessingLatency(iterationTime.getElapsedMillis()));

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -437,7 +437,7 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
         }
 
         /**
-         * Refreshes the cached {@link DirectSegmentAccess} objects to point to fresh metadata. This method is invoked
+         * Refreshes the cached {@link DirectSegmentAccess} object to point to fresh metadata. This method is invoked
          * on each processing iteration.
          *
          * @return Returns a {@link CompletableFuture} that, when successfully complete, sets a new {@link DirectSegmentAccess}
@@ -541,7 +541,7 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
                     }, this.executor)
                     // Only do the actual truncation if the internal Segment has accumulated the configured amount of data.
                     // Note that a restart will induce re-processing of the non-truncated tasks, but this is fine as this class
-                    // ensured at-least-once processing guarantees
+                    // ensured at-least-once processing guarantees.
                     .thenCompose(v -> shouldTruncate() ? doTruncateInternalSegment() : CompletableFuture.completedFuture(null))
                     // Report latency metrics upon complete processing iteration (irrespective of if truncation happened or not).
                     .thenAccept(v -> this.metrics.batchProcessingLatency(iterationTime.getElapsedMillis()));

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -289,7 +289,7 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
             this.failedIteration = new AtomicBoolean(false);
             // Set with actual value when upon initialization.
             this.processedUpToOffset = new AtomicLong(segment.getInfo().getStartOffset());
-            this.lastTruncationOffset = new AtomicLong(0);
+            this.lastTruncationOffset = new AtomicLong(segment.getInfo().getStartOffset());
         }
 
         //endregion
@@ -429,8 +429,8 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
          */
         private void reconcileStartOffset() {
             long newStartOffset = segment.getInfo().getStartOffset();
-            log.info("{}: Reconciling start offset from {} to {}.", this.traceObjectId, this.processedUpToOffset.get(), newStartOffset);
-            this.processedUpToOffset.set(newStartOffset);
+            log.info("{}: Reconciling start offset from {} to {}.", this.traceObjectId, this.processedUpToOffset.getAndSet(newStartOffset), newStartOffset);
+            log.info("{}: Reconciling last truncation offset from {} to {}.", this.traceObjectId, this.lastTruncationOffset.getAndSet(newStartOffset), newStartOffset);
         }
 
         /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -429,8 +429,10 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
          */
         private void reconcileStartOffset() {
             long newStartOffset = segment.getInfo().getStartOffset();
-            log.info("{}: Reconciling start offset from {} to {}.", this.traceObjectId, this.processedUpToOffset.getAndSet(newStartOffset), newStartOffset);
-            log.info("{}: Reconciling last truncation offset from {} to {}.", this.traceObjectId, this.lastTruncationOffset.getAndSet(newStartOffset), newStartOffset);
+            log.info("{}: Reconciling start offset from {} to {}.", this.traceObjectId, this.processedUpToOffset.get(), newStartOffset);
+            this.processedUpToOffset.set(newStartOffset);
+            log.info("{}: Reconciling last truncation offset from {} to {}.", this.traceObjectId, this.lastTruncationOffset.get(), newStartOffset);
+            this.lastTruncationOffset.set(newStartOffset);
         }
 
         /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -29,6 +29,7 @@ import io.pravega.common.io.serialization.RevisionDataOutput;
 import io.pravega.common.io.serialization.VersionedSerializer;
 import io.pravega.common.util.BufferView;
 import io.pravega.common.util.ByteArraySegment;
+import io.pravega.segmentstore.contracts.AttributeId;
 import io.pravega.segmentstore.contracts.SegmentType;
 import io.pravega.segmentstore.server.ContainerEventProcessor;
 import io.pravega.segmentstore.server.DirectSegmentAccess;
@@ -50,6 +51,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -114,7 +116,7 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
     /**
      * This function instantiates a new Segment supplier by creating actual Segment against the {@link SegmentContainer}
      * passed as input based on the name passed to the function. Note that the Segment is only created if it does not
-     * exists. Otherwise, it is just loaded and returned.
+     * exist. Otherwise, it is just loaded and returned.
      *
      * @param container {@link SegmentContainer} to create Segments from.
      * @param timeout   Timeout for the Segment creation to complete.
@@ -385,6 +387,7 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
                        .handle((r, ex) -> {
                            if (ex != null) {
                                log.warn("{}: Terminated due to unexpected exception.", this.traceObjectId, ex);
+                               throw new CompletionException(ex);
                            } else {
                                log.info("{}: Terminated.", this.traceObjectId);
                            }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -471,8 +471,8 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
          * Combines refreshing the internal Segment and performing offset reconciliation.
          *
          * @param shouldReconcile If offset reconciliation is required.
-         * @return A completable that, when complete, will perform an internal Segment refresh and offset reconciliation
-         * if shouldReconcile is set to true.
+         * @return A {@link CompletableFuture} that, when complete, will perform an internal Segment refresh and offset
+         * reconciliation if shouldReconcile is set to true.
          */
         private CompletableFuture<Void> reconcileOffsetsIfNeeded(boolean shouldReconcile) {
             if (shouldReconcile) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
@@ -45,7 +45,7 @@ public class StorageEventProcessor implements AbstractTaskQueueManager<GarbageCo
     private final static GarbageCollector.TaskInfo.Serializer SERIALIZER = new GarbageCollector.TaskInfo.Serializer();
     // For SLTS GC, truncating the ContainerEventProcessor internal Segment every 128KB is enough to prevent unnecessary
     // storage metadata activity that may occur if we truncate it too frequently.
-    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = 128 * 1024;
+    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = 16 * 1024;
 
     private final int containerID;
     private final ContainerEventProcessor eventProcessor;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
@@ -45,7 +45,7 @@ public class StorageEventProcessor implements AbstractTaskQueueManager<GarbageCo
     private final static GarbageCollector.TaskInfo.Serializer SERIALIZER = new GarbageCollector.TaskInfo.Serializer();
     // For SLTS GC, truncating the ContainerEventProcessor internal Segment every 128KB is enough to prevent unnecessary
     // storage metadata activity that may occur if we truncate it too frequently.
-    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = Long.MAX_VALUE;
+    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = 128 * 1024;
 
     private final int containerID;
     private final ContainerEventProcessor eventProcessor;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
@@ -45,7 +45,7 @@ public class StorageEventProcessor implements AbstractTaskQueueManager<GarbageCo
     private final static GarbageCollector.TaskInfo.Serializer SERIALIZER = new GarbageCollector.TaskInfo.Serializer();
     // For SLTS GC, truncating the ContainerEventProcessor internal Segment every 128KB is enough to prevent unnecessary
     // storage metadata activity that may occur if we truncate it too frequently.
-    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = 0 * 1024;
+    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = Long.MAX_VALUE;
 
     private final int containerID;
     private final ContainerEventProcessor eventProcessor;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
@@ -45,7 +45,7 @@ public class StorageEventProcessor implements AbstractTaskQueueManager<GarbageCo
     private final static GarbageCollector.TaskInfo.Serializer SERIALIZER = new GarbageCollector.TaskInfo.Serializer();
     // For SLTS GC, truncating the ContainerEventProcessor internal Segment every 128KB is enough to prevent unnecessary
     // storage metadata activity that may occur if we truncate it too frequently.
-    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = 16 * 1024;
+    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = 0 * 1024;
 
     private final int containerID;
     private final ContainerEventProcessor eventProcessor;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
@@ -43,6 +43,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class StorageEventProcessor implements AbstractTaskQueueManager<GarbageCollector.TaskInfo> {
 
     private final static GarbageCollector.TaskInfo.Serializer SERIALIZER = new GarbageCollector.TaskInfo.Serializer();
+    // For SLTS GC, truncating the ContainerEventProcessor internal Segment every 1MB is enough to prevent unnecessary
+    // storage metadata activity that may occur if we truncate it too frequently.
+    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = 1024 * 1024;
 
     private final int containerID;
     private final ContainerEventProcessor eventProcessor;
@@ -81,7 +84,7 @@ public class StorageEventProcessor implements AbstractTaskQueueManager<GarbageCo
     @Override
     public CompletableFuture<Void> addQueue(String queueName, Boolean ignoreProcessing) {
         Preconditions.checkNotNull(queueName, "queueName");
-        val config = new ContainerEventProcessor.EventProcessorConfig(maxItemsAtOnce, Long.MAX_VALUE, 1024 * 1024);
+        val config = new ContainerEventProcessor.EventProcessorConfig(maxItemsAtOnce, Long.MAX_VALUE, CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE);
         val f = ignoreProcessing ?
                 eventProcessor.forDurableQueue(queueName) :
                 eventProcessor.forConsumer(queueName, this::processEvents, config);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
@@ -43,9 +43,9 @@ import java.util.concurrent.ConcurrentHashMap;
 public class StorageEventProcessor implements AbstractTaskQueueManager<GarbageCollector.TaskInfo> {
 
     private final static GarbageCollector.TaskInfo.Serializer SERIALIZER = new GarbageCollector.TaskInfo.Serializer();
-    // For SLTS GC, truncating the ContainerEventProcessor internal Segment every 1MB is enough to prevent unnecessary
+    // For SLTS GC, truncating the ContainerEventProcessor internal Segment every 128KB is enough to prevent unnecessary
     // storage metadata activity that may occur if we truncate it too frequently.
-    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = 1024 * 1024;
+    private final static long CONTAINER_EVENT_PROCESSOR_TRUNCATE_DATA_SIZE = 128 * 1024;
 
     private final int containerID;
     private final ContainerEventProcessor eventProcessor;

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StorageEventProcessor.java
@@ -81,7 +81,7 @@ public class StorageEventProcessor implements AbstractTaskQueueManager<GarbageCo
     @Override
     public CompletableFuture<Void> addQueue(String queueName, Boolean ignoreProcessing) {
         Preconditions.checkNotNull(queueName, "queueName");
-        val config = new ContainerEventProcessor.EventProcessorConfig(maxItemsAtOnce, Long.MAX_VALUE);
+        val config = new ContainerEventProcessor.EventProcessorConfig(maxItemsAtOnce, Long.MAX_VALUE, 1024 * 1024);
         val f = ignoreProcessing ?
                 eventProcessor.forDurableQueue(queueName) :
                 eventProcessor.forConsumer(queueName, this::processEvents, config);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
@@ -291,7 +291,7 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
     }
 
     /**
-     * Determines whether the Segment with given metadata can be evicted, based on the the given Sequence Number Threshold.
+     * Determines whether the Segment with given metadata can be evicted, based on the given Sequence Number Threshold.
      * A Segment will not be chosen for eviction if {@link SegmentMetadata#isPinned()} is true.
      *
      * @param metadata             The Metadata for the Segment that is considered for eviction.

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
@@ -231,7 +231,12 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
         synchronized (this.lock) {
             candidates = this.metadataById
                     .values().stream()
-                    .filter(m -> isEligibleForEviction(m, adjustedCutoff))
+                    .filter(m -> {
+                        boolean eligible = isEligibleForEviction(m, adjustedCutoff);
+                        log.info("{}: MapStreamSegment SegmentId = {}, Name = '{}', Active = {}, Deleted = {}. Eligible = {}",
+                                this.traceObjectId, m.getId(), m.getName(), m.isActive(), m.isDeleted(), eligible);
+                        return eligible;
+                    })
                     .collect(Collectors.toList());
         }
 
@@ -263,7 +268,7 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
         }
 
         if (evictedSegments.size() > 0) {
-            log.info("{}: EvictedStreamSegments Count = {}, Active = {}", this.traceObjectId, evictedSegments.size(), count);
+            log.info("{}: EvictedStreamSegments Count = {}, Active = {}, Segments = {}", this.traceObjectId, evictedSegments.size(), count, evictedSegments);
             this.metrics.segmentCount(count);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
@@ -231,12 +231,7 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
         synchronized (this.lock) {
             candidates = this.metadataById
                     .values().stream()
-                    .filter(m -> {
-                        boolean eligible = isEligibleForEviction(m, adjustedCutoff);
-                        log.info("{}: MapStreamSegment SegmentId = {}, Name = '{}', Active = {}, Deleted = {}. Eligible = {}",
-                                this.traceObjectId, m.getId(), m.getName(), m.isActive(), m.isDeleted(), eligible);
-                        return eligible;
-                    })
+                    .filter(m -> isEligibleForEviction(m, adjustedCutoff))
                     .collect(Collectors.toList());
         }
 
@@ -268,7 +263,7 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
         }
 
         if (evictedSegments.size() > 0) {
-            log.info("{}: EvictedStreamSegments Count = {}, Active = {}, Segments = {}", this.traceObjectId, evictedSegments.size(), count, evictedSegments);
+            log.info("{}: EvictedStreamSegments Count = {}, Active = {}", this.traceObjectId, evictedSegments.size(), count);
             this.metrics.segmentCount(count);
         }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentMetadata.java
@@ -388,6 +388,7 @@ public class StreamSegmentMetadata implements UpdateableSegmentMetadata {
      */
     @VisibleForTesting
     public synchronized void markInactive() {
+        log.debug("{}: Inactive = true.", this.traceObjectId);
         this.active = false;
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -826,7 +826,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                         // This segment existed in our Update Transaction/Base Metadata, however this checkpoint no longer has it.
                         // This means that the segment has been evicted at one point between the last checkpoint and this one,
                         // so it should be safe to remove it from our list (if possible).
-                        log.debug("MetadataUpdate[{}]: Un-mapping Segment Id '%s' because it is no longer present in a MetadataCheckpoint.", t.containerId);
+                        log.info("MetadataUpdate[{}]: Un-mapping Segment Id {} because it is no longer present in a MetadataCheckpoint.", t.containerId, segmentId);
                         t.removeNewSegment(segmentId);
                     }
                 } else {
@@ -837,6 +837,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                     }
 
                     if (m.isDeletedInStorage()) {
+                        log.info("MetadataUpdate[{}]: Marking segment {} ({}) as deleted.", t.containerId, segmentUpdate.getId(), segmentId);
                         segmentUpdate.markDeleted();
                     }
 
@@ -846,8 +847,12 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         }
 
         private boolean canUnregister(SegmentMetadata existingMetadata) {
-            return existingMetadata.isDeleted()
+            boolean canUnregister = existingMetadata.isDeleted()
                     || existingMetadata.getStorageLength() >= existingMetadata.getLength();
+            log.info("MetadataUpdate[{}]: Can unregister segment {} ({}) (deleted = {}, storageLength = {}, length = {})? {}",
+                    existingMetadata.getContainerId(), existingMetadata.getId(), existingMetadata.getName(), existingMetadata.isDeleted(),
+                    existingMetadata.getStorageLength(), existingMetadata.getLength(), canUnregister);
+            return canUnregister;
         }
 
         @Data

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -826,7 +826,7 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                         // This segment existed in our Update Transaction/Base Metadata, however this checkpoint no longer has it.
                         // This means that the segment has been evicted at one point between the last checkpoint and this one,
                         // so it should be safe to remove it from our list (if possible).
-                        log.info("MetadataUpdate[{}]: Un-mapping Segment Id {} because it is no longer present in a MetadataCheckpoint.", t.containerId, segmentId);
+                        log.debug("MetadataUpdate[{}]: Un-mapping Segment Id {} because it is no longer present in a MetadataCheckpoint.", t.containerId, segmentId);
                         t.removeNewSegment(segmentId);
                     }
                 } else {
@@ -837,7 +837,6 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                     }
 
                     if (m.isDeletedInStorage()) {
-                        log.info("MetadataUpdate[{}]: Marking segment {} ({}) as deleted.", t.containerId, segmentUpdate.getId(), segmentId);
                         segmentUpdate.markDeleted();
                     }
 
@@ -847,12 +846,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         }
 
         private boolean canUnregister(SegmentMetadata existingMetadata) {
-            boolean canUnregister = existingMetadata.isDeleted()
+            return existingMetadata.isDeleted()
                     || existingMetadata.getStorageLength() >= existingMetadata.getLength();
-            log.info("MetadataUpdate[{}]: Can unregister segment {} ({}) (deleted = {}, storageLength = {}, length = {})? {}",
-                    existingMetadata.getContainerId(), existingMetadata.getId(), existingMetadata.getName(), existingMetadata.isDeleted(),
-                    existingMetadata.getStorageLength(), existingMetadata.getLength(), canUnregister);
-            return canUnregister;
         }
 
         @Data

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorTests.java
@@ -64,7 +64,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
     private static final Duration CONTAINER_OPERATION_TIMEOUT = Duration.ofMillis(1000);
 
     @Rule
-    public Timeout globalTimeout = new Timeout(TIMEOUT_SUITE_MILLIS * 100, TimeUnit.MILLISECONDS);
+    public Timeout globalTimeout = new Timeout(TIMEOUT_SUITE_MILLIS, TimeUnit.MILLISECONDS);
 
     @Override
     protected int getThreadPoolSize() {
@@ -87,7 +87,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
     public static void testBasicContainerEventProcessor(ContainerEventProcessor containerEventProcessor) throws Exception {
         int maxItemsPerBatch = 10;
         int maxOutstandingBytes = 4 * 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         ReusableLatch latch = new ReusableLatch();
         final AtomicReference<String> userEvent = new AtomicReference<>("event1");
         Function<List<BufferView>, CompletableFuture<Void>> handler = l -> {
@@ -136,7 +136,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
         int maxItemsPerBatch = 10;
         int maxOutstandingBytes = 4 * 1024 * 1024;
         int allEventsToProcess = 1000;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         List<Integer> processedItems = new ArrayList<>();
         Function<List<BufferView>, CompletableFuture<Void>> handler = getNumberSequenceHandler(processedItems, maxItemsPerBatch);
         ContainerEventProcessor.EventProcessorConfig config = new ContainerEventProcessor.EventProcessorConfig(maxItemsPerBatch,
@@ -172,7 +172,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
     public static void testFaultyHandler(ContainerEventProcessor eventProcessorService) throws Exception {
         int maxItemsProcessed = 10;
         int maxOutstandingBytes = 4 * 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         AtomicLong retries = new AtomicLong(0);
         Function<List<BufferView>, CompletableFuture<Void>> handler = l -> {
             retries.addAndGet(1);
@@ -210,7 +210,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
         int allEventsToProcess = 100;
         int maxItemsPerBatch = 10;
         int maxOutstandingBytes = 4 * 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         List<Integer> processorResults1 = new ArrayList<>();
         Function<List<BufferView>, CompletableFuture<Void>> handler1 = getNumberSequenceHandler(processorResults1, maxItemsPerBatch);
         List<Integer> processorResults2 = new ArrayList<>();
@@ -266,7 +266,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
     public static void testEventProcessorWithSerializationError(ContainerEventProcessor containerEventProcessor) throws Exception {
         int maxItemsPerBatch = 10;
         int maxOutstandingBytes = 4 * 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         AtomicLong readEvents = new AtomicLong(0);
         Function<List<BufferView>, CompletableFuture<Void>> handler = l -> {
             readEvents.addAndGet(l.size());
@@ -308,7 +308,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
     public static void testEventRejectionOnMaxOutstanding(ContainerEventProcessor eventProcessorService) throws Exception {
         int maxItemsProcessed = 1000;
         int maxOutstandingBytes = 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         ContainerEventProcessor.EventProcessorConfig config = new ContainerEventProcessor.EventProcessorConfig(maxItemsProcessed,
                 maxOutstandingBytes, truncationDataSize);
         AtomicLong processorResults = new AtomicLong(0);
@@ -361,7 +361,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
                 ITERATION_DELAY, CONTAINER_OPERATION_TIMEOUT, this.executorService());
         int maxItemsProcessed = 10;
         int maxOutstandingBytes = 4 * 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         ContainerEventProcessor.EventProcessorConfig config = new ContainerEventProcessor.EventProcessorConfig(maxItemsProcessed,
                 maxOutstandingBytes, truncationDataSize);
         Function<List<BufferView>, CompletableFuture<Void>> doNothing = l -> null;
@@ -388,7 +388,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
                 ITERATION_DELAY, CONTAINER_OPERATION_TIMEOUT, this.executorService());
         int maxItemsProcessed = 10;
         int maxOutstandingBytes = 4 * 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         ContainerEventProcessor.EventProcessorConfig config = new ContainerEventProcessor.EventProcessorConfig(maxItemsProcessed,
                 maxOutstandingBytes, truncationDataSize);
         ReusableLatch latch = new ReusableLatch();
@@ -422,7 +422,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
                 ITERATION_DELAY, CONTAINER_OPERATION_TIMEOUT, this.executorService());
         int maxItemsProcessed = 10;
         int maxOutstandingBytes = 4 * 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         ContainerEventProcessor.EventProcessorConfig config = new ContainerEventProcessor.EventProcessorConfig(maxItemsProcessed,
                 maxOutstandingBytes, truncationDataSize);
 
@@ -473,7 +473,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
                 ITERATION_DELAY, CONTAINER_OPERATION_TIMEOUT, this.executorService());
         int maxItemsProcessed = 10;
         int maxOutstandingBytes = 4 * 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         ContainerEventProcessor.EventProcessorConfig config = new ContainerEventProcessor.EventProcessorConfig(maxItemsProcessed,
                 maxOutstandingBytes, truncationDataSize);
 
@@ -508,7 +508,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
                 ITERATION_DELAY, CONTAINER_OPERATION_TIMEOUT, this.executorService());
         int maxItemsProcessed = 10;
         int maxOutstandingBytes = 4 * 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         ContainerEventProcessor.EventProcessorConfig config = new ContainerEventProcessor.EventProcessorConfig(maxItemsProcessed,
                 maxOutstandingBytes, truncationDataSize);
         AtomicLong processorResults = new AtomicLong(0);
@@ -565,7 +565,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
     }
 
     /**
-     * This test shows that we avoid events to be re-processed in the case of a failure related to Segment truncation.
+     * This test shows that we could have events re-processed in the case that failures are related to Segment truncation.
      *
      * @throws Exception
      */
@@ -576,8 +576,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
         Consumer<DirectSegmentAccess> failOnTruncation = faultySegment -> when(faultySegment.truncate(anyLong(),
                 any(Duration.class))).thenThrow(IntentionalException.class).thenCallRealMethod();
         executeEventOrderingTest(numEvents, readEvents, failOnTruncation);
-        // If a single truncation operation fails, tasks do not get re-processed, as we keep track of the data to truncate.
-        Assert.assertEquals(readEvents.size(), numEvents);
+        Assert.assertTrue(readEvents.size() > numEvents);
     }
 
     private void executeEventOrderingTest(int numEvents, List<Integer> readEvents, Consumer<DirectSegmentAccess> segmentFailure) throws Exception {
@@ -588,7 +587,7 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
                 ITERATION_DELAY, CONTAINER_OPERATION_TIMEOUT, this.executorService());
         int maxItemsProcessed = 100;
         int maxOutstandingBytes = 4 * 1024 * 1024;
-        int truncationDataSize = 0;
+        int truncationDataSize = 500;
         Function<List<BufferView>, CompletableFuture<Void>> handler = l -> {
             l.forEach(d -> readEvents.add(new ByteArraySegment(d.getCopy()).getInt(0)));
             return CompletableFuture.completedFuture(null);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorTests.java
@@ -194,20 +194,6 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
         AssertExtensions.assertEventuallyEquals(true, () -> retries.get() == 10, 10000);
     }
 
-    /**
-     * Check that multiple EventProcessors can work in parallel under the same {@link ContainerEventProcessor}, even in if
-     * some of them are faulty.
-     *
-     * @throws Exception
-     */
-    @Test(timeout = TIMEOUT_SUITE_MILLIS)
-    public void testMultipleProcessors() throws Exception {
-        @Cleanup
-        ContainerEventProcessor eventProcessorService = new ContainerEventProcessorImpl(0, mockSegmentSupplier(),
-                ITERATION_DELAY, CONTAINER_OPERATION_TIMEOUT, this.executorService());
-        testMultipleProcessors(eventProcessorService);
-    }
-
     public static void testMultipleProcessors(ContainerEventProcessor eventProcessorService) throws Exception {
         int allEventsToProcess = 100;
         int maxItemsPerBatch = 10;
@@ -691,12 +677,12 @@ public class ContainerEventProcessorTests extends ThreadPooledTestSuite {
     }
 
     private Function<String, CompletableFuture<DirectSegmentAccess>> mockSegmentSupplier() {
-        return s -> CompletableFuture.completedFuture(new SegmentMock(this.executorService()));
+        MockSegmentSupplier mockSegmentSupplier = new MockSegmentSupplier();
+        return s -> mockSegmentSupplier.mockSegmentSupplier().apply(s);
     }
 
     class MockSegmentSupplier {
         SegmentMock segmentMock = spy(new SegmentMock(executorService()));
-
         private Function<String, CompletableFuture<DirectSegmentAccess>> mockSegmentSupplier() {
             return s -> CompletableFuture.completedFuture(this.segmentMock);
         }

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -195,6 +195,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
     private static final SegmentType BASIC_TYPE = SegmentType.STREAM_SEGMENT;
     private static final int EVENT_PROCESSOR_EVENTS_AT_ONCE = 10;
     private static final int EVENT_PROCESSOR_MAX_OUTSTANDING_BYTES = 4 * 1024 * 1024;
+    private static final int EVENT_PROCESSOR_TRUNCATE_SIZE_BYTES = 1024 * 1024;
     private static final SegmentType[] SEGMENT_TYPES = new SegmentType[]{
             BASIC_TYPE,
             SegmentType.builder(BASIC_TYPE).build(),
@@ -2549,8 +2550,8 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
         ((ContainerEventProcessorImpl.EventProcessorImpl) processor).awaitTerminated();
 
         // Now, re-create the Event Processor with a handler to consume the events.
-        ContainerEventProcessor.EventProcessorConfig eventProcessorConfig =
-                new ContainerEventProcessor.EventProcessorConfig(EVENT_PROCESSOR_EVENTS_AT_ONCE, EVENT_PROCESSOR_MAX_OUTSTANDING_BYTES);
+        ContainerEventProcessor.EventProcessorConfig eventProcessorConfig = new ContainerEventProcessor.EventProcessorConfig(EVENT_PROCESSOR_EVENTS_AT_ONCE,
+                EVENT_PROCESSOR_MAX_OUTSTANDING_BYTES, EVENT_PROCESSOR_TRUNCATE_SIZE_BYTES);
         List<Integer> processorResults = new ArrayList<>();
         Function<List<BufferView>, CompletableFuture<Void>> handler = l -> {
             l.forEach(b -> {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -195,7 +195,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
     private static final SegmentType BASIC_TYPE = SegmentType.STREAM_SEGMENT;
     private static final int EVENT_PROCESSOR_EVENTS_AT_ONCE = 10;
     private static final int EVENT_PROCESSOR_MAX_OUTSTANDING_BYTES = 4 * 1024 * 1024;
-    private static final int EVENT_PROCESSOR_TRUNCATE_SIZE_BYTES = 1024 * 1024;
+    private static final int EVENT_PROCESSOR_TRUNCATE_SIZE_BYTES = 1024;
     private static final SegmentType[] SEGMENT_TYPES = new SegmentType[]{
             BASIC_TYPE,
             SegmentType.builder(BASIC_TYPE).build(),


### PR DESCRIPTION
**Change log description**  
Adds the possibility to configure the truncation data side to `ContainerEventProcessor`. Set to 128KB the default truncation size for SLTS GC. Also, refresh the internal `DirectSegmentAccess` on each processing iteration of `ContainerEventProcessor`. Increased `ContainerEventProcessor` timeout from 100ms to 1 second, to reduce log noise when there are no items to process.

**Purpose of the change**  
Fixes #6523.
Fixes #6509.

**What the code does**  
This PR adds the ability to `ContainerEventProcessor` to configure length at which processed data is truncated. This can help to induce too frequent truncation in the internal Segment of the `ContainerEventProcessor`, which leads the `StorageWriter` to not  be able to batch operations on that Segment. This PR contains the following changes:
- Added a new property called `processedDataTruncationSizeInBytes` in `ContainerEventProcessor` to define how much data needs to be processed before actually truncating the internal Segment.
- For SLTS GC, just configured the `ContainerEventProcessor` to truncate the internal Segment every 128KB. That is enough to prevent the original problem reported in #6523. Note that, as it is a low level parameter, it is defined as a constant in `StorageEventProcessor` rather than exposing it via the configuration of SLTS GC (adds complexity and seems unnecessary).
- In `ContainerEventProcessor`, apart from the existing attribute `segmentStartOffset` that was essentially the same as the start offset of the Segment, we added two new ones: `processedUpToOffset` (it tracks the offset of the data processed) and `segmentLength` (tracks more accurately segment length without querying the Segment). When `processedUpToOffset - segmentLength >= processedDataTruncationSizeInBytes`, then the current iteration of the `ContainerEventProcessor` truncates the internal Segment.

Apart from the previous changes, we have fixed an additional (day 0) bug in `ContainerEventProcessor`: this class was caching long term `DirectSegmentAccess` objects related to the internal truncation Segment. According to the documentation: https://github.com/pravega/pravega/blob/e1913b8fed98ee339abcd0da999eaf9b61fa943e/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentContainer.java#L84
Caching for long time `DirectSegmentAccess` objects is discouraged as the state of that object can become stale quickly. This was the root cause for the problems we had developing this PR, as the `ContainerEventProcessor` after some time of operation either did not found the metadata of its internal Segment and/or it started to work with some random Segment name. 

Finally, Increased `ContainerEventProcessor` timeout from 100ms to 1 second, to reduce log noise when there are no items to process.

**How to verify it**  
All existing tests are passing. Added new test for new functionality.
System tests have passed:
test-pravega-continuous-1/1928
test-pravega-continuous-1/1930
test-pravega-continuous/4334

A 2 day longevity has passed:
pravega-longevity/1050