### PR TITLE
Issue 6563: Fix operationlogsize metric

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentStoreMetrics.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/SegmentStoreMetrics.java
@@ -37,7 +37,9 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.val;
 
-import static io.pravega.shared.MetricsTags.*;
+import static io.pravega.shared.MetricsTags.containerTag;
+import static io.pravega.shared.MetricsTags.eventProcessorTag;
+import static io.pravega.shared.MetricsTags.throttlerTag;
 
 /**
  * General Metrics for the SegmentStore.
@@ -519,7 +521,7 @@ public final class SegmentStoreMetrics {
      * @param containerId       Container owning the operationlog.
      */
     public static void reportOperationLogSize(int logSize, int containerId) {
-        DYNAMIC_LOGGER.reportGaugeValue(MetricsNames.OPERATION_LOG_SIZE, logSize, new String[] {TAG_CONTAINER, String.valueOf(containerId)});
+        DYNAMIC_LOGGER.reportGaugeValue(MetricsNames.OPERATION_LOG_SIZE, logSize, containerTag(containerId));
     }
 
     //endregion

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/DurableLog.java
@@ -37,6 +37,7 @@ import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperatio
 import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.logs.operations.OperationPriority;
 import io.pravega.segmentstore.server.logs.operations.StorageMetadataCheckpointOperation;
+import io.pravega.segmentstore.server.SegmentStoreMetrics;
 import io.pravega.segmentstore.storage.DataLogCorruptedException;
 import io.pravega.segmentstore.storage.DataLogDisabledException;
 import io.pravega.segmentstore.storage.DurableDataLog;
@@ -211,7 +212,6 @@ public class DurableLog extends AbstractService implements OperationLog {
         // Make sure we are in the correct state. We do not want to do recovery while we are in full swing.
         Preconditions.checkState(state() == State.STARTING || (state() == State.RUNNING && isOffline()), "Invalid State for recovery.");
 
-        this.operationProcessor.getMetrics().operationLogInit();
         Timer timer = new Timer();
         try {
             // Initialize the DurableDataLog, which will acquire its lock and ensure we are the only active users of it.
@@ -221,6 +221,7 @@ public class DurableLog extends AbstractService implements OperationLog {
             RecoveryProcessor p = new RecoveryProcessor(this.metadata, this.durableDataLog, this.memoryStateUpdater);
             int recoveredItemCount = p.performRecovery();
             this.operationProcessor.getMetrics().operationsCompleted(recoveredItemCount, timer.getElapsed());
+            SegmentStoreMetrics.reportOperationLogSize(recoveredItemCount, this.getId());
 
             // Verify that the Recovery Processor has left the metadata in a non-recovery mode.
             Preconditions.checkState(!this.metadata.isRecoveryMode(), "Recovery completed but Metadata is still in Recovery Mode.");
@@ -350,7 +351,7 @@ public class DurableLog extends AbstractService implements OperationLog {
         CompletableFuture<Queue<Operation>> result = this.inMemoryOperationLog.take(maxCount, timeout, this.executor);
         result.thenAccept(r -> {
             final int size = r.size();
-            this.operationProcessor.getMetrics().operationLogRead(size);
+            SegmentStoreMetrics.reportOperationLogSize(this.inMemoryOperationLog.size(), this.getId());
             log.debug("{}: ReadResult (Count = {}, Remaining = {}).", this.traceObjectId, size, this.inMemoryOperationLog.size());
             if (size > 0) {
                 this.memoryStateUpdater.notifyLogRead();

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/OperationProcessor.java
@@ -479,6 +479,7 @@ class OperationProcessor extends AbstractThreadPoolService implements AutoClosea
                 this.stateUpdater.process(items.stream().flatMap(List::stream).map(CompletableOperation::getOperation).iterator(),
                         this.state::notifyOperationCommitted);
                 this.metrics.memoryCommit(items.size(), memoryCommitTimer.getElapsed());
+                SegmentStoreMetrics.reportOperationLogSize(this.stateUpdater.getInMemoryOperationLogSize(), this.metadata.getContainerId());
                 items = this.commitQueue.poll(MAX_COMMIT_QUEUE_SIZE);
             } while (!items.isEmpty());
         } catch (Throwable ex) {

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
@@ -216,7 +216,7 @@ public class SegmentStoreMetricsTests {
     }
 
     @Test
-    public void testOperationProcessorMetrics() {
+    public void testOperationProcessorMetrics() throws Exception {
         int containerId = 1;
         final String[] containerTag = containerTag(containerId);
         @Cleanup
@@ -231,16 +231,9 @@ public class SegmentStoreMetricsTests {
                 new TestCompletableOperation(30));
         op.operationsFailed(opf);
         assertEquals(20, (int) MetricRegistryUtils.getTimer(MetricsNames.OPERATION_LATENCY, containerTag).totalTime(TimeUnit.MILLISECONDS));
-
-        assertEquals(3, (int) MetricRegistryUtils.getCounter(MetricsNames.OPERATION_LOG_SIZE, containerTag).count());
-        op.operationLogRead(1);
-        assertEquals(2, (int) MetricRegistryUtils.getCounter(MetricsNames.OPERATION_LOG_SIZE, containerTag).count());
-
-        op.operationLogInit();
-        assertEquals(0, (int) MetricRegistryUtils.getCounter(MetricsNames.OPERATION_LOG_SIZE, containerTag).count());
-
+        SegmentStoreMetrics.reportOperationLogSize(1000, 1);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricRegistryUtils.getGauge(MetricsNames.OPERATION_LOG_SIZE).value() == 1000, 2000);
         op.close();
-        assertNull(MetricRegistryUtils.getCounter(MetricsNames.OPERATION_LOG_SIZE, containerTag));
     }
 
     private static class TestCompletableOperation extends CompletableOperation {


### PR DESCRIPTION
Signed-off-by: Abhin Balur <Abhin_Balur@dell.com>

**Change log description**  
Fixes the OpeartionLog size metric in Grafana dashboard for SegmentStore.

**Purpose of the change**  
Fixes #6563 

**What the code does**  
Fixes the OpeartionLog size metric in Grafana dashboard for SegmentStore. This metric was originally a 
counter which was leading to wrong operation log sizes being reported when in actuality it should have been a guage.

**How to verify it**  
Bring up Grafana dashboards for SegmentStore. View the operationlog size graph while writing data to Pravega.
