### PR TITLE
Issue 4097: Serialization Framework for Synchronizer Config

### DIFF
--- a/client/src/main/java/io/pravega/client/state/SynchronizerConfig.java
+++ b/client/src/main/java/io/pravega/client/state/SynchronizerConfig.java
@@ -25,7 +25,6 @@ import io.pravega.common.io.serialization.VersionedSerializer;
 import io.pravega.common.util.ByteArraySegment;
 import lombok.Builder;
 import lombok.Data;
-import java.nio.charset.Charset;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import lombok.SneakyThrows;
@@ -75,16 +74,13 @@ public class SynchronizerConfig implements Serializable {
         }
 
         private void read00(RevisionDataInput revisionDataInput, SynchronizerConfigBuilder builder) throws IOException {
-            byte[] b = new byte[0];
             builder.readBufferSize(revisionDataInput.readInt());
-            revisionDataInput.readFully(b);
-            builder.eventWriterConfig(builder.eventWriterConfig.fromBytes(ByteBuffer.wrap(b)));
+            builder.eventWriterConfig.fromBytes(ByteBuffer.wrap(revisionDataInput.readArray()));
         }
 
         private void write00(SynchronizerConfig object, RevisionDataOutput revisionDataOutput) throws IOException {
-            Charset cs = Charset.forName("UTF-8");
             revisionDataOutput.writeInt(object.getReadBufferSize());
-            revisionDataOutput.writeBytes(cs.decode(object.eventWriterConfig.toBytes()).toString());
+            revisionDataOutput.writeArray(object.eventWriterConfig.toBytes().array());
         }
     }
 

