### PR TITLE
Issue 6537: Fix flakey test: ClusterCommandsTest.

### DIFF
--- a/cli/admin/src/test/java/io/pravega/cli/admin/AbstractAdminCommandTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/AbstractAdminCommandTest.java
@@ -44,6 +44,7 @@ public abstract class AbstractAdminCommandTest {
         pravegaProperties.setProperty("pravegaservice.zk.connect.uri", SETUP_UTILS.getZkTestServer().getConnectString());
         pravegaProperties.setProperty("pravegaservice.container.count", "4");
         pravegaProperties.setProperty("pravegaservice.admin.gateway.port", String.valueOf(SETUP_UTILS.getAdminPort()));
+        pravegaProperties.setProperty("pravegaservice.clusterName", "pravega-cluster");
         STATE.get().getConfigBuilder().include(pravegaProperties);
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ jjwtVersion=0.9.1
 bouncyCastleVersion=1.69
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.12.0-SHAPSHOT
+pravegaVersion=0.12.0-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ jjwtVersion=0.9.1
 bouncyCastleVersion=1.69
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.11.0-SNAPSHOT
+pravegaVersion=0.12.0-SHAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
Signed-off-by: Bhupender-Y <Bhupender.Y@dell.com>

**Change log description**  
ClusterCommandTest getting failed because of mismatching of clusterName. To resolve it,  Update clusterName in config file before running admin cli testcases.

**Purpose of the change**  
Fixes: #6537 

**What the code does**  
Update clusterName in config file before running admin cli testcases.

**How to verify it**  
Run admin cli testcases.
