### PR TITLE
Issue 6557: Cherry-pick 6538 to r0.10

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/ContainerKeyIndex.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -605,8 +606,13 @@ class ContainerKeyIndex implements AutoCloseable {
     }
 
     /**
-     * Reads the tail section (beyond {@link TableAttributes#INDEX_OFFSET}) of the given segment and caches the latest
-     * values recorded there in the tail index.
+     * Reads the tail section of the given segment (from either start offset or {@link TableAttributes#COMPACTION_OFFSET},
+     * whatever is highest) and only caches the latest values beyond last indexed offset (i.e., {@link TableAttributes#INDEX_OFFSET})
+     * in the tail index. Note that the reason for starting the scan before last index offset is to cover a case in which
+     * there could be just a compacted entry for k1 beyond last index offset, while a newer value for it has been already
+     * indexed. If at this point a recovery is executed and the tail-caching accepts the compacted entry, there is a window
+     * of time (until the {@link IndexWriter} processes that compacted entry and evicts it from tail-cache) until when it
+     * could be serving a stale (compacted) version of k1 (see https://github.com/pravega/pravega/issues/6539).
      *
      * The operation will not execute if any of the following is true:
      * - The tail section has a length of 0.
@@ -615,14 +621,17 @@ class ContainerKeyIndex implements AutoCloseable {
      * This method triggers this operation asynchronously and does not wait for it to complete. Its completion status and
      * any errors will be logged.
      *
-     * NOTE: this does not peform a proper recovery nor does it update the durable index - it simply caches the values.
+     * NOTE: this does not perform a proper recovery nor does it update the durable index - it simply caches the values.
      * The {@link WriterTableProcessor} must be used to update the index.
      *
      * @param segment A {@link DirectSegmentAccess} representing the Segment for which to cache the tail index.
+     * @param tailCachingStartOffset Offset from where the tail-caching process will start scanning. Note that there
+     *                               can be a part of the segment (from either start or last compaction offset, whatever is
+     *                               max) that is just scanned, but no entries are added to tail cache.
      */
