### PR TITLE
Issue 6526: LTS - Implement ChunkedSegmentStorage::listSegments

### DIFF
--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3StorageTest.java
@@ -250,14 +250,14 @@ public class ExtendedS3StorageTest extends IdempotentStorageTestBase {
     public void testListSegmentsBatch() throws Exception {
         try (Storage s = createStorage()) {
             s.initialize(DEFAULT_EPOCH);
-            Iterator<SegmentProperties> iterator = s.listSegments();
+            Iterator<SegmentProperties> iterator = s.listSegments().get();
             Assert.assertFalse(iterator.hasNext());
             int expectedCount = 1001; // Create more segments than 1000 which is the maximum number of segments in one batch.
             for (int i = 0; i < expectedCount; i++) {
                 String segmentName = "segment-" + i;
                 createSegment(segmentName, s);
             }
-            iterator = s.listSegments();
+            iterator = s.listSegments().get();
             int actualCount = 0;
             while (iterator.hasNext()) {
                 iterator.next();

--- a/cli/admin/src/main/java/io/pravega/cli/admin/dataRecovery/StorageListSegmentsCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/dataRecovery/StorageListSegmentsCommand.java
@@ -125,7 +125,7 @@ public class StorageListSegmentsCommand extends DataRecoveryCommand {
         createCSVFiles();
 
         output("Writing segments' details to the csv files...");
-        Iterator<SegmentProperties> segmentIterator = storage.listSegments();
+        Iterator<SegmentProperties> segmentIterator = storage.listSegments().get();
         while (segmentIterator.hasNext()) {
             SegmentProperties currentSegment = segmentIterator.next();
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerRecoveryUtils.java
@@ -102,7 +102,7 @@ public class ContainerRecoveryUtils {
 
         SegmentToContainerMapper segToConMapper = new SegmentToContainerMapper(containerCount, true);
 
-        Iterator<SegmentProperties> segmentIterator = storage.listSegments();
+        Iterator<SegmentProperties> segmentIterator = storage.listSegments().join();
         Preconditions.checkNotNull(segmentIterator);
 
         // Iterate through all segments. Create each one of their using their respective debugSegmentContainer instance.

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestStorage.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/TestStorage.java
@@ -211,8 +211,8 @@ public class TestStorage implements Storage {
     }
 
     @Override
-    public Iterator<SegmentProperties> listSegments() {
-        return null;
+    public CompletableFuture<Iterator<SegmentProperties>> listSegments() {
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/AsyncStorageWrapper.java
@@ -22,7 +22,6 @@ import io.pravega.common.concurrent.MultiKeySequentialProcessor;
 import io.pravega.common.function.RunnableWithException;
 import io.pravega.segmentstore.contracts.SegmentProperties;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Arrays;
@@ -154,8 +153,12 @@ public class AsyncStorageWrapper implements Storage {
     }
 
     @Override
-    public Iterator<SegmentProperties> listSegments() throws IOException {
-        return this.syncStorage.listSegments();
+    public CompletableFuture<Iterator<SegmentProperties>> listSegments() {
+        try {
+            return CompletableFuture.completedFuture(this.syncStorage.listSegments());
+        } catch (Exception ex) {
+            return CompletableFuture.failedFuture(ex);
+        }
     }
 
     //endregion

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/Storage.java
@@ -16,7 +16,6 @@
 package io.pravega.segmentstore.storage;
 
 import io.pravega.segmentstore.contracts.SegmentProperties;
-import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Iterator;
@@ -192,10 +191,10 @@ public interface Storage extends ReadOnlyStorage, AutoCloseable {
     /**
      * Lists all the segments stored on the storage device.
      *
-     * @return Iterator that can be used to enumerate and retrieve properties of all the segments.
-     * @throws IOException if exception occurred while listing segments.
+     * @return A CompletableFuture that, when completed, will contain an {@link Iterator} that can be used to enumerate and retrieve properties of all the segments.
+     * If the operation failed, it will contain the cause of the failure.
      */
-    Iterator<SegmentProperties> listSegments() throws IOException;
+    CompletableFuture<Iterator<SegmentProperties>> listSegments();
 
     @Override
     void close();

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -610,7 +610,7 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
     @Override
     public CompletableFuture<Iterator<SegmentProperties>> listSegments() {
         return metadataStore.getAllEntries()
-                .thenApplyAsync( storageMetadataStream ->
+                .thenApplyAsync(storageMetadataStream ->
                         storageMetadataStream
                                 .filter(metadata -> metadata instanceof SegmentMetadata && (((SegmentMetadata) metadata).isActive()))
                                 .map(metadata -> {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
@@ -778,7 +778,8 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
 
 
     /**
-     * Retrieve all entries.
+     * Retrieve all key-value pairs stored in this instance of {@link ChunkMetadataStore}.
+     * There is no order guarantee provided.
      *
      * @return A CompletableFuture that, when completed, will contain {@link Stream} of {@link StorageMetadata} entries.
      * If the operation failed, it will be completed with the appropriate exception.
@@ -786,7 +787,8 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
     abstract public CompletableFuture<Stream<StorageMetadata>> getAllEntries();
 
     /**
-     * Retrieve all keys.
+     * Retrieve all keys stored in this instance of {@link ChunkMetadataStore}.
+     * There is no order guarantee provided.
      *
      * @return A CompletableFuture that, when completed, will contain {@link Stream} of  {@link String} keys.
      * If the operation failed, it will be completed with the appropriate exception.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/BaseMetadataStore.java
@@ -54,6 +54,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.pravega.segmentstore.storage.metadata.StorageMetadataMetrics.COMMIT_LATENCY;
 import static io.pravega.segmentstore.storage.metadata.StorageMetadataMetrics.GET_LATENCY;
@@ -774,6 +775,23 @@ abstract public class BaseMetadataStore implements ChunkMetadataStore {
      * @return A CompletableFuture that, when completed, will indicate the operation succeeded.
      */
     abstract protected CompletableFuture<Void> writeAll(Collection<TransactionData> dataList);
+
+
+    /**
+     * Retrieve all entries.
+     *
+     * @return A CompletableFuture that, when completed, will contain {@link Stream} of {@link StorageMetadata} entries.
+     * If the operation failed, it will be completed with the appropriate exception.
+     */
+    abstract public CompletableFuture<Stream<StorageMetadata>> getAllEntries();
+
+    /**
+     * Retrieve all keys.
+     *
+     * @return A CompletableFuture that, when completed, will contain {@link Stream} of  {@link String} keys.
+     * If the operation failed, it will be completed with the appropriate exception.
+     */
+    abstract public CompletableFuture<Stream<String>> getAllKeys();
 
     /**
      * Updates existing metadata.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStore.java
@@ -20,6 +20,7 @@ import io.pravega.segmentstore.storage.chunklayer.StatsReporter;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Stream;
 
 /**
  * Storage Metadata store.
@@ -217,4 +218,20 @@ public interface ChunkMetadataStore extends AutoCloseable, StatsReporter {
      * Once marked fenced no modifications to data should be allowed.
      */
     void markFenced();
+
+    /**
+     * Retrieve all entries.
+     *
+     * @return A CompletableFuture that, when completed, will contain {@link Stream} of {@link StorageMetadata} entries.
+     * If the operation failed, it will be completed with the appropriate exception.
+     */
+    CompletableFuture<Stream<StorageMetadata>> getAllEntries();
+
+    /**
+     * Retrieve all keys.
+     *
+     * @return A CompletableFuture that, when completed, will contain {@link Stream} of  {@link String} keys.
+     * If the operation failed, it will be completed with the appropriate exception.
+     */
+    CompletableFuture<Stream<String>> getAllKeys();
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/ChunkMetadataStore.java
@@ -220,7 +220,8 @@ public interface ChunkMetadataStore extends AutoCloseable, StatsReporter {
     void markFenced();
 
     /**
-     * Retrieve all entries.
+     * Retrieve all key-value pairs stored in this instance of {@link ChunkMetadataStore}.
+     * There is no order guarantee provided.
      *
      * @return A CompletableFuture that, when completed, will contain {@link Stream} of {@link StorageMetadata} entries.
      * If the operation failed, it will be completed with the appropriate exception.
@@ -228,7 +229,8 @@ public interface ChunkMetadataStore extends AutoCloseable, StatsReporter {
     CompletableFuture<Stream<StorageMetadata>> getAllEntries();
 
     /**
-     * Retrieve all keys.
+     * Retrieve all keys stored in this instance of {@link ChunkMetadataStore}.
+     * There is no order guarantee provided.
      *
      * @return A CompletableFuture that, when completed, will contain {@link Stream} of  {@link String} keys.
      * If the operation failed, it will be completed with the appropriate exception.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStore.java
@@ -204,7 +204,8 @@ public class TableBasedMetadataStore extends BaseMetadataStore {
     }
 
     /**
-     * Retrieve all entries.
+     * Retrieve all key-value pairs stored in this instance of {@link ChunkMetadataStore}.
+     * There is no order guarantee provided.
      *
      * @return A CompletableFuture that, when completed, will contain {@link Stream} of {@link StorageMetadata} entries.
      * If the operation failed, it will be completed with the appropriate exception.
@@ -212,7 +213,7 @@ public class TableBasedMetadataStore extends BaseMetadataStore {
     @Override
     public CompletableFuture<Stream<StorageMetadata>> getAllEntries() {
         return this.tableStore.entryIterator(tableName, IteratorArgs.builder().fetchTimeout(timeout).build())
-                .thenApplyAsync( i -> getStreamFromTableIterator(i).map(td -> td.getValue()), getExecutor())
+                .thenApplyAsync(i -> getStreamFromTableIterator(i).map(td -> td.getValue()), getExecutor())
                 .exceptionally(e -> {
                     val ex = Exceptions.unwrap(e);
                     throw new CompletionException(handleException(ex));
@@ -220,7 +221,8 @@ public class TableBasedMetadataStore extends BaseMetadataStore {
     }
 
     /**
-     * Retrieve all keys.
+     * Retrieve all keys stored in this instance of {@link ChunkMetadataStore}.
+     * There is no order guarantee provided.
      *
      * @return A CompletableFuture that, when completed, will contain {@link Stream} of  {@link String} keys.
      * If the operation failed, it will be completed with the appropriate exception.
@@ -228,7 +230,7 @@ public class TableBasedMetadataStore extends BaseMetadataStore {
     @Override
     public CompletableFuture<Stream<String>> getAllKeys() {
         return this.tableStore.entryIterator(tableName, IteratorArgs.builder().fetchTimeout(timeout).build())
-                .thenApplyAsync( i -> getStreamFromTableIterator(i).map(td -> td.getKey()), getExecutor())
+                .thenApplyAsync(i -> getStreamFromTableIterator(i).map(td -> td.getKey()), getExecutor())
                 .exceptionally(e -> {
                     val ex = Exceptions.unwrap(e);
                     throw new CompletionException(handleException(ex));
@@ -241,7 +243,7 @@ public class TableBasedMetadataStore extends BaseMetadataStore {
      * @return {@link Stream} of {@link TransactionData}.
      */
     Stream<TransactionData> getStreamFromTableIterator(AsyncIterator<IteratorItem<TableEntry>> iterator) {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator.asIterator(), Spliterator.ORDERED), true)
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator.asIterator(), Spliterator.CONCURRENT), true)
                 .map(collection -> collection.getEntries())
                 .flatMap(entry -> entry.stream())
                 .map(tableEntry -> {

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/TableBasedMetadataStore.java
@@ -20,11 +20,14 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import io.pravega.common.Exceptions;
 import io.pravega.common.Timer;
+import io.pravega.common.util.AsyncIterator;
 import io.pravega.common.util.BufferView;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.segmentstore.contracts.SegmentType;
 import io.pravega.segmentstore.contracts.StreamSegmentExistsException;
 import io.pravega.segmentstore.contracts.tables.BadKeyVersionException;
+import io.pravega.segmentstore.contracts.tables.IteratorArgs;
+import io.pravega.segmentstore.contracts.tables.IteratorItem;
 import io.pravega.segmentstore.contracts.tables.TableEntry;
 import io.pravega.segmentstore.contracts.tables.TableKey;
 import io.pravega.segmentstore.contracts.tables.TableStore;
@@ -38,10 +41,14 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static io.pravega.segmentstore.storage.metadata.StorageMetadataMetrics.METADATA_FOUND_IN_STORE;
 import static io.pravega.segmentstore.storage.metadata.StorageMetadataMetrics.METADATA_NOT_FOUND;
@@ -193,6 +200,56 @@ public class TableBasedMetadataStore extends BaseMetadataStore {
                 .exceptionally(e -> {
                     val ex = Exceptions.unwrap(e);
                     throw new CompletionException(handleException(ex));
+                });
+    }
+
+    /**
+     * Retrieve all entries.
+     *
+     * @return A CompletableFuture that, when completed, will contain {@link Stream} of {@link StorageMetadata} entries.
+     * If the operation failed, it will be completed with the appropriate exception.
+     */
+    @Override
+    public CompletableFuture<Stream<StorageMetadata>> getAllEntries() {
+        return this.tableStore.entryIterator(tableName, IteratorArgs.builder().fetchTimeout(timeout).build())
+                .thenApplyAsync( i -> getStreamFromTableIterator(i).map(td -> td.getValue()), getExecutor())
+                .exceptionally(e -> {
+                    val ex = Exceptions.unwrap(e);
+                    throw new CompletionException(handleException(ex));
+                });
+    }
+
+    /**
+     * Retrieve all keys.
+     *
+     * @return A CompletableFuture that, when completed, will contain {@link Stream} of  {@link String} keys.
+     * If the operation failed, it will be completed with the appropriate exception.
+     */
+    @Override
+    public CompletableFuture<Stream<String>> getAllKeys() {
+        return this.tableStore.entryIterator(tableName, IteratorArgs.builder().fetchTimeout(timeout).build())
+                .thenApplyAsync( i -> getStreamFromTableIterator(i).map(td -> td.getKey()), getExecutor())
+                .exceptionally(e -> {
+                    val ex = Exceptions.unwrap(e);
+                    throw new CompletionException(handleException(ex));
+                });
+    }
+
+    /**
+     * Converts the given {@link AsyncIterator} to {@link Stream} of {@link TransactionData}.
+     * @param iterator Iterator to convert.
+     * @return {@link Stream} of {@link TransactionData}.
+     */
+    Stream<TransactionData> getStreamFromTableIterator(AsyncIterator<IteratorItem<TableEntry>> iterator) {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator.asIterator(), Spliterator.ORDERED), true)
+                .map(collection -> collection.getEntries())
+                .flatMap(entry -> entry.stream())
+                .map(tableEntry -> {
+                    try {
+                        return SERIALIZER.deserialize(tableEntry.getValue());
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
                 });
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryMetadataStore.java
@@ -19,6 +19,7 @@ package io.pravega.segmentstore.storage.mocks;
 import com.google.common.base.Preconditions;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.segmentstore.storage.metadata.BaseMetadataStore;
+import io.pravega.segmentstore.storage.metadata.StorageMetadata;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.val;
@@ -30,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * InMemoryMetadataStore stores the key-values in memory.
@@ -135,6 +137,32 @@ public class InMemoryMetadataStore extends BaseMetadataStore {
                 }
             }
         }, getExecutor());
+    }
+
+    /**
+     * Retrieve all entries.
+     *
+     * @return A CompletableFuture that, when completed, will contain {@link Stream} of {@link StorageMetadata} entries.
+     * If the operation failed, it will be completed with the appropriate exception.
+     */
+    @Override
+    public CompletableFuture<Stream<StorageMetadata>> getAllEntries() {
+        return CompletableFuture.completedFuture(backingStore.values().stream()
+                .filter(transactionData -> transactionData != null && transactionData.getValue() != null)
+                .map(TransactionData::getValue));
+    }
+
+    /**
+     * Retrieve all keys.
+     *
+     * @return A CompletableFuture that, when completed, will contain {@link Stream} of  {@link String} keys.
+     * If the operation failed, it will be completed with the appropriate exception.
+     */
+    @Override
+    public CompletableFuture<Stream<String>> getAllKeys() {
+        return CompletableFuture.completedFuture(backingStore.values().stream()
+                .filter(transactionData -> transactionData != null && transactionData.getValue() != null)
+                .map(TransactionData::getKey));
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryMetadataStore.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/mocks/InMemoryMetadataStore.java
@@ -19,6 +19,7 @@ package io.pravega.segmentstore.storage.mocks;
 import com.google.common.base.Preconditions;
 import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
 import io.pravega.segmentstore.storage.metadata.BaseMetadataStore;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
 import io.pravega.segmentstore.storage.metadata.StorageMetadata;
 import lombok.Getter;
 import lombok.Setter;
@@ -140,7 +141,8 @@ public class InMemoryMetadataStore extends BaseMetadataStore {
     }
 
     /**
-     * Retrieve all entries.
+     * Retrieve all key-value pairs stored in this instance of {@link ChunkMetadataStore}.
+     * There is no order guarantee provided.
      *
      * @return A CompletableFuture that, when completed, will contain {@link Stream} of {@link StorageMetadata} entries.
      * If the operation failed, it will be completed with the appropriate exception.
@@ -153,7 +155,8 @@ public class InMemoryMetadataStore extends BaseMetadataStore {
     }
 
     /**
-     * Retrieve all keys.
+     * Retrieve all keys stored in this instance of {@link ChunkMetadataStore}.
+     * There is no order guarantee provided.
      *
      * @return A CompletableFuture that, when completed, will contain {@link Stream} of  {@link String} keys.
      * If the operation failed, it will be completed with the appropriate exception.

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/StorageTestBase.java
@@ -105,10 +105,10 @@ public abstract class StorageTestBase extends ThreadPooledTestSuite {
         String segmentName = "foo_open";
         try (Storage s = createStorage()) {
             s.initialize(DEFAULT_EPOCH);
-            Iterator<SegmentProperties> iterator = s.listSegments();
+            Iterator<SegmentProperties> iterator = s.listSegments().get();
             Assert.assertFalse(iterator.hasNext());
             createSegment(segmentName, s);
-            iterator = s.listSegments();
+            iterator = s.listSegments().get();
             Assert.assertTrue(iterator.hasNext());
             SegmentProperties prop = iterator.next();
             Assert.assertEquals(prop.getName(), segmentName);
@@ -164,14 +164,14 @@ public abstract class StorageTestBase extends ThreadPooledTestSuite {
     public void testListSegmentsNextNoSuchElementException() throws Exception {
         try (Storage s = createStorage()) {
             s.initialize(DEFAULT_EPOCH);
-            Iterator<SegmentProperties> iterator = s.listSegments();
+            Iterator<SegmentProperties> iterator = s.listSegments().get();
             Assert.assertFalse(iterator.hasNext());
             int expectedCount = 10; // Create more segments than 1000 which is the maximum number of segments in one batch.
             for (int i = 0; i < expectedCount; i++) {
                 String segmentName = "segment-" + i;
                 createSegment(segmentName, s);
             }
-            iterator = s.listSegments();
+            iterator = s.listSegments().get();
             for (int i = 0; i < expectedCount; i++) {
                 SegmentProperties prop = iterator.next();
             }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedRollingStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedRollingStorageTests.java
@@ -82,12 +82,4 @@ public abstract class ChunkedRollingStorageTests extends RollingStorageTestBase 
     protected ChunkMetadataStore getMetadataStore() throws Exception {
         return new InMemoryMetadataStore(getDefaultConfig(), executorService());
     }
-
-    @Override
-    public void testListSegmentsWithOneSegment() {
-    }
-
-    @Override
-    public void testListSegmentsNextNoSuchElementException() {
-    }
 }


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Issue 6526: LTS - Implement ChunkedSegmentStorage::listSegments

**Purpose of the change**  
Fixes #6526 

**What the code does**  
- Make `Storage::listSegments()` return `CompletableFuture`
- Add `getAllEntries() `and `getAllKeys()` methods to `ChunkMetadataStoare`
- Implement `ChunkedSegmentStorage::listSegments`
- Update in memory table mock used in chunked segment storage tests to implement `getAllEntries() `and `getAllKeys()`

**How to verify it**  
All tests should pass.
