### PR TITLE
Issue 6534: Git Actions seems to be picking wrong Java version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -68,11 +68,16 @@ jobs:
         run: echo Building a '${{ github.event_name }}' for target '${{ github.ref }}'.
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
+      - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -104,11 +109,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
+      - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '8'
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -136,11 +146,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
+      - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -168,11 +183,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
+      - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -205,11 +225,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
+      - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -241,11 +266,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
+      - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -291,11 +321,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
+      - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -338,11 +373,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Gradle & Maven Cache
-        uses: actions/cache@v2.1.0
+      - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'
+      - name: Gradle & Maven Cache
+        uses: actions/cache@v2.1.0
+        with:
+          path: ${{env.GLOBAL_CACHE_PATH}}
+          key: ${{env.GLOBAL_CACHE_KEY}}
+          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -71,9 +71,8 @@ jobs:
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+          distribution: 'adopt'
+          java-version: '11'
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -108,9 +107,8 @@ jobs:
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+          distribution: 'adopt'
+          java-version: '8'
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -141,9 +139,8 @@ jobs:
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+          distribution: 'adopt'
+          java-version: '11'
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -174,9 +171,8 @@ jobs:
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+          distribution: 'adopt'
+          java-version: '11'
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -212,9 +208,8 @@ jobs:
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+          distribution: 'adopt'
+          java-version: '11'
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -249,9 +244,8 @@ jobs:
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+          distribution: 'adopt'
+          java-version: '11'
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -300,9 +294,8 @@ jobs:
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+          distribution: 'adopt'
+          java-version: '11'
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:
@@ -348,9 +341,8 @@ jobs:
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:
-          path: ${{env.GLOBAL_CACHE_PATH}}
-          key: ${{env.GLOBAL_CACHE_KEY}}
-          restore-keys: ${{env.GLOBAL_CACHE_RESTORE_KEYS}}
+          distribution: 'adopt'
+          java-version: '11'
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '11'
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
@@ -185,7 +185,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
@@ -227,7 +227,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
@@ -268,7 +268,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
@@ -323,7 +323,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0
@@ -375,7 +375,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Gradle & Maven Cache
         uses: actions/cache@v2.1.0


### PR DESCRIPTION
**Change log description**  
Explicitly set `actions/setup-java@v2` in the Git Actions configuration file. Also, explicitly set AdoptJDK 11 as the JDK to use.

**Purpose of the change**  
Fixes #6534.

**What the code does**  
Explicitly sets to use AdoptJDK 11 in our builds, as some change in the underlying Git Actions environment could inadvertently switch it to Java 8, which causes compilation errors.

**How to verify it**  
Build must pass.