### PR TITLE
Issue 6498:Hardcoded port 8000 in standalone mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -971,6 +971,7 @@ project('standalone') {
         runtime.exclude group: "com.sun.jersey", module: "jersey-server"
     }
 
+
     task startStandalone(type: JavaExec) {
         main = "io.pravega.local.LocalPravegaEmulator"
         classpath = sourceSets.main.runtimeClasspath


### PR DESCRIPTION
Signed-off-by: Shwetha N <shwetha.n1@dell.com>

**Change log description**  
In Standalone mode JDWP(Java Debug port) is disabled by default and can be enabled by setting through environment variable. 

**Purpose of the change**  
Fixing #6498 

**What the code does**  
JDWP(Java debug port) is used only if user wants to debug the code . In Pravega this port is enabled by default and post this PR it will be disabled by default.
If user wants to troubleshoot running java application remotely then enable JDWP port  before starting Pravega in standalone mode(either it can be from  Source code or from installation package), user should set the environment variable using below command.
export JVM_DEBUG_ARGS="-Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n" 
In above command **address=8000** , 8000 can be changed to any other value, ex: 8020

**How to verify it**  

1. Start Pravega standalone from installation package
       A. Start Pravega without JDWP port enabled : $ pravega-<version>/bin/pravega-standalone
       B. Start Pravega with JDWP port enabled: 
          $ export JVM_DEBUG_ARGS="-Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n" 
          $ pravega-<version>/bin/pravega-standalone

2. Start Pravega standalone from Source code
       A.  Start Pravega without JDWP port enabled : $ ./gradlew startStandalone
       B. Start Pravega with JDWP port enabled: 
           $ export JVM_DEBUG_ARGS="-Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n" 
           $ ./gradlew startStandalone
3. To reset debug arguments
       $ export JVM_DEBUG_ARGS=
4. All tests should pass
 
