### PR TITLE
Issue 6539: Table Segment tail-caching may populate tail cache with stale data

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -616,7 +616,7 @@ class ContainerKeyIndex implements AutoCloseable {
      * This method triggers this operation asynchronously and does not wait for it to complete. Its completion status and
      * any errors will be logged.
      *
-     * NOTE: this does not peform a proper recovery nor does it update the durable index - it simply caches the values.
+     * NOTE: this does not perform a proper recovery nor does it update the durable index - it simply caches the values.
      * The {@link WriterTableProcessor} must be used to update the index.
      *
      * @param segment A {@link DirectSegmentAccess} representing the Segment for which to cache the tail index.
@@ -696,6 +696,9 @@ class ContainerKeyIndex implements AutoCloseable {
                 if (!tailCachePreIndexVersionTracker.containsKey(hash) || tailCachePreIndexVersionTracker.get(hash) < e.getVersion()) {
                     tailCachePreIndexVersionTracker.put(hash, e.getVersion());
                     result.add(hash, nextOffset, e.getHeader().getTotalLength(), e.getHeader().isDeletion());
+                } else {
+                    log.warn("{}: Not tail-caching key {} as it has a lower version {} than the existing cached entry ({}).", this.traceObjectId,
+                            hash, e.getVersion(), tailCachePreIndexVersionTracker.get(hash));
                 }
                 // Irrespective of whether the entry is added to the tail updates, set the max processed offset.
                 result.setMaxOffset(nextOffset, e.getHeader().getTotalLength());

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -731,7 +731,7 @@ class ContainerKeyIndex implements AutoCloseable {
                         result.add(hash, nextOffset, e.getHeader().getTotalLength(), e.getHeader().isDeletion());
                     }
                 } else {
-                    log.warn("{}: Not tail-caching key {} as it has a lower version {} than the existing cached entry ({}).", this.traceObjectId,
+                    log.info("{}: Not tail-caching key {} as it has a lower version {} than the existing cached entry ({}).", this.traceObjectId,
                             hash, e.getVersion(), tailCachePreIndexVersionTracker.get(hash));
                 }
                 // Irrespective of whether the entry is added to the tail updates, set the max processed offset.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -260,7 +260,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
     private static final Duration TIMEOUT_EVENT_PROCESSOR_ITERATION = Duration.ofMillis(100);
 
     @Rule
-    public Timeout globalTimeout = Timeout.millis(100 * TEST_TIMEOUT_MILLIS);
+    public Timeout globalTimeout = Timeout.millis(TEST_TIMEOUT_MILLIS);
 
     @Override
     protected int getThreadPoolSize() {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -3282,7 +3282,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
         private final ConcurrentHashMap<String, Long> truncationOffsets = new ConcurrentHashMap<>();
         // Allow tests to run a custom callback after write() method is invoked in Storage.
         @Getter
-        private final AtomicReference<Consumer<SegmentHandle>> writeCallback = new AtomicReference<>(s-> {});
+        private final AtomicReference<Consumer<SegmentHandle>> writeCallback = new AtomicReference<>(s -> { });
 
 
         public WatchableInMemoryStorageFactory(ScheduledExecutorService executor) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -2376,7 +2376,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
         // have completed its first iteration, so it is the time to add a new value for key1 while TableCompactor is working.
         CompletableFuture<Void> callbackExecuted = new CompletableFuture<>();
         context.storageFactory.getPostWriteCallback().set((segmentHandle, offset) -> {
-            if (segmentHandle.getSegmentName().equals("Segment_0_Table") && !callbackExecuted.isDone()) {
+            if (segmentHandle.getSegmentName().contains("Segment_0_Table$attributes.index") && !callbackExecuted.isDone()) {
                 Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 4)), TIMEOUT)).join();
                 callbackExecuted.complete(null);
             }
@@ -2415,82 +2415,6 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
                 .get(0);
         Assert.assertEquals(actual.getKey().getKey(), expected.getKey().getKey());
         Assert.assertEquals(actual.getValue(), expected.getValue());
-    }
-
-    @Test
-    public void testTableSegmentReadAfterCompactedButNonIndexedEntryAndRecovery() throws Exception {
-        @Cleanup
-        TestContext context = new TestContext(DEFAULT_CONFIG, NO_TRUNCATIONS_DURABLE_LOG_CONFIG, DEFAULT_WRITER_CONFIG, null);
-        val durableLog = new AtomicReference<OperationLog>();
-        val durableLogFactory = new WatchableOperationLogFactory(context.operationLogFactory, durableLog::set);
-        @Cleanup
-        StreamSegmentContainer container = new StreamSegmentContainer(CONTAINER_ID, DEFAULT_CONFIG, durableLogFactory,
-                context.readIndexFactory, context.attributeIndexFactory, context.writerFactory, context.storageFactory,
-                context.getCompactionTestExtensions(), executorService());
-        container.startAsync().awaitRunning();
-        Assert.assertNotNull(durableLog.get());
-        val tableStore = container.getExtension(ContainerTableExtension.class);
-        // Data size and count to be written in this test.
-        long serializedEntryLength = 28;
-        long writtenEntries = 9;
-
-        // 1. Create the Table Segment and get a DirectSegmentAccess to it to monitor its size.
-        String tableSegmentName = getSegmentName(0) + "_Table";
-        val type = SegmentType.builder(getSegmentType(tableSegmentName)).tableSegment().build();
-        tableStore.createSegment(tableSegmentName, type, TIMEOUT).join();
-        DirectSegmentAccess directTableSegment = container.forSegment(tableSegmentName, TIMEOUT).join();
-
-        // 2. Add some entries to the table segments. Note tha we write multiple values to each key, so the TableCompactor
-        // can find entries to move to the tail.
-        final BiFunction<String, Integer, TableEntry> createTableEntry = (key, value) ->
-                TableEntry.unversioned(new ByteArraySegment(key.getBytes()),
-                        new ByteArraySegment(String.format("Value_%s", value).getBytes()));
-
-        // 3. This callback will run when the StorageWriter writes data to Storage. At this point, StorageWriter would
-        // have completed its first iteration, so it is the time to add a new value for key1 while TableCompactor is working.
-        CompletableFuture<Void> callbackExecuted = new CompletableFuture<>();
-        context.storageFactory.getPostWriteCallback().set((segmentHandle, offset) -> {
-            if (segmentHandle.getSegmentName().equals("Segment_0_Table") && !callbackExecuted.isDone()) {
-                Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 6)), TIMEOUT)).join();
-                callbackExecuted.complete(null);
-            }
-        });
-
-        // Do the actual puts.
-        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 1)), TIMEOUT)).join();
-        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 2)), TIMEOUT)).join();
-        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 3)), TIMEOUT)).join();
-        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 4)), TIMEOUT)).join();
-        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 5)), TIMEOUT)).join();
-        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key2", 1)), TIMEOUT)).join();
-        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key2", 2)), TIMEOUT)).join();
-        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key2", 3)), TIMEOUT)).join();
-
-        // 4. Above, the test does 7 puts, each one 28 bytes in size (6 entries directly, 1 via callback). Now, we need
-        // to wait for the TableCompactor writing the entry (key1, 3) to the tail of the Segment.
-        callbackExecuted.join();
-        AssertExtensions.assertEventuallyEquals(true, () -> directTableSegment.getInfo().getLength() > serializedEntryLength * writtenEntries, 5000);
-
-        // 5. The TableCompactor has moved the entry, so we immediately stop the container to prevent StorageWriter from
-        // making more progress.
-        container.close();
-
-        // 6. Create a new container instance that will recover from existing data.
-        @Cleanup
-        val container2 = new StreamSegmentContainer(CONTAINER_ID, DEFAULT_CONFIG, durableLogFactory,
-                context.readIndexFactory, context.attributeIndexFactory, context.writerFactory, context.storageFactory,
-                context.getCompactionTestExtensions(), executorService());
-        container2.startAsync().awaitRunning();
-
-        // 7. Verify that (key1, 4) is the actual value after performing the tail-caching process, which now takes care
-        // of entry versions.
-        val expected = createTableEntry.apply("key1", 6);
-        val tableStore2 = container2.getExtension(ContainerTableExtension.class);
-        val actual = tableStore2.get(tableSegmentName, Collections.singletonList(expected.getKey().getKey()), TIMEOUT)
-                .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
-                .get(0);
-        Assert.assertEquals(expected.getKey().getKey(), actual.getKey().getKey());
-        Assert.assertEquals(expected.getValue(), actual.getValue());
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -2387,8 +2387,8 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
 
         // 4. Above, the test does 7 puts, each one 28 bytes in size. Now, we need to wait for the TableCompactor writing
         // the entry (key1, 3) to the tail of the Segment.
