### PR TITLE
Issue 6580: Fix system test memory config on r0.10

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/AbstractService.java
@@ -224,7 +224,7 @@ public abstract class AbstractService implements Service {
     // Removal of the JVM option 'UseCGroupMemoryLimitForHeap' is required with JVM environments >= 10. This option
     // is supplied by default by the operators. We cannot 'deactivate' it using the XX:- counterpart as it is unrecognized.
     private String[] getSegmentStoreJVMOptions() {
-        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:MaxDirectMemorySize=5g", "-Xmx1024m"};
+        return new String[]{"-XX:+UseContainerSupport", "-XX:+IgnoreUnrecognizedVMOptions", "-XX:MaxDirectMemorySize=4g", "-Xmx1024m"};
     }
 
     private String[] getControllerJVMOptions() {

--- a/test/system/src/test/resources/pravega.properties
+++ b/test/system/src/test/resources/pravega.properties
@@ -25,7 +25,7 @@ controller.transaction.lease.count.max=600000
 controller.retention.frequency.minutes=2
 log.level=DEBUG
 hdfs.replaceDataNodesOnFailure.enable=false
-#4GB of cache.
-pravegaservice.cache.size.max=4294967296
-#4GB of cache + a buffer for whatever else Netty might need it for.
+#3GB of cache.
+pravegaservice.cache.size.max=3094967296
+#3GB of cache + a buffer for whatever else Netty might need it for.
 io.netty.maxDirectMemory=5368709120

--- a/test/system/src/test/resources/pravega_withAuth.properties
+++ b/test/system/src/test/resources/pravega_withAuth.properties
@@ -30,9 +30,9 @@ controller.security.pwdAuthHandler.accountsDb.location=/opt/pravega/conf/passwd
 controller.security.auth.delegationToken.signingKey.basis=secret
 autoscale.controller.connect.security.auth.enable=true
 autoscale.security.auth.token.signingKey.basis=secret
-#4GB of cache.
-pravegaservice.cache.size.max=4294967296
-#4GB of cache + a buffer for whatever else Netty might need it for.
+#3GB of cache.
+pravegaservice.cache.size.max=3094967296
+#3GB of cache + a buffer for whatever else Netty might need it for.
 io.netty.maxDirectMemory=5368709120
 pravega.client.auth.token=YWRtaW46MTExMV9hYWFh
 pravega.client.auth.method=Basic

--- a/test/system/src/test/resources/pravega_withTLS.properties
+++ b/test/system/src/test/resources/pravega_withTLS.properties
@@ -30,9 +30,9 @@ controller.security.pwdAuthHandler.accountsDb.location=/opt/pravega/conf/passwd
 controller.security.auth.delegationToken.signingKey.basis=secret
 autoScale.controller.connect.security.auth.enable=true
 autoScale.security.auth.token.signingKey.basis=secret
-#4GB of cache.
-pravegaservice.cache.size.max=4294967296
-#4GB of cache + a buffer for whatever else Netty might need it for.
+#3GB of cache.
+pravegaservice.cache.size.max=3094967296
+#3GB of cache + a buffer for whatever else Netty might need it for.
 io.netty.maxDirectMemory=5368709120
 pravega.client.auth.token=YWRtaW46MTExMV9hYWFh
 pravega.client.auth.method=Basic


### PR DESCRIPTION
Signed-off-by: Abhin Balur <Abhin_Balur@dell.com>

**Change log description**  
This change corrrects the memory configuration for system tests, without which system tests are currently failing. 

**Purpose of the change**  
Fixes #6580

**What the code does**  
The code puts in the right values for memory related configuration of SegmentStore, without which we see errors as described in #6580.

**How to verify it**  
System tests should pass