-    private void triggerCacheTailIndex(DirectSegmentAccess segment, long lastIndexedOffset, SegmentTracker.RecoveryTask task) {
-        long tailIndexLength = task.triggerIndexOffset - lastIndexedOffset;
-        if (lastIndexedOffset >= task.triggerIndexOffset) {
+    private void triggerCacheTailIndex(DirectSegmentAccess segment, long tailCachingStartOffset, SegmentTracker.RecoveryTask task) {
+        long tailIndexLength = task.triggerIndexOffset - tailCachingStartOffset;
+        if (tailCachingStartOffset >= task.triggerIndexOffset) {
             // Fully caught up. Nothing else to do.
             log.debug("{}: Table Segment {} fully indexed.", this.traceObjectId, segment.getSegmentId());
             return;
@@ -634,27 +643,41 @@ class ContainerKeyIndex implements AutoCloseable {
 
         // Read the tail section of the segment and process its updates. All of this should already be in the cache so
         // we are not going to do any Storage reads.
-        log.info("{}: Tail-caching started for Table Segment {}. LastIndexedOffset={}, SegmentLength={}.",
-                this.traceObjectId, segment.getSegmentId(), lastIndexedOffset, task.triggerIndexOffset);
-        val preIndexOffset = new AtomicLong(lastIndexedOffset);
+        final long lastIndexedOffset = IndexReader.getLastIndexedOffset(segment.getInfo());
+        log.info("{}: Tail-caching started for Table Segment {}. TailCachingStartOffset={}, LastIndexedOffset={}, SegmentLength={}.",
+                this.traceObjectId, segment.getSegmentId(), tailCachingStartOffset, lastIndexedOffset, task.triggerIndexOffset);
+        val preIndexOffset = new AtomicLong(tailCachingStartOffset);
 
         // Begin a loop which will end when either we've reached the target offset (defined in the RecoveryTask) or when
         // the recovery task itself has been cancelled (i.e., segment evicted, shutting down, etc.).
+        Map<UUID, Long> tailCachePreIndexVersionTracker = new ConcurrentHashMap<>();
         Futures.loop(
                 () -> !task.task.isDone() && preIndexOffset.get() < task.triggerIndexOffset,
                 () -> {
                     int maxLength = (int) Math.min(this.config.getMaxTailCachePreIndexBatchLength(), task.triggerIndexOffset - preIndexOffset.get());
-                    return preIndexBatch(segment, preIndexOffset.get(), maxLength)
+                    return preIndexBatch(segment, preIndexOffset.get(), maxLength, tailCachePreIndexVersionTracker, lastIndexedOffset)
                             .thenAccept(preIndexOffset::set);
                 },
                 this.executor)
                 .exceptionally(ex -> {
-                    log.warn("{}: Tail-caching failed for Table Segment {}; LastIndexedOffset={}, CurrentOffset={}, SegmentLength={}.", this.traceObjectId, segment.getSegmentId(), lastIndexedOffset, preIndexOffset, task.triggerIndexOffset, Exceptions.unwrap(ex));
+                    log.warn("{}: Tail-caching failed for Table Segment {}; TailCachingStartOffset={}, LastIndexedOffset={}, CurrentOffset={}, SegmentLength={}.",
+                            this.traceObjectId, segment.getSegmentId(), tailCachingStartOffset, lastIndexedOffset, preIndexOffset, task.triggerIndexOffset, Exceptions.unwrap(ex));
                     return null;
                 });
     }
 
-    private CompletableFuture<Long> preIndexBatch(DirectSegmentAccess segment, long startOffset, int maxLength) {
+    /**
+     * Includes a batch of entries in the tail cache of the Table Segment. It also takes into account selecting the entries
+     * with higher version for the same key (which may not be always the ones with the highest offsets due to Table Compaction).
+     *
+     * @param segment Table Segment to pre-index.
+     * @param startOffset Start offset to pre-index the Segment in this batch.
+     * @param maxLength Max amount of data processed in this batch.
+     * @param tailCachePreIndexVersionTracker Helps to track versions of entries to select the highest ones.
+     * @return Max offset of processed entries.
+     */
+    private CompletableFuture<Long> preIndexBatch(DirectSegmentAccess segment, long startOffset, int maxLength,
+                                                  Map<UUID, Long> tailCachePreIndexVersionTracker, long lastIndexedOffset) {
         log.trace("{}: Tail-caching batch started for Table Segment {}. StartOffset={}, MaxLength={}.",
                 this.traceObjectId, segment.getSegmentId(), startOffset, maxLength);
         val timer = new Timer();
@@ -664,7 +687,7 @@ class ContainerKeyIndex implements AutoCloseable {
                 .thenApplyAsync(inputData -> {
                     // Parse out all Table Keys and collect their latest offsets, as well as whether they were deleted.
                     val updates = new TailUpdates();
-                    collectLatestOffsets(inputData, startOffset, maxLength, updates);
+                    collectEntriesWithHighestVersion(inputData, startOffset, maxLength, updates, tailCachePreIndexVersionTracker, lastIndexedOffset);
 
                     // Incorporate that into the cache.
                     this.cache.includeTailCache(segment.getSegmentId(), updates.byBucket);
@@ -678,8 +701,20 @@ class ContainerKeyIndex implements AutoCloseable {
                 }, this.executor);
     }
 
+    /**
+     * Processes the entries from the input {@link BufferView} and collects the ones that have the highest version. Note
+     * that this selection of versions is done thanks to the tailCachePreIndexVersionTracker map that is used across the
+     * whole tail-caching process.
+     *
+     * @param input Input data to read Table Entries from.
+     * @param startOffset Start offset from which the input data refers to in the Segment.
+     * @param maxLength Max amount of data to process in this batch.
+     * @param result Table Entries processed with max version.
+     * @param tailCachePreIndexVersionTracker Helps to track versions of entries to select the highest ones.
+     */
     @SneakyThrows(IOException.class)
-    private void collectLatestOffsets(BufferView input, long startOffset, int maxLength, TailUpdates result) {
+    private void collectEntriesWithHighestVersion(BufferView input, long startOffset, int maxLength, TailUpdates result,
+                                                  Map<UUID, Long> tailCachePreIndexVersionTracker, long lastIndexedOffset) {
         EntrySerializer serializer = new EntrySerializer();
         long nextOffset = startOffset;
         final long maxOffset = startOffset + maxLength;
@@ -688,7 +723,19 @@ class ContainerKeyIndex implements AutoCloseable {
             while (nextOffset < maxOffset) {
                 val e = AsyncTableEntryReader.readEntryComponents(inputReader, nextOffset, serializer);
                 val hash = this.keyHasher.hash(e.getKey());
-                result.add(hash, nextOffset, e.getHeader().getTotalLength(), e.getHeader().isDeletion());
+                // Consider for the tail cache the new entries or the entries whose version is higher than the observed one.
+                if (!tailCachePreIndexVersionTracker.containsKey(hash) || tailCachePreIndexVersionTracker.get(hash) < e.getVersion()) {
+                    tailCachePreIndexVersionTracker.put(hash, e.getVersion());
+                    // Only add to tail cache the entries beyond the lastIndexedOffset (previous ones are index already).
+                    if (nextOffset >= lastIndexedOffset) {
+                        result.add(hash, nextOffset, e.getHeader().getTotalLength(), e.getHeader().isDeletion());
+                    }
+                } else {
+                    log.info("{}: Not tail-caching key {} as it has a lower version {} than the existing cached entry ({}).", this.traceObjectId,
+                            hash, e.getVersion(), tailCachePreIndexVersionTracker.get(hash));
+                }
+                // Irrespective of whether the entry is added to the tail updates, set the max processed offset.
+                result.setMaxOffset(nextOffset, e.getHeader().getTotalLength());
                 nextOffset += e.getHeader().getTotalLength();
             }
         } catch (BufferView.Reader.OutOfBoundsException ex) {
@@ -722,6 +769,10 @@ class ContainerKeyIndex implements AutoCloseable {
             CacheBucketOffset cbo = new CacheBucketOffset(offset, isDeletion);
             this.byBucket.put(keyHash, cbo);
             this.keyCount++;
+            setMaxOffset(offset, serializationLength);
+        }
+
+        void setMaxOffset(long offset, int serializationLength) {
             this.maxOffset = offset + serializationLength;
         }
     }
@@ -925,8 +976,14 @@ class ContainerKeyIndex implements AutoCloseable {
                 log.debug("{}: TableSegment {} is not fully recovered. Queuing 1 task.", traceObjectId, segment.getSegmentId());
                 if (firstTask) {
                     setupRecoveryTask(task);
-                    assert lastIndexedOffset >= 0;
-                    triggerCacheTailIndex(segment, lastIndexedOffset, task);
+                    // Starting at last indexed offset may leave behind the last value of an indexed key that is succeeded
+                    // by an (older) compacted entry of the same key. In that case, there is a risk that the tail cache
+                    // just contains the old version of the key to serve gets. Starting from the last compaction offset
+                    // (or start of the Segment, whatever is max) can remove this risk at the cost of processing more data.
+                    SegmentProperties sp = segment.getInfo();
+                    long lastSafeIndexedOffset = Math.max(sp.getStartOffset(), IndexReader.getCompactionOffset(sp));
+                    assert lastSafeIndexedOffset >= 0;
+                    triggerCacheTailIndex(segment, lastSafeIndexedOffset, task);
                 }
 
                 // A recovery task is registered. Queue behind it.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -88,7 +88,9 @@ import io.pravega.segmentstore.server.reading.ReadIndexConfig;
 import io.pravega.segmentstore.server.reading.TestReadResultHandler;
 import io.pravega.segmentstore.server.tables.ContainerTableExtension;
 import io.pravega.segmentstore.server.tables.ContainerTableExtensionImpl;
+import io.pravega.segmentstore.server.tables.EntrySerializerTests;
 import io.pravega.segmentstore.server.tables.TableExtensionConfig;
+import io.pravega.segmentstore.server.tables.WriterTableProcessor;
 import io.pravega.segmentstore.server.writer.StorageWriterFactory;
 import io.pravega.segmentstore.server.writer.WriterConfig;
 import io.pravega.segmentstore.storage.AsyncStorageWrapper;
@@ -113,7 +115,9 @@ import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -139,10 +143,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -2328,6 +2333,99 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
         container.stopAsync().awaitTerminated();
     }
 
+    /**
+     * Tests a non-trivial scenario in which ContainerKeyIndex may be tail-caching a stale version of a key if the
+     * following conditions occur:
+     * 1. StorageWriter processes values v0...vn for k1 and {@link WriterTableProcessor} indexes them.
+     * 2. As a result of {@link WriterTableProcessor} activity, the last value vn for k1 is moved to the tail of the Segment.
+     * 3. While TableCompactor works, a new PUT operation is appended to the Segment with new value vn+1 for k1.
+     * 4. At this point, the StorageWriter stops its progress and the container restarts without processing neither the
+     *    new value vn+1 nor the compacted value vn for k1.
+     * 5. A subsequent restart will trigger the tail-caching from the last indexed offset, which points to vn+1.
+     * 6. The bug, which consists of the tail-caching process not taking care of table entry versions, would overwrite
+     *    vn+1 with vn, just because it has a higher offset as it was written later in the Segment.
+     */
+    @Test
+    public void testTableSegmentReadAfterCompactionAndRecovery() throws Exception {
+        @Cleanup
+        TestContext context = new TestContext(DEFAULT_CONFIG, NO_TRUNCATIONS_DURABLE_LOG_CONFIG, DEFAULT_WRITER_CONFIG, null);
+        val durableLog = new AtomicReference<OperationLog>();
+        val durableLogFactory = new WatchableOperationLogFactory(context.operationLogFactory, durableLog::set);
+        // Data size and count to be written in this test.
+        int serializedEntryLength = 28;
+        int writtenEntries = 7;
+
+        @Cleanup
+        StreamSegmentContainer container = new StreamSegmentContainer(CONTAINER_ID, DEFAULT_CONFIG, durableLogFactory,
+                context.readIndexFactory, context.attributeIndexFactory, context.writerFactory, context.storageFactory,
+                context.getDefaultExtensions(), executorService());
+        container.startAsync().awaitRunning();
+        Assert.assertNotNull(durableLog.get());
+        val tableStore = container.getExtension(ContainerTableExtension.class);
+
+        // 1. Create the Table Segment and get a DirectSegmentAccess to it to monitor its size.
+        String tableSegmentName = getSegmentName(0) + "_Table";
+        val type = SegmentType.builder(getSegmentType(tableSegmentName)).tableSegment().build();
+        tableStore.createSegment(tableSegmentName, type, TIMEOUT).join();
+        DirectSegmentAccess directTableSegment = container.forSegment(tableSegmentName, TIMEOUT).join();
+
+        // 2. Add some entries to the table segments. Note tha we write multiple values to each key, so the TableCompactor
+        // can find entries to move to the tail.
+        final BiFunction<String, Integer, TableEntry> createTableEntry = (key, value) ->
+                TableEntry.unversioned(new ByteArraySegment(key.getBytes()),
+                        new ByteArraySegment(String.format("Value_%s", value).getBytes()));
+
+        // 3. This callback will run when the StorageWriter writes data to Storage. At this point, StorageWriter would
+        // have completed its first iteration, so it is the time to add a new value for key1 while TableCompactor is working.
+        val compactedEntry = List.of(TableEntry.versioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)),
+                new ByteArraySegment("3".getBytes(StandardCharsets.UTF_8)), serializedEntryLength * 2L));
+        // Simulate that Table Compactor moves [k1, 3] to the tail of the Segment as a result of compacting the first 4 entries.
+        val compactedEntryUpdate = EntrySerializerTests.generateUpdateWithExplicitVersion(compactedEntry);
+        CompletableFuture<Void> callbackExecuted = new CompletableFuture<>();
+        context.storageFactory.getPostWriteCallback().set((segmentHandle, offset) -> {
+            if (segmentHandle.getSegmentName().contains("Segment_0_Table$attributes.index") && !callbackExecuted.isDone()) {
+                // New PUT with the newest value.
+                Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 4)), TIMEOUT)).join();
+                // Simulates a compacted entry append performed by Table Compactor.
+                directTableSegment.append(compactedEntryUpdate, null, TIMEOUT).join();
+                callbackExecuted.complete(null);
+            }
+        });
+
+        // Do the actual puts.
+        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 1)), TIMEOUT)).join();
+        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 2)), TIMEOUT)).join();
+        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key1", 3)), TIMEOUT)).join();
+        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key2", 1)), TIMEOUT)).join();
+        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key2", 2)), TIMEOUT)).join();
+        Futures.toVoid(tableStore.put(tableSegmentName, Collections.singletonList(createTableEntry.apply("key2", 3)), TIMEOUT)).join();
+
+        // 4. Above, the test does 7 puts, each one 28 bytes in size (6 entries directly, 1 via callback). Now, we need
+        // to wait for the TableCompactor writing the entry (key1, 3) to the tail of the Segment.
+        callbackExecuted.join();
+        AssertExtensions.assertEventuallyEquals(true, () -> directTableSegment.getInfo().getLength() > (long) serializedEntryLength * writtenEntries, 5000);
+
+        // 5. The TableCompactor has moved the entry, so we immediately stop the container to prevent StorageWriter from
+        // making more progress.
+        container.close();
+
+        // 6. Create a new container instance that will recover from existing data.
+        @Cleanup
+        val container2 = new StreamSegmentContainer(CONTAINER_ID, DEFAULT_CONFIG, durableLogFactory,
+                context.readIndexFactory, context.attributeIndexFactory, context.writerFactory, context.storageFactory,
+                context.getDefaultExtensions(), executorService());
+        container2.startAsync().awaitRunning();
+
+        // 7. Verify that (key1, 4) is the actual value after performing the tail-caching process, which now takes care
+        // of entry versions.
+        val expected = createTableEntry.apply("key1", 4);
+        val tableStore2 = container2.getExtension(ContainerTableExtension.class);
+        val actual = tableStore2.get(tableSegmentName, Collections.singletonList(expected.getKey().getKey()), TIMEOUT)
+                .get(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
+                .get(0);
+        Assert.assertEquals(actual.getKey().getKey(), expected.getKey().getKey());
+        Assert.assertEquals(actual.getValue(), expected.getValue());
+    }
 
     /**
      * Test that the {@link ContainerEventProcessor} service is started as part of the {@link StreamSegmentContainer}
@@ -3193,6 +3291,10 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
 
     private static class WatchableInMemoryStorageFactory extends InMemoryStorageFactory {
         private final ConcurrentHashMap<String, Long> truncationOffsets = new ConcurrentHashMap<>();
+        // Allow tests to run a custom callback after write() method is invoked in Storage.
+        @Getter
+        private final AtomicReference<BiConsumer<SegmentHandle, Long>> postWriteCallback = new AtomicReference<>(null);
+
 
         public WatchableInMemoryStorageFactory(ScheduledExecutorService executor) {
             super(executor);
@@ -3206,6 +3308,15 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
         private class WatchableAsyncStorageWrapper extends AsyncStorageWrapper {
             public WatchableAsyncStorageWrapper(SyncStorage syncStorage, Executor executor) {
                 super(syncStorage, executor);
+            }
+
+            @Override
+            public CompletableFuture<Void> write(SegmentHandle handle, long offset, InputStream data, int length, Duration timeout) {
+                return (postWriteCallback.get() == null) ? super.write(handle, offset, data, length, timeout) :
+                   super.write(handle, offset, data, length, timeout).thenCompose(v -> {
+                        postWriteCallback.get().accept(handle, offset);
+                        return null;
+                    });
             }
 
             @Override

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/ContainerKeyIndexTests.java
@@ -38,6 +38,8 @@ import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.IntentionalException;
 import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.ThreadPooledTestSuite;
+
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -570,6 +572,158 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
     }
 
     /**
+     * Tests a situation in which we have written various values for 2 keys, and the most recent ones are the last
+     * writes among them. Then, the IndexWriter processes all of them and immediately after, Table Compactor processes a
+     * subset of these entries, and it writes one compacted (and stale) value to the tail of the Segment. At this point,
+     * there is a Table Segment recovery for which there is only one un-indexed entry: the last compacted one. The test
+     * verifies that we are not tail caching the last compacted entry, because it is stale already and could lead to
+     * serving stale data on gets during a window of time (until IndexWriter processes that compacted entry and evicts
+     * it from the tail cache).
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRecoveryWithOneNonIndexedUncompactedEntry() throws Exception {
+        val s = new EntrySerializer();
+        @Cleanup
+        val context = new TestContext(TableExtensionConfig.builder()
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_LENGTH, (long) TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH)
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE, Integer.MAX_VALUE)
+                .with(TableExtensionConfig.RECOVERY_TIMEOUT, (int) ContainerKeyIndexTests.SHORT_TIMEOUT_MILLIS)
+                .build());
+
+        // Setup the segment with initial attributes.
+        val iw = new IndexWriter(HASHER, executorService());
+
+        // 1. Add several values for key1 and key2 that can be easily picked by the Table Compactor. Note that the
+        // expected last value in this scenario for key1 is 4.
+        val entries = Arrays.asList(
+                TableEntry.unversioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("1".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("2".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("3".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key2".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("1".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key2".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("2".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("4".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key2".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("4".getBytes(StandardCharsets.UTF_8))),
+                TableEntry.unversioned(new ByteArraySegment("key2".getBytes(StandardCharsets.UTF_8)), new ByteArraySegment("5".getBytes(StandardCharsets.UTF_8))));
+
+        val offset = new AtomicLong();
+        val hashes = new ArrayList<UUID>();
+        val keysWithOffsets = new HashMap<UUID, KeyWithOffset>();
+        for (val e : entries) {
+            val hash = HASHER.hash(e.getKey().getKey());
+            hashes.add(hash);
+            keysWithOffsets.put(hash, new KeyWithOffset(e.getKey().getKey(), offset.getAndAdd(s.getUpdateLength(e))));
+        }
+
+        // Write all the previous entries to the Segment.
+        val update1 = s.serializeUpdate(entries);
+        Assert.assertEquals(offset.get(), update1.getLength());
+        context.segment.append(update1, null, TIMEOUT).join();
+
+        // 2. Initiate a recovery and verify pre-caching is triggered and requests are auto-unblocked.
+        val get1 = context.index.getBucketOffsets(context.segment, hashes, context.timer);
+        val result1 = get1.get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        val expected1 = new HashMap<UUID, Long>();
+        keysWithOffsets.forEach((k, o) -> expected1.put(k, o.offset));
+        AssertExtensions.assertMapEquals("Unexpected result from getBucketOffsets() after auto pre-caching.", expected1, result1);
+
+        // 3. Set LastIdx to Length.
+        val buckets = iw.locateBuckets(context.segment, keysWithOffsets.keySet(), context.timer).join();
+        Collection<BucketUpdate> bucketUpdates = buckets.entrySet().stream()
+                .map(e -> {
+                    val builder = BucketUpdate.forBucket(e.getValue());
+                    val ko = keysWithOffsets.get(e.getKey());
+                    builder.withKeyUpdate(new BucketUpdate.KeyUpdate(ko.key, ko.offset, ko.offset, false));
+                    return builder.build();
+                })
+                .collect(Collectors.toList());
+        iw.updateBuckets(context.segment, bucketUpdates, 0L, offset.get(), keysWithOffsets.size(), TIMEOUT).join();
+
+        // 4. After indexing, let's write the compacted entry (key1, 3).
+        val compactedEntry = List.of(TableEntry.versioned(new ByteArraySegment("key1".getBytes(StandardCharsets.UTF_8)),
+                new ByteArraySegment("3".getBytes(StandardCharsets.UTF_8)), s.getUpdateLength(entries.get(0)) * 3L));
+        val update2 = s.serializeUpdateWithExplicitVersion(compactedEntry);
+        context.segment.append(update2, null, TIMEOUT).join();
+
+        // 5. Verify that when performing a get on key1, the tail-caching is not caching [key1, v3] (last offset), as it
+        // has scanned a previous value in which key1 is 4 (6th element in entries list) and has been indexed already.
+        // This already stale compacted entry should not be cached and will be removed by the index when it gets processed.
+        context.index.notifyIndexOffsetChanged(context.segment.getSegmentId(), -1, 0); // Force-evict it so we start clean.
+        val key1hash = List.of(HASHER.hash(entries.get(0).getKey().getKey()));
+        val getBucketOffsets = context.index.getBucketOffsets(context.segment, key1hash, context.timer).join();
+        Assert.assertArrayEquals(key1hash.toArray(), getBucketOffsets.keySet().toArray()); // Ensure that we get key1 as key.
+        Assert.assertEquals(Long.valueOf(5L * 22L), getBucketOffsets.get(key1hash.get(0))); // (key1, 4) is the 6th element in entries.
+    }
+
+    @Test
+    public void testRecoveryOneBatchWithVersion() throws Exception {
+        testRecoveryWithVersions(TableExtensionConfig.builder()
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_LENGTH, (long) TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH)
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE, Integer.MAX_VALUE)
+                .with(TableExtensionConfig.RECOVERY_TIMEOUT, (int) ContainerKeyIndexTests.SHORT_TIMEOUT_MILLIS)
+                .build(), new int[] {1, 2, 3, 4});
+    }
+
+    @Test
+    public void testRecoveryOneBatchAfterCompactionWithVersion() throws Exception {
+        testRecoveryWithVersions(TableExtensionConfig.builder()
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_LENGTH, (long) TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH)
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE, Integer.MAX_VALUE)
+                .with(TableExtensionConfig.RECOVERY_TIMEOUT, (int) ContainerKeyIndexTests.SHORT_TIMEOUT_MILLIS)
+                .build(), new int[] {4, 3});
+    }
+
+    @Test
+    public void testRecoveryOneBatchAfterCompactionWithVersion2() throws Exception {
+        testRecoveryWithVersions(TableExtensionConfig.builder()
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_LENGTH, (long) TEST_MAX_TAIL_CACHE_PRE_INDEX_LENGTH)
+                .with(TableExtensionConfig.MAX_TAIL_CACHE_PREINDEX_BATCH_SIZE, Integer.MAX_VALUE)
+                .with(TableExtensionConfig.RECOVERY_TIMEOUT, (int) ContainerKeyIndexTests.SHORT_TIMEOUT_MILLIS)
+                .build(), new int[] {3, 4, 2});
+    }
+
+    private void testRecoveryWithVersions(TableExtensionConfig config, int[] versions) throws Exception {
+        val s = new EntrySerializer();
+        @Cleanup
+        val context = new TestContext(config);
+
+        // Setup the segment with initial attributes.
+        val iw = new IndexWriter(HASHER, executorService());
+
+        // 1. Generate initial set of keys and serialize them to the segment.
+        val entries1 = new ArrayList<TableEntry>(versions.length);
+        val offset = new AtomicLong();
+        val key = new ByteArraySegment("TEST_KEY".getBytes(StandardCharsets.UTF_8));
+        val expected = new HashMap<UUID, Long>();
+        val hash = HASHER.hash(key);
+        int highestVersion = -1;
+        for (int i : versions) {
+            val k = TableKey.versioned(key, i);
+            byte[] valueData = ("value" + i).getBytes(StandardCharsets.UTF_8);
+            val entry = TableEntry.versioned(k.getKey(), new ByteArraySegment(valueData), i);
+            val off = offset.getAndAdd(s.getUpdateLength(entry));
+            if (highestVersion < i) {
+                highestVersion = i;
+                expected.put(hash, off);
+            }
+
+            entries1.add(entry);
+        }
+
+        // Make sure to serialize versions, as Table Compactor does.
+        val update1 = s.serializeUpdateWithExplicitVersion(entries1);
+        Assert.assertEquals(offset.get(), update1.getLength());
+        context.segment.append(update1, null, TIMEOUT).join();
+
+        // 2. Initiate a recovery and verify pre-caching is triggered and requests are auto-unblocked.
+        val results = context.index.getBucketOffsets(context.segment,
+                Collections.singleton(hash),
+                context.timer).get(SHORT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        AssertExtensions.assertMapEquals("Unexpected result from getBucketOffsets() after auto pre-caching.", expected, results);
+    }
+
+    /**
      * Checks the ability for the {@link ContainerKeyIndex} class to cancel recovery-bound tasks if recovery took too long.
      */
     @Test
