### PR TITLE
Issue-6570: LTS - Make FileChannel cache expiration configurable

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemChunkStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemChunkStorage.java
@@ -76,7 +76,7 @@ public class FileSystemChunkStorage extends BaseChunkStorage {
     public FileSystemChunkStorage(FileSystemStorageConfig config, Executor executor) {
         super(executor);
         this.config = Preconditions.checkNotNull(config, "config");
-        this.fileSystem = new FileSystemWrapper(config.getReadChannelCacheSize(), config.getWriteChannelCacheSize());
+        this.fileSystem = new FileSystemWrapper(config.getReadChannelCacheSize(), config.getWriteChannelCacheSize(), config.getReadChannelCacheExpiration(), config.getWriteChannelCacheExpiration());
     }
 
     /**

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageConfig.java
@@ -21,6 +21,7 @@ import io.pravega.common.util.Property;
 import io.pravega.common.util.TypedProperties;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import java.time.Duration;
 
 /**
  * Configuration for the NFS Storage component.
@@ -33,6 +34,8 @@ public class FileSystemStorageConfig {
     public static final Property<String> ROOT = Property.named("root", "/fs/");
     public static final Property<Boolean> REPLACE_ENABLED = Property.named("replace.enable", false);
     public static final String COMPONENT_CODE = "filesystem";
+    public static final Property<Integer> WRITE_CACHE_EXPIRATION = Property.named("write.channel.cache.expiration.sec", 600);
+    public static final Property<Integer> READ_CACHE_EXPIRATION = Property.named("read.channel.cache.expiration.sec", 600);
 
     //endregion
 
@@ -58,6 +61,12 @@ public class FileSystemStorageConfig {
     @Getter
     private final int writeChannelCacheSize;
 
+    @Getter
+    private  final Duration readChannelCacheExpiration;
+
+    @Getter
+    private final Duration writeChannelCacheExpiration;
+
     //endregion
 
     //region Constructor
@@ -72,6 +81,8 @@ public class FileSystemStorageConfig {
         this.replaceEnabled = properties.getBoolean(REPLACE_ENABLED);
         this.readChannelCacheSize = properties.getPositiveInt(READ_CHANNEL_CACHE_SIZE);
         this.writeChannelCacheSize = properties.getPositiveInt(WRITE_CHANNEL_CACHE_SIZE);
+        this.readChannelCacheExpiration = Duration.ofSeconds(properties.getPositiveInt(READ_CACHE_EXPIRATION));
+        this.writeChannelCacheExpiration = Duration.ofSeconds(properties.getPositiveInt(WRITE_CACHE_EXPIRATION));
     }
 
     /**

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageConfig.java
@@ -55,19 +55,27 @@ public class FileSystemStorageConfig {
     @Getter
     private final boolean replaceEnabled;
 
-    // Read cache size of the FileChannel
+    /**
+     * Size of FileChannel Read Cache.
+     */
     @Getter
     private final int readChannelCacheSize;
 
-    // Write cache size of the FileChannel
+    /**
+     * Size of FileChannel Write Cache.
+     */
     @Getter
     private final int writeChannelCacheSize;
 
-    // Read cache expiration of the FileChannel
+    /**
+     * Expiration duration for FileChannel Read Cache.
+     */
     @Getter
     private  final Duration readChannelCacheExpiration;
 
-    // Write cache expiration of the FileChannel
+    /**
+     * Expiration duration for FileChannel Write Cache.
+     */
     @Getter
     private final Duration writeChannelCacheExpiration;
 

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemStorageConfig.java
@@ -55,15 +55,19 @@ public class FileSystemStorageConfig {
     @Getter
     private final boolean replaceEnabled;
 
+    // Read cache size of the FileChannel
     @Getter
     private final int readChannelCacheSize;
 
+    // Write cache size of the FileChannel
     @Getter
     private final int writeChannelCacheSize;
 
+    // Read cache expiration of the FileChannel
     @Getter
     private  final Duration readChannelCacheExpiration;
 
+    // Write cache expiration of the FileChannel
     @Getter
     private final Duration writeChannelCacheExpiration;
 

--- a/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemWrapper.java
+++ b/bindings/src/main/java/io/pravega/storage/filesystem/FileSystemWrapper.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
+import java.time.Duration;
 import java.util.Set;
 
 /**
@@ -66,14 +67,18 @@ public class FileSystemWrapper {
      * Constructs new instance of FileSystemWrapper.
      * @param readCacheSize Read cache size
      * @param writeCacheSize Write cache size
+     * @param readCacheExpirationDuration Read Cache Expiration Duration
+     * @param writeCacheExpirationDuration Write Cache Expiration Duration
      */
-    public FileSystemWrapper(int readCacheSize, int writeCacheSize) {
+    public FileSystemWrapper(int readCacheSize, int writeCacheSize, Duration readCacheExpirationDuration, Duration writeCacheExpirationDuration) {
         readCache = CacheBuilder.newBuilder()
-                .maximumSize(FileSystemStorageConfig.READ_CHANNEL_CACHE_SIZE.getDefaultValue())
+                .maximumSize(readCacheSize)
+                .expireAfterAccess(readCacheExpirationDuration)
                 .removalListener(this::handleRemovalNotification)
                 .build();
         writeCache = CacheBuilder.newBuilder()
-                .maximumSize(FileSystemStorageConfig.WRITE_CHANNEL_CACHE_SIZE.getDefaultValue())
+                .maximumSize(writeCacheSize)
+                .expireAfterAccess(writeCacheExpirationDuration)
                 .removalListener(this::handleRemovalNotification)
                 .build();
     }

--- a/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemChunkStorageMockTest.java
+++ b/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemChunkStorageMockTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.when;
 public class FileSystemChunkStorageMockTest extends ThreadPooledTestSuite {
     static final Duration TIMEOUT = Duration.ofSeconds(30);
     static final int CACHE_SIZE = 1024;
+    static final Duration CACHE_EXP = Duration.ofSeconds(600);
     @Rule
     public Timeout globalTimeout = Timeout.seconds(TIMEOUT.getSeconds());
 
@@ -155,7 +156,7 @@ public class FileSystemChunkStorageMockTest extends ThreadPooledTestSuite {
 
     @Test
     public void testStorageFull() throws Exception {
-        val fs = spy(new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE));
+        val fs = spy(new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE, CACHE_EXP, CACHE_EXP));
         doThrow(new IOException("No space left on device")).when(fs).getFileSize(any());
         FileSystemChunkStorage storage = new FileSystemChunkStorage(storageConfig, fs, executorService());
         AssertExtensions.assertFutureThrows("should throw ChunkStorageFull exception",
@@ -165,7 +166,7 @@ public class FileSystemChunkStorageMockTest extends ThreadPooledTestSuite {
 
     @Test
     public void testGetUsageException() {
-        val fs = spy(new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE));
+        val fs = spy(new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE, CACHE_EXP, CACHE_EXP));
         doThrow(new RuntimeException("Intentional")).when(fs).getUsedSpace(any());
         FileSystemChunkStorage storage = new FileSystemChunkStorage(storageConfig, fs, executorService());
         AssertExtensions.assertFutureThrows("should throw ChunkStorageException exception",

--- a/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemWrapperTests.java
+++ b/bindings/src/test/java/io/pravega/storage/filesystem/FileSystemWrapperTests.java
@@ -19,6 +19,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.time.Duration;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -31,6 +33,7 @@ import java.util.Set;
 
 public class FileSystemWrapperTests {
     public static final int CACHE_SIZE = 1024;
+    public static final Duration CACHE_EXP = Duration.ofSeconds(600);
     public static final String USER_NAME_PROPERTY = "user.name";
     public static final String ROOT_USER_NAME = "root";
     Path tempDirPath;
@@ -56,7 +59,7 @@ public class FileSystemWrapperTests {
     private void testCachedPopulated(StandardOpenOption option, String fileName, boolean isWrite) throws IOException {
         // Arrange. Create FileSystemWrapper instance to test
         Path filePath = tempDirPath.resolve(Path.of(fileName));
-        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE);
+        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE, CACHE_EXP, CACHE_EXP);
 
         // Check that file doesn't exist
         Assert.assertFalse(fw.exists(filePath));
@@ -101,7 +104,7 @@ public class FileSystemWrapperTests {
         // Arrange. Create FileSystemWrapper instance to test
         String fileName1 = "temp5";
         Path filePath = tempDirPath.resolve(Path.of(fileName1));
-        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE);
+        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE, CACHE_EXP, CACHE_EXP);
 
         // Check that the file doesn't exist
         Assert.assertFalse(fw.exists(filePath));
@@ -129,7 +132,7 @@ public class FileSystemWrapperTests {
         // Arrange. Create FileSystemWrapper instance to test
         String fileName2 = "temp6";
         Path filePath = tempDirPath.resolve(Path.of(fileName2));
-        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE);
+        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE, CACHE_EXP, CACHE_EXP);
 
         // Check that file doesn't exist
         boolean b = fw.exists(filePath);
@@ -153,7 +156,7 @@ public class FileSystemWrapperTests {
         // Arrange. Create FileSystemWrapper instance to test
         String fileName3 = "temp7";
         Path filePath = tempDirPath.resolve(Path.of(fileName3));
-        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE);
+        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE, CACHE_EXP, CACHE_EXP);
 
         // Check that file doesn't exist
         Assert.assertFalse(fw.exists(filePath));
@@ -178,7 +181,7 @@ public class FileSystemWrapperTests {
         // Arrange. Create FileSystemWrapper instance to test
         String filename4 = "temp8";
         Path filePath = tempDirPath.resolve(Path.of(filename4));
-        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE);
+        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE, CACHE_EXP, CACHE_EXP);
 
         // Check that file doesn't exist
         Assert.assertFalse(fw.exists(filePath));
@@ -198,7 +201,7 @@ public class FileSystemWrapperTests {
         // Arrange. Create FileSystemWrapper instance to test
         String filename5 = "temp9";
         Path filePath = tempDirPath.resolve(Path.of(filename5));
-        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE);
+        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE, CACHE_EXP, CACHE_EXP);
 
         // Check that file doesn't exist
         Assert.assertFalse(fw.exists(filePath));
@@ -219,7 +222,7 @@ public class FileSystemWrapperTests {
         // Arrange. Create FileSystemWrapper instance to test
         String dirName = "tempDir1";
         Path dirPath = tempDirPath.resolve(Path.of(dirName));
-        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE);
+        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE, CACHE_EXP, CACHE_EXP);
 
         // Check that directory doesn't exist
         Assert.assertFalse(fw.exists(dirPath));
@@ -242,7 +245,7 @@ public class FileSystemWrapperTests {
         // Arrange. Create FileSystemWrapper instance to test
         String filename6 = "temp10";
         Path filePath = tempDirPath.resolve(Path.of(filename6));
-        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE);
+        FileSystemWrapper fw = new FileSystemWrapper(CACHE_SIZE, CACHE_SIZE, CACHE_EXP, CACHE_EXP);
 
         // Check that file doesn't exist
         Assert.assertFalse(fw.exists(filePath));


### PR DESCRIPTION
**Change log description**  
The aim is to make expiration of cache configurable for the  recently added FileChannel cache in FileSystemWrapper.

**Purpose of the change**  
Adding a new config value for the FileChannel cache expiration.

**What the code does**  
Instead of having no expiration or hardcoding the time out which is not really preferred, the code:
- Adds two new config values to FileSystemStorageConfig "write.channel.cache.expiration.sec" and "read.channel.cache.expiration.sec" each of these with 600 as default and passing it to the FileSystemWrapper constructor
- And then use them during CacheBuilder.newBuilder().maximumSize(...).expireAfterAccess(...) --> using Duration value passed to constructor.

**How to verify it**  
Changes can be verified by running the testcases.