-        int serializedEntryLength = 28;
-        int writtenEntries = 7;
+        long serializedEntryLength = 28;
+        long writtenEntries = 7;
         AssertExtensions.assertEventuallyEquals(true, () -> directTableSegment.getInfo().getLength() > serializedEntryLength * writtenEntries, 5000);
 
         // 5. The TableCompactor has moved the entry, so we immediately stop the container to prevent StorageWriter from

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -83,7 +83,7 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
     private static final KeyHasher HASHER = KeyHashers.DEFAULT_HASHER;
     private static final int TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH = 128 * 1024;
     @Rule
-    public Timeout globalTimeout = new Timeout(200 * TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    public Timeout globalTimeout = new Timeout(2 * TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
     @Override
     protected int getThreadPoolSize() {
@@ -626,6 +626,7 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
             entries1.add(entry);
         }
 
+        // Make sure to serialize versions, as Table Compactor does.
         val update1 = s.serializeUpdateWithExplicitVersion(entries1);
         Assert.assertEquals(offset.get(), update1.getLength());
         context.segment.append(update1, null, TIMEOUT).join();

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -83,7 +83,7 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
     private static final KeyHasher HASHER = KeyHashers.DEFAULT_HASHER;
     private static final int TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH = 128 * 1024;
     @Rule
-    public Timeout globalTimeout = new Timeout(2 * TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    public Timeout globalTimeout = new Timeout(200 * TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
     @Override
     protected int getThreadPoolSize() {
@@ -626,7 +626,7 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
             entries1.add(entry);
         }
 
-        val update1 = s.serializeUpdate(entries1);
+        val update1 = s.serializeUpdateWithExplicitVersion(entries1);
         Assert.assertEquals(offset.get(), update1.getLength());
         context.segment.append(update1, null, TIMEOUT).join();
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -877,8 +877,11 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         val context = new TestContext(maxUnindexedSize);
 
         // Begin with a non-empty Table Segment that also has a backlog of unindexed entries. This should simulate a
-        // recovery and verify that the throttling does account for this scenario.
+        // recovery and verify that the throttling does account for this scenario. Note that the tail-caching starts
+        // scanning the segment (i.e., consuming credits) from the max from start offset or compaction offset to prevent
+        // missing tail-caching last values for keys. This requires us to also update the compaction offset to initialIndexOffset.
         context.segment.updateAttributes(Collections.singletonMap(TableAttributes.INDEX_OFFSET, (long) initialIndexOffset));
+        context.segment.updateAttributes(Collections.singletonMap(TableAttributes.COMPACTION_OFFSET, (long) initialIndexOffset));
         context.segment.append(new ByteArraySegment(new byte[initialIndexOffset]), null, TIMEOUT).join();
         val initialEntry = randomEntry(keySize, keySize, context);
         val initialEntryLength = s.getUpdateLength(initialEntry);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -571,6 +571,91 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
                 ex -> ex instanceof ObjectClosedException);
     }
 
+    /**
+     * Tests a situation in which we have written various values for 2 keys, and the most recent ones are the last
+     * writes among them. Then, the IndexWriter processes all of them and immediately after, Table Compactor processes a
+     * subset of these entries, and it writes one compacted (and stale) value to the tail of the Segment. At this point,
+     * there is a Table Segment recovery for which there is only one un-indexed entry: the last compacted one. The test
+     * verifies that we are not tail caching the last compacted entry, because it is stale already and could lead to
+     * serving stale data on gets during a window of time (until IndexWriter processes that compacted entry and evicts
+     * it from the tail cache).
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRecoveryWithOneNonIndexedUncompactedEntry() throws Exception {
+        val s = new EntrySerializer();
+        @Cleanup
+        val context = new TestContext(TableExtensionConfig.builder()
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_LENGTH, (long) TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH)
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE, Integer.MAX_VALUE)
+                .with(TableExtensionConfig.RECOVERY_TIMEOUT, (int) ContainerKeyIndexTests.SHORT_TIMEOUT_MILLIS)
+                .build());
+
+        // Setup the segment with initial attributes.
+        val iw = new IndexWriter(HASHER, executorService());
+
+        // 1. Add several values for key1 and key2 that can be easily picked by the Table Compactor. Note that the
+        // expected last value in this scenario for key1 is 4.
+        val entries = Arrays.asList(
+                TableEntry.unversioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("1".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("2".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("3".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key2".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("1".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key2".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("2".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("4".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key2".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("4".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key2".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("5".getBytes(StandardCharsets.UTF_8))));
+
+        val offset = new AtomicLong();
+        val hashes = new ArrayList<UUID>();
+        val keysWithOffsets = new HashMap<UUID, KeyWithOffset>();
+        for (val e : entries) {
+            val hash = HASHER.hash(e.getKey().getKey());
+            hashes.add(hash);
+            keysWithOffsets.put(hash, new KeyWithOffset(e.getKey().getKey(), offset.getAndAdd(s.getUpdateLength(e))));
+        }
+
+        // Write all the previous entries to the Segment.
+        val update1 = s.serializeUpdate(entries);
+        Assert.assertEquals(offset.get(), update1.getLength());
+        context.segment.append(update1, null, TIMEOUT).join();
+
+        // 2. Initiate a recovery and verify pre-caching is triggered and requests are auto-unblocked.
+        val get1 = context.index.getBucketOffsets(context.segment, hashes, context.timer);
+        val result1 = get1.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        val expected1 = new HashMap<UUID, Long>();
+        keysWithOffsets.forEach((k, o) -> expected1.put(k, o.offset));
+        AssertExtensions.assertMapEquals("Unexpected result from getBucketOffsets() after auto pre-caching.", expected1, result1);
+
+        // 3. Set LastIdx to Length.
+        val buckets = iw.locateBuckets(context.segment, keysWithOffsets.keySet(), context.timer).join();
+        Collection<BucketUpdate> bucketUpdates = buckets.entrySet().stream()
+                .map(e -> {
+                    val builder = BucketUpdate.forBucket(e.getValue());
+                    val ko = keysWithOffsets.get(e.getKey());
+                    builder.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, ko.offset, false));
+                    return builder.build();
+                })
+                .collect(Collectors.toList());
+        iw.updateBuckets(context.segment, bucketUpdates, 0L, offset.get(), keysWithOffsets.size(), TIMEOUT).join();
+
+        // 4. After indexing, let's write the compacted entry (key1, 3).
+        val compactedEntry = List.of(TableEntry.versioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)),
+                new ByteArraySegment("3".getBytes(StandardCharsets.UTF_8)), s.getUpdateLength(entries.get(0)) * 3L));
+        val update2 = s.serializeUpdateWithExplicitVersion(compactedEntry);
+        context.segment.append(update2, null, TIMEOUT).join();
+
+        // 5. Verify that when performing a get on key1, the tail-caching is not caching [key1, v3] (last offset), as it
+        // has scanned a previous value in which key1 is 4 (6th element in entries list) and has been indexed already.
+        // This already stale compacted entry should not be cached and will be removed by the index when it gets processed.
+        context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), -1, 0); // Force-evict it so we start clean.
+        val key1hash = List.of(HASHER.hash(entries.get(0).getKey().getKey()));
+        val getBucketOffsets = context.index.getBucketOffsets(context.segment, key1hash, context.timer).join();
+        Assert.assertArrayEquals(key1hash.toArray(), getBucketOffsets.keySet().toArray()); // Ensure that we get key1 as key.
+        Assert.assertEquals(Long.valueOf(5L * 22L), getBucketOffsets.get(key1hash.get(0))); // (key1, 4) is the 6th element in entries.
+    }
+
     @Test
     public void testRecoveryOneBatchWithVersion() throws Exception {
         testRecoveryWithVersions(TableExtensionConfig.builder()
@@ -636,7 +721,6 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
                 Collections.singleton(hash),
                 context.timer).get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         AssertExtensions.assertMapEquals("Unexpected result from getBucketOffsets() after auto pre-caching.", expected, results);
-
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/EntrySerializerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/EntrySerializerTests.java
@@ -15,6 +15,8 @@
  */
 package io.pravega.segmentstore.server.tables;
 
+import com.google.common.annotations.VisibleForTesting;
+import io.pravega.common.util.BufferView;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.contracts.tables.TableKey;
@@ -99,6 +101,18 @@ public class EntrySerializerTests {
         }
 
         Assert.assertEquals("Did not read the entire serialization.", serialization.length, offset);
+    }
+
+    /**
+     * Utility method for tests that need to append serialized TableEntries outside the tables package.
+     *
+     * @param entries Table Entries to serialize.
+     * @return Serialized Table Entries.
+     */
+    @VisibleForTesting
+    public static BufferView generateUpdateWithExplicitVersion(List<TableEntry> entries) {
+        val s = new EntrySerializer();
+        return s.serializeUpdateWithExplicitVersion(entries);
     }
 
     private List<TableKey> generateKeys() {


### PR DESCRIPTION
**Change log description**  
Ensures that `TableEntry` versions are considered when populating the tail-cache of a hash-based Table Segment during recovery. When triggering tail-caching, starts scanning Table Entries from the highest value between start segment offset and last compaction offset to make sure that we are not missing last value of any key (still, the tail-cache is only populated with elements beyond `lastIndexedOffset` as before).

**Purpose of the change**  
Fixes https://github.com/pravega/pravega/issues/6539.

**What the code does**  
When a hash-based Table Segment is used for the first time, it checks whether there is data stored in tier 1 but not yet indexed (which depends on the progress of moving data to LTS). If there is a delta, the Table Segment starts a blocking process to any caller in which the data that is not yet in LTS is pre-indexed. Pre-indexing basically means storing the not yet indexed keys/values on a separate in-heap cache (i.e., a `HashMap`) with the values that will eventually be indexed, in order to be able to reply to `get()` requests with updated data.

However, the tail-caching process blindly puts entries to the tail cache assuming that whatever is at a higher Segment offset is a newer version of the data. This is true in general, but there is an important exception: Table Segment compaction. When Table Segment compaction comes into play, it may be the case that some older values for a key are placed after a newer value for that key in the Segment. If, at that point, a tail-cache recovery is performed, the older values (with a higher offset) will override the newer ones (with a lower offset). This may lead to serve stale data until `WriteTableProcessor` and `IndexWriter` make progress and remove indexed keys from the tail cache (`WriteTableProcessor` and `IndexWriter` do consider `TableEntry` versions).

To prevent this time-window  in which Table Segments can serve stale data, this PR proposes the following changes:
- Use a map in `triggerCacheTailIndex()` that is going to be passed over the multiple iterations of `preIndexBatch()` during the potential multiple iterations that involve tail-caching. That map is intended to store they keys and versions being tail cached.
- In `collectLatestOffsetsWithHighestVersion()` use this map to only add entries to a `TailUpdate` object if they are seen for first time, or if the entry exist but has a higher version.
- Make sure to set the right `maxOffset` to `TailUpdates` object, which should be the max offset of all processed entries (irrespective of whether they have been added to the tail cache or not).
- Start tail-caching from an offset prior to the `lastSegmentOffset` (max between start offset and last compaction offset). However, we only use Table Entries beyond `lastIndexedOffset` to populate tail-cache, as before. This can prevent adding to the tail-cache a compacted (stale) value for a key, assuming is the only Table Entry for that key after `lastIndexedOffset`. Note that this is trading-off correctness by additional cost of processing data during tail-caching.

**How to verify it**  
New tests created for issue 1 (if tail caching finds 2 unindexed entries `k1,v4` , `k1, v2 (compacted)`, the last one prevails without taking into account versions):
- `StreamSegmentContainerTests.testTableSegmentReadAfterCompactionAndRecovery()` that simulates the first issue from the `StreamSegmentContainer` perspective.
-  `ContainerKeyIndexTests.testRecoveryOneBatchWithVersion()`,  `ContainerKeyIndexTests.testRecoveryOneBatchAfterCompactionWithVersion()`,  `ContainerKeyIndexTests.testRecoveryOneBatchAfterCompactionWithVersion2()` (by @sachin-j-joshi) to validate the fix from `ContainerKeyIndex` perspective.

New test added for issue 2 (if tail caching finds1 unindexed entry `k1, v2 (compacted)` for a key, it will tail cache it even though there is a newer version in the index):
- `ContainerKeyIndexTests.testRecoveryWithOneNonIndexedUncompactedEntry()` simulates the problem at the `ContainerKeyIndex` level and validates the fix.

System tests passed (`test-pravega-continuous/4307`, `test-pravega-continuous-1/1903`, `test-pravega-continuous/4316/`, `test-pravega-continuous-1/1912/`).
