### PR TITLE
issue-5887 Revisit Bucket Counts

### DIFF
--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -172,7 +172,7 @@ public final class Config {
             "retention.frequency.minutes", 30, "retention.frequencyMinutes");
 
     public static final Property<Integer> PROPERTY_RETENTION_BUCKET_COUNT = Property.named(
-            "retention.bucket.count", 1, "retention.bucketCount");
+            "retention.bucket.count", 5, "retention.bucketCount");
 
     public static final Property<Integer> PROPERTY_RETENTION_THREAD_COUNT = Property.named(
             "retention.thread.count", 1, "retention.threadCount");
@@ -193,7 +193,7 @@ public final class Config {
             "watermarking.frequency.seconds", 10, "watermarking.frequencySeconds");
 
     public static final Property<Integer> PROPERTY_WATERMARKING_BUCKET_COUNT = Property.named(
-            "watermarking.bucket.count", 100, "watermarking.bucketCount");
+            "watermarking.bucket.count", 50, "watermarking.bucketCount");
 
     public static final Property<Integer> PROPERTY_WATERMARKING_THREAD_COUNT = Property.named(
             "watermarking.thread.count", 10, "watermarking.threadCount");

--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -303,7 +303,7 @@ public final class Config {
     //endregion
 
 
-    //region Initialization
+    //#region Initialization
 
     static {
         val properties = loadConfiguration();


### PR DESCRIPTION
Signed-off-by: Shashwat Sharma <shashwat_sharma@dell.com>

**Change log description**  
Changes the default bucket count for Watermarking and retention. Current calculation is 5 counts per bucket thread.

**Purpose of the change**  
Fixes #5887 

**What the code does**  
Update default properties `PROPERTY_RETENTION_BUCKET_COUNT` from default value `1` to `5` and the property `PROPERTY_WATERMARKING_BUCKET_COUNT` from default value `100` to `50` to keep the calculation in sync with 5 counts per thread.

**How to verify it**  
All existing test cases (including system tests) should run successfully
