### PR TITLE
Issue 6593: Fix operationlogsize metric based test

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/SegmentStoreMetricsTests.java
@@ -230,8 +230,8 @@ public class SegmentStoreMetricsTests {
                 new TestCompletableOperation(30));
         op.operationsFailed(opf);
         assertEquals(20, (int) MetricRegistryUtils.getTimer(MetricsNames.OPERATION_LATENCY, containerTag).totalTime(TimeUnit.MILLISECONDS));
-        SegmentStoreMetrics.reportOperationLogSize(1000, 1);
-        AssertExtensions.assertEventuallyEquals(true, () -> MetricRegistryUtils.getGauge(MetricsNames.OPERATION_LOG_SIZE).value() == 1000, 2000);
+        SegmentStoreMetrics.reportOperationLogSize(1000, containerId);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricRegistryUtils.getGauge(MetricsNames.OPERATION_LOG_SIZE, containerTag(containerId)).value() == 1000, 2000);
         op.close();
     }
 


### PR DESCRIPTION
**Change log description**  
Fix operationlogsize metric based test.

**Purpose of the change**  
Fixes #6593 

**What the code does**  
There was an issue with how the gauge is retrieved in the test. Basically in the test while reporting the gauge we report the OperationLog Size metric/gauge  for a specific container. However while retrieving the gauge we query the MetricRegistryUtils which return the operationlogsize for all containers. There is a precondition check where we expect only one gauge to be retrieved(since we are querying for only one container). However this container id wasnt passed resulting in gauges for all containers to be retrieved thereby failing the Precondition Check. 
The fix passes the right container id while retrieving the gauge.

**How to verify it**  
Unit tests should pass.