--- a/client/src/main/java/io/pravega/client/state/SynchronizerConfig.java
+++ b/client/src/main/java/io/pravega/client/state/SynchronizerConfig.java
@@ -75,7 +75,7 @@ public class SynchronizerConfig implements Serializable {
 
         private void read00(RevisionDataInput revisionDataInput, SynchronizerConfigBuilder builder) throws IOException {
             builder.readBufferSize(revisionDataInput.readInt());
-            builder.eventWriterConfig.fromBytes(ByteBuffer.wrap(revisionDataInput.readArray()));
+            builder.eventWriterConfig(builder.eventWriterConfig.fromBytes(ByteBuffer.wrap(revisionDataInput.readArray())));
         }
 
         private void write00(SynchronizerConfig object, RevisionDataOutput revisionDataOutput) throws IOException {

--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -145,7 +145,7 @@ public class EventWriterConfig implements Serializable {
         }
     }
 
-    private static class EventWriterConfigSerializer
+    static class EventWriterConfigSerializer
             extends VersionedSerializer.WithBuilder<EventWriterConfig, EventWriterConfigBuilder> {
         @Override
         protected EventWriterConfigBuilder newBuilder() {

--- a/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
+++ b/client/src/main/java/io/pravega/client/stream/EventWriterConfig.java
@@ -17,6 +17,7 @@ package io.pravega.client.stream;
 
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
+
 import io.pravega.common.io.serialization.RevisionDataInput;
 import io.pravega.common.io.serialization.RevisionDataOutput;
 import io.pravega.common.io.serialization.VersionedSerializer;
@@ -193,5 +194,20 @@ public class EventWriterConfig implements Serializable {
     @SneakyThrows(IOException.class)
     public static EventWriterConfig fromBytes(ByteBuffer buff) {
         return SERIALIZER.deserialize(new ByteArraySegment(buff));
+    }
+
+    @SneakyThrows(IOException.class)
+    private Object writeReplace() {
+        return new EventWriterConfig.SerializedForm(SERIALIZER.serialize(this).getCopy());
+    }
+
+    @Data
+    private static class SerializedForm implements Serializable {
+        private static final long serialVersionUID = 2L;
+        private final byte[] value;
+        @SneakyThrows(IOException.class)
+        Object readResolve() {
+            return SERIALIZER.deserialize(new ByteArraySegment(value));
+        }
     }
 }

--- a/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
+++ b/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
@@ -43,16 +43,16 @@ public class SynchronizerConfigTest {
 
         SynchronizerConfig.SynchronizerConfigSerializer serializer = new SynchronizerConfig.SynchronizerConfigSerializer();
         ByteArraySegment buff = serializer.serialize(synchConfig);
-        SynchronizerConfig s = serializer.deserialize(buff);
+        SynchronizerConfig result = serializer.deserialize(buff);
 
-        assertEquals(true, synchConfig.getEventWriterConfig().isAutomaticallyNoteTime());
-        assertEquals(2, synchConfig.getEventWriterConfig().getBackoffMultiple());
-        assertEquals(false, synchConfig.getEventWriterConfig().isEnableConnectionPooling());
-        assertEquals(100, synchConfig.getEventWriterConfig().getInitialBackoffMillis());
-        assertEquals(1000, synchConfig.getEventWriterConfig().getMaxBackoffMillis());
-        assertEquals(3, synchConfig.getEventWriterConfig().getRetryAttempts());
-        assertEquals(100000, synchConfig.getEventWriterConfig().getTransactionTimeoutTime());
-        assertEquals(1024, s.getReadBufferSize());
+        assertEquals(true, result.getEventWriterConfig().isAutomaticallyNoteTime());
+        assertEquals(2, result.getEventWriterConfig().getBackoffMultiple());
+        assertEquals(false, result.getEventWriterConfig().isEnableConnectionPooling());
+        assertEquals(100, result.getEventWriterConfig().getInitialBackoffMillis());
+        assertEquals(1000, result.getEventWriterConfig().getMaxBackoffMillis());
+        assertEquals(3, result.getEventWriterConfig().getRetryAttempts());
+        assertEquals(100000, result.getEventWriterConfig().getTransactionTimeoutTime());
+        assertEquals(1024, result.getReadBufferSize());
 
     }
 

--- a/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
+++ b/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import io.pravega.client.stream.EventWriterConfig;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 public class SynchronizerConfigTest {
 
@@ -43,16 +44,28 @@ public class SynchronizerConfigTest {
 
         SynchronizerConfig.SynchronizerConfigSerializer serializer = new SynchronizerConfig.SynchronizerConfigSerializer();
         ByteArraySegment buff = serializer.serialize(synchConfig);
-        SynchronizerConfig result = serializer.deserialize(buff);
+        SynchronizerConfig result1 = serializer.deserialize(buff);
 
-        assertEquals(true, result.getEventWriterConfig().isAutomaticallyNoteTime());
-        assertEquals(2, result.getEventWriterConfig().getBackoffMultiple());
-        assertEquals(false, result.getEventWriterConfig().isEnableConnectionPooling());
-        assertEquals(100, result.getEventWriterConfig().getInitialBackoffMillis());
-        assertEquals(1000, result.getEventWriterConfig().getMaxBackoffMillis());
-        assertEquals(3, result.getEventWriterConfig().getRetryAttempts());
-        assertEquals(100000, result.getEventWriterConfig().getTransactionTimeoutTime());
-        assertEquals(1024, result.getReadBufferSize());
+        ByteBuffer buffer = synchConfig.toBytes();
+        SynchronizerConfig result2 = SynchronizerConfig.fromBytes(buffer);
+
+        assertEquals(true, result1.getEventWriterConfig().isAutomaticallyNoteTime());
+        assertEquals(2, result1.getEventWriterConfig().getBackoffMultiple());
+        assertEquals(false, result1.getEventWriterConfig().isEnableConnectionPooling());
+        assertEquals(100, result1.getEventWriterConfig().getInitialBackoffMillis());
+        assertEquals(1000, result1.getEventWriterConfig().getMaxBackoffMillis());
+        assertEquals(3, result1.getEventWriterConfig().getRetryAttempts());
+        assertEquals(100000, result1.getEventWriterConfig().getTransactionTimeoutTime());
+        assertEquals(1024, result1.getReadBufferSize());
+
+        assertEquals(true, result2.getEventWriterConfig().isAutomaticallyNoteTime());
+        assertEquals(2, result2.getEventWriterConfig().getBackoffMultiple());
+        assertEquals(false, result2.getEventWriterConfig().isEnableConnectionPooling());
+        assertEquals(100, result2.getEventWriterConfig().getInitialBackoffMillis());
+        assertEquals(1000, result2.getEventWriterConfig().getMaxBackoffMillis());
+        assertEquals(3, result2.getEventWriterConfig().getRetryAttempts());
+        assertEquals(100000, result2.getEventWriterConfig().getTransactionTimeoutTime());
+        assertEquals(1024, result2.getReadBufferSize());
 
     }
 

--- a/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
+++ b/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
@@ -35,7 +35,7 @@ public class SynchronizerConfigTest {
                 .transactionTimeoutTime(100000)
                 .build();
         SynchronizerConfig synchConfig = SynchronizerConfig.builder()
-                .eventWriterConfig(econfig)
+                .eventWriterConfig(eventConfig)
                 .build();
 
         assertEquals(true, synchConfig.eventWriterConfig.isAutomaticallyNoteTime());

--- a/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
+++ b/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.client.state;
+
+import org.junit.Test;
+
+import static io.pravega.test.common.AssertExtensions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import io.pravega.client.stream.EventWriterConfig;
+
+public class SynchronizerConfigTest {
+
+    @Test
+    public void testValidValues() {
+        EventWriterConfig eventConfig = EventWriterConfig.builder()
+                .automaticallyNoteTime(true)
+                .backoffMultiple(2)
+                .enableConnectionPooling(false)
+                .initialBackoffMillis(100)
+                .maxBackoffMillis(1000)
+                .retryAttempts(3)
+                .transactionTimeoutTime(100000)
+                .build();
+        SynchronizerConfig synchConfig = SynchronizerConfig.builder()
+                .eventWriterConfig(econfig)
+                .build();
+
+        assertEquals(true, synchConfig.eventWriterConfig.isAutomaticallyNoteTime());
+        assertEquals(2, synchConfig.eventWriterConfig.getBackoffMultiple());
+        assertEquals(false, synchConfig.eventWriterConfig.isEnableConnectionPooling());
+        assertEquals(100, synchConfig.eventWriterConfig.getInitialBackoffMillis());
+        assertEquals(1000, synchConfig.eventWriterConfig.getMaxBackoffMillis());
+        assertEquals(3, synchConfig.eventWriterConfig.getRetryAttempts());
+        assertEquals(100000, synchConfig.eventWriterConfig.getTransactionTimeoutTime());
+    }
+
+}

--- a/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
+++ b/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
@@ -15,15 +15,18 @@
  */
 package io.pravega.client.state;
 
+import io.pravega.common.util.ByteArraySegment;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import io.pravega.client.stream.EventWriterConfig;
 
+import java.io.IOException;
+
 public class SynchronizerConfigTest {
 
     @Test
-    public void testValidValues() {
+    public void testValidValues() throws IOException {
         EventWriterConfig eventConfig = EventWriterConfig.builder()
                 .automaticallyNoteTime(true)
                 .backoffMultiple(2)
@@ -34,16 +37,23 @@ public class SynchronizerConfigTest {
                 .transactionTimeoutTime(100000)
                 .build();
         SynchronizerConfig synchConfig = SynchronizerConfig.builder()
+                .readBufferSize(1024)
                 .eventWriterConfig(eventConfig)
                 .build();
 
-        assertEquals(true, synchConfig.eventWriterConfig.isAutomaticallyNoteTime());
-        assertEquals(2, synchConfig.eventWriterConfig.getBackoffMultiple());
-        assertEquals(false, synchConfig.eventWriterConfig.isEnableConnectionPooling());
-        assertEquals(100, synchConfig.eventWriterConfig.getInitialBackoffMillis());
-        assertEquals(1000, synchConfig.eventWriterConfig.getMaxBackoffMillis());
-        assertEquals(3, synchConfig.eventWriterConfig.getRetryAttempts());
-        assertEquals(100000, synchConfig.eventWriterConfig.getTransactionTimeoutTime());
+        SynchronizerConfig.SynchronizerConfigSerializer serializer = new SynchronizerConfig.SynchronizerConfigSerializer();
+        ByteArraySegment buff = serializer.serialize(synchConfig);
+        SynchronizerConfig s = serializer.deserialize(buff);
+
+        assertEquals(true, synchConfig.getEventWriterConfig().isAutomaticallyNoteTime());
+        assertEquals(2, synchConfig.getEventWriterConfig().getBackoffMultiple());
+        assertEquals(false, synchConfig.getEventWriterConfig().isEnableConnectionPooling());
+        assertEquals(100, synchConfig.getEventWriterConfig().getInitialBackoffMillis());
+        assertEquals(1000, synchConfig.getEventWriterConfig().getMaxBackoffMillis());
+        assertEquals(3, synchConfig.getEventWriterConfig().getRetryAttempts());
+        assertEquals(100000, synchConfig.getEventWriterConfig().getTransactionTimeoutTime());
+        assertEquals(1024, s.getReadBufferSize());
+
     }
 
 }

--- a/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
+++ b/client/src/test/java/io/pravega/client/state/SynchronizerConfigTest.java
@@ -17,7 +17,6 @@ package io.pravega.client.state;
 
 import org.junit.Test;
 
-import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;
 import io.pravega.client.stream.EventWriterConfig;
 

--- a/client/src/test/java/io/pravega/client/stream/EventWriterConfigTest.java
+++ b/client/src/test/java/io/pravega/client/stream/EventWriterConfigTest.java
@@ -15,7 +15,6 @@
  */
 package io.pravega.client.stream;
 
-import io.pravega.client.state.SynchronizerConfig;
 import io.pravega.common.util.ByteArraySegment;
 import org.junit.Test;
 

--- a/client/src/test/java/io/pravega/client/stream/EventWriterConfigTest.java
+++ b/client/src/test/java/io/pravega/client/stream/EventWriterConfigTest.java
@@ -15,10 +15,12 @@
  */
 package io.pravega.client.stream;
 
+import io.pravega.client.state.SynchronizerConfig;
 import io.pravega.common.util.ByteArraySegment;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;
@@ -40,15 +42,26 @@ public class EventWriterConfigTest {
 
         EventWriterConfig.EventWriterConfigSerializer serializer = new EventWriterConfig.EventWriterConfigSerializer();
         ByteArraySegment buff = serializer.serialize(config);
-        EventWriterConfig result = serializer.deserialize(buff);
+        EventWriterConfig result1 = serializer.deserialize(buff);
 
-        assertEquals(true, result.isAutomaticallyNoteTime());
-        assertEquals(2, result.getBackoffMultiple());
-        assertEquals(false, result.isEnableConnectionPooling());
-        assertEquals(100, result.getInitialBackoffMillis());
-        assertEquals(1000, result.getMaxBackoffMillis());
-        assertEquals(3, result.getRetryAttempts());
-        assertEquals(100000, result.getTransactionTimeoutTime());
+        ByteBuffer buffer = config.toBytes();
+        EventWriterConfig result2 = EventWriterConfig.fromBytes(buffer);
+
+        assertEquals(true, result1.isAutomaticallyNoteTime());
+        assertEquals(2, result1.getBackoffMultiple());
+        assertEquals(false, result1.isEnableConnectionPooling());
+        assertEquals(100, result1.getInitialBackoffMillis());
+        assertEquals(1000, result1.getMaxBackoffMillis());
+        assertEquals(3, result1.getRetryAttempts());
+        assertEquals(100000, result1.getTransactionTimeoutTime());
+
+        assertEquals(true, result2.isAutomaticallyNoteTime());
+        assertEquals(2, result2.getBackoffMultiple());
+        assertEquals(false, result2.isEnableConnectionPooling());
+        assertEquals(100, result2.getInitialBackoffMillis());
+        assertEquals(1000, result2.getMaxBackoffMillis());
+        assertEquals(3, result2.getRetryAttempts());
+        assertEquals(100000, result2.getTransactionTimeoutTime());
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/EventWriterConfigTest.java
+++ b/client/src/test/java/io/pravega/client/stream/EventWriterConfigTest.java
@@ -15,7 +15,10 @@
  */
 package io.pravega.client.stream;
 
+import io.pravega.common.util.ByteArraySegment;
 import org.junit.Test;
+
+import java.io.IOException;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;
@@ -24,7 +27,7 @@ public class EventWriterConfigTest {
 
 
     @Test
-    public void testValidValues() {
+    public void testValidValues() throws IOException {
         EventWriterConfig config = EventWriterConfig.builder()
                 .automaticallyNoteTime(true)
                 .backoffMultiple(2)
@@ -34,13 +37,18 @@ public class EventWriterConfigTest {
                 .retryAttempts(3)
                 .transactionTimeoutTime(100000)
                 .build();
-        assertEquals(true, config.isAutomaticallyNoteTime());
-        assertEquals(2, config.getBackoffMultiple());
-        assertEquals(false, config.isEnableConnectionPooling());
-        assertEquals(100, config.getInitialBackoffMillis());
-        assertEquals(1000, config.getMaxBackoffMillis());
-        assertEquals(3, config.getRetryAttempts());
-        assertEquals(100000, config.getTransactionTimeoutTime());
+
+        EventWriterConfig.EventWriterConfigSerializer serializer = new EventWriterConfig.EventWriterConfigSerializer();
+        ByteArraySegment buff = serializer.serialize(config);
+        EventWriterConfig result = serializer.deserialize(buff);
+
+        assertEquals(true, result.isAutomaticallyNoteTime());
+        assertEquals(2, result.getBackoffMultiple());
+        assertEquals(false, result.isEnableConnectionPooling());
+        assertEquals(100, result.getInitialBackoffMillis());
+        assertEquals(1000, result.getMaxBackoffMillis());
+        assertEquals(3, result.getRetryAttempts());
+        assertEquals(100000, result.getTransactionTimeoutTime());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@emc.com>

**Change log description**  
Creating a custom Serializer instead of relying on Java Serializion for the SynchronizerConfig and the EventWriterConfig.

**Purpose of the change**  
Fixes #4097 

**What the code does**  
Adds a SynchronizerConfigSerializer and an EventWriterConfigSerializer for serializing the SynchronizerConfig and the EventWriterConfig objects respectively.

**How to verify it**  
All tests should pass