@@ -723,8 +877,11 @@ public class ContainerKeyIndexTests extends ThreadPooledTestSuite {
         val context = new TestContext(maxUnindexedSize);
 
         // Begin with a non-empty Table Segment that also has a backlog of unindexed entries. This should simulate a
-        // recovery and verify that the throttling does account for this scenario.
+        // recovery and verify that the throttling does account for this scenario. Note that the tail-caching starts
+        // scanning the segment (i.e., consuming credits) from the max from start offset or compaction offset to prevent
+        // missing tail-caching last values for keys. This requires us to also update the compaction offset to initialIndexOffset.
         context.segment.updateAttributes(Collections.singletonMap(TableAttributes.INDEX_OFFSET, (long) initialIndexOffset));
+        context.segment.updateAttributes(Collections.singletonMap(TableAttributes.COMPACTION_OFFSET, (long) initialIndexOffset));
         context.segment.append(new ByteArraySegment(new byte[initialIndexOffset]), null, TIMEOUT).join();
         val initialEntry = randomEntry(keySize, keySize, context);
         val initialEntryLength = s.getUpdateLength(initialEntry);

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/EntrySerializerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/tables/EntrySerializerTests.java
@@ -15,6 +15,8 @@
  */
 package io.pravega.segmentstore.server.tables;
 
+import com.google.common.annotations.VisibleForTesting;
+import io.pravega.common.util.BufferView;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.contracts.tables.TableKey;
@@ -99,6 +101,18 @@ public class EntrySerializerTests {
         }
 
         Assert.assertEquals("Did not read the entire serialization.", serialization.length, offset);
+    }
+
+    /**
+     * Utility method for tests that need to append serialized TableEntries outside the tables package.
+     *
+     * @param entries Table Entries to serialize.
+     * @return Serialized Table Entries.
+     */
+    @VisibleForTesting
+    public static BufferView generateUpdateWithExplicitVersion(List<TableEntry> entries) {
+        val s = new EntrySerializer();
+        return s.serializeUpdateWithExplicitVersion(entries);
     }
 
     private List<TableKey> generateKeys() {


### PR DESCRIPTION
**Change log description**  
Cherry-pick #6538 to r0.10

**Purpose of the change**  
Fixes #6557.

**What the code does**  

More details here #6538

> Ensures that TableEntry versions are considered when populating the tail-cache of a hash-based Table Segment during recovery. When triggering tail-caching, starts scanning Table Entries from the highest value between start segment offset and last compaction offset to make sure that we are not missing last value of any key (still, the tail-cache is only populated with elements beyond lastIndexedOffset as before).

**How to verify it**  

Build should pass