### PR TITLE
Issue 6616: Pinned Segments my not be pinned after a container restart

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -448,6 +448,7 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
         private CompletableFuture<Void> refreshSegment() {
             return this.segmentSupplier.apply(this.name).thenApply(segment -> {
                 this.segment = segment;
+                log.info("{}: Refreshing Segment {} (pinned = {}).", this.traceObjectId, this.segment.getInfo(), this.segment.getInfo().isPinned());
                 return null;
             });
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/ContainerEventProcessorImpl.java
@@ -448,7 +448,6 @@ class ContainerEventProcessorImpl implements ContainerEventProcessor {
         private CompletableFuture<Void> refreshSegment() {
             return this.segmentSupplier.apply(this.name).thenApply(segment -> {
                 this.segment = segment;
-                log.info("{}: Refreshing Segment {} (pinned = {}).", this.traceObjectId, this.segment.getInfo(), this.segment.getInfo().isPinned());
                 return null;
             });
         }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -499,7 +499,7 @@ public abstract class MetadataStore implements AutoCloseable {
                     CompletableFuture.completedFuture(false);
             return pinFuture.thenCompose(pinned -> {
                                 if (pinned) {
-                                    log.info("{}: Segment {} has been pinned to memory.", this.traceObjectId, existingSegmentId);
+                                    log.info("{}: Segment {} ({}) has been pinned to memory.", this.traceObjectId, existingSegmentId, properties.getName());
                                 }
                                 completeAssignment(properties.getName(), existingSegmentId);
                                 return CompletableFuture.completedFuture(existingSegmentId);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/MetadataStore.java
@@ -490,10 +490,10 @@ public abstract class MetadataStore implements AutoCloseable {
             return Futures.failedFuture(new StreamSegmentNotExistsException(properties.getName()));
         }
 
-        long existingSegmentId = this.connector.containerMetadata.getStreamSegmentId(properties.getName(), true);
+        long existingSegmentId = this.connector.getContainerMetadata().getStreamSegmentId(properties.getName(), true);
         if (isValidSegmentId(existingSegmentId)) {
             // Looks like someone else beat us to it. Still, we need to know if the Segment needs to be pinned.
-            boolean needsToBePinned = pin && !this.connector.containerMetadata.getStreamSegmentMetadata(existingSegmentId).isPinned();
+            boolean needsToBePinned = pin && !this.connector.getContainerMetadata().getStreamSegmentMetadata(existingSegmentId).isPinned();
             CompletableFuture<Boolean> pinFuture = needsToBePinned ?
                     this.connector.getPinSegment().apply(existingSegmentId, properties, pin, timeout) :
                     CompletableFuture.completedFuture(false);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -41,12 +41,14 @@ import io.pravega.segmentstore.server.logs.operations.DeleteSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
+import io.pravega.segmentstore.server.logs.operations.PinSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.StorageMetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentMapOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentSealOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentTruncateOperation;
 import io.pravega.segmentstore.server.logs.operations.UpdateAttributesOperation;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -364,6 +366,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
             processMetadataOperation((StorageMetadataCheckpointOperation) operation);
         } else if (operation instanceof StreamSegmentMapOperation) {
             preProcessMetadataOperation((StreamSegmentMapOperation) operation);
+        } else if (operation instanceof PinSegmentOperation) {
+            preProcessMetadataOperation((PinSegmentOperation) operation);
         }
     }
 
@@ -411,6 +415,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
             ((CheckpointOperationBase) operation).clearContents();
         } else if (operation instanceof StreamSegmentMapOperation) {
             acceptMetadataOperation((StreamSegmentMapOperation) operation);
+        } else if (operation instanceof PinSegmentOperation) {
+            acceptMetadataOperation((PinSegmentOperation) operation);
         }
     }
 
@@ -419,6 +425,12 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         // segment id as the one the operation is trying to set.
         checkExistingMapping(operation);
         assignUniqueSegmentId(operation);
+    }
+
+    private void preProcessMetadataOperation(PinSegmentOperation operation) throws ContainerException {
+        // Verify that the segment does exist and is mapped to an id. If it is mapped, then it needs to have
+        // the exact same segment id as the one the operation is trying to set.
+        checkNonExistingMapping(operation);
     }
 
     private void processMetadataOperation(MetadataCheckpointOperation operation) throws MetadataUpdateException {
@@ -481,6 +493,18 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         updateMetadata(operation, segmentMetadata);
     }
 
+    private void acceptMetadataOperation(PinSegmentOperation operation) throws MetadataUpdateException {
+        if (operation.getStreamSegmentId() == ContainerMetadata.NO_STREAM_SEGMENT_ID) {
+            throw new MetadataUpdateException(this.containerId,
+                    "StreamSegmentMapOperation does not have a SegmentId assigned: " + operation);
+        }
+
+        // Create or reuse an existing Segment Metadata.
+        UpdateableSegmentMetadata segmentMetadata = getOrCreateSegmentUpdateTransaction(
+                operation.getStreamSegmentName(), operation.getStreamSegmentId());
+        updateMetadata(operation, segmentMetadata);
+    }
+
     private void updateMetadata(StreamSegmentMapOperation mapping, UpdateableSegmentMetadata metadata) {
         metadata.setStorageLength(mapping.getLength());
 
@@ -505,6 +529,14 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         metadata.refreshDerivedProperties();
     }
 
+    private void updateMetadata(PinSegmentOperation mapping, UpdateableSegmentMetadata metadata) {
+
+        // Pin this to memory if needed.
+        if (mapping.isPinned()) {
+            metadata.markPinned();
+        }
+    }
+
     //endregion
 
     //region Helpers
@@ -515,6 +547,15 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
                 && existingSegmentId != operation.getStreamSegmentId()) {
             throw new MetadataUpdateException(this.containerId,
                     String.format("Operation '%s' wants to map a Segment that is already mapped in the metadata. Existing Id = %d.",
+                            operation, existingSegmentId));
+        }
+    }
+
+    private void checkNonExistingMapping(PinSegmentOperation operation) throws MetadataUpdateException {
+        long existingSegmentId = getStreamSegmentId(operation.getStreamSegmentName(), false);
+        if (existingSegmentId == ContainerMetadata.NO_STREAM_SEGMENT_ID && existingSegmentId != operation.getStreamSegmentId()) {
+            throw new MetadataUpdateException(this.containerId,
+                    String.format("Operation '%s' wants to update pinned flag for wrong or non-existing Segment Id = %d.",
                             operation, existingSegmentId));
         }
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransaction.java
@@ -529,10 +529,9 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
         metadata.refreshDerivedProperties();
     }
 
-    private void updateMetadata(PinSegmentOperation mapping, UpdateableSegmentMetadata metadata) {
-
+    private void updateMetadata(PinSegmentOperation pinSegment, UpdateableSegmentMetadata metadata) {
         // Pin this to memory if needed.
-        if (mapping.isPinned()) {
+        if (pinSegment.isPinned()) {
             metadata.markPinned();
         }
     }
@@ -553,7 +552,8 @@ class ContainerMetadataUpdateTransaction implements ContainerMetadata {
 
     private void checkNonExistingMapping(PinSegmentOperation operation) throws MetadataUpdateException {
         long existingSegmentId = getStreamSegmentId(operation.getStreamSegmentName(), false);
-        if (existingSegmentId == ContainerMetadata.NO_STREAM_SEGMENT_ID && existingSegmentId != operation.getStreamSegmentId()) {
+        if (existingSegmentId == ContainerMetadata.NO_STREAM_SEGMENT_ID
+                || existingSegmentId != operation.getStreamSegmentId()) {
             throw new MetadataUpdateException(this.containerId,
                     String.format("Operation '%s' wants to update pinned flag for wrong or non-existing Segment Id = %d.",
                             operation, existingSegmentId));

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/OperationSerializer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/OperationSerializer.java
@@ -37,6 +37,7 @@ public class OperationSerializer extends VersionedSerializer.MultiType<Operation
          .serializer(StreamSegmentTruncateOperation.class, 7, new StreamSegmentTruncateOperation.Serializer())
          .serializer(MetadataCheckpointOperation.class, 8, new MetadataCheckpointOperation.Serializer())
          .serializer(StorageMetadataCheckpointOperation.class, 9, new StorageMetadataCheckpointOperation.Serializer())
-         .serializer(DeleteSegmentOperation.class, 10, new DeleteSegmentOperation.Serializer());
+         .serializer(DeleteSegmentOperation.class, 10, new DeleteSegmentOperation.Serializer())
+         .serializer(PinSegmentOperation.class, 11, new PinSegmentOperation.Serializer());
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/PinSegmentOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/PinSegmentOperation.java
@@ -105,7 +105,7 @@ public class PinSegmentOperation extends MetadataOperation {
     //endregion
 
     static class Serializer extends OperationSerializer<PinSegmentOperation> {
-        private static final int STATIC_LENGTH = 4 * Long.BYTES + 2 * Byte.BYTES;
+        private static final int STATIC_LENGTH = 2 * Long.BYTES + Byte.BYTES;
 
         @Override
         protected OperationBuilder<PinSegmentOperation> newBuilder() {
@@ -129,6 +129,7 @@ public class PinSegmentOperation extends MetadataOperation {
         }
 
         private void write00(PinSegmentOperation o, RevisionDataOutput target) throws IOException {
+            target.length(STATIC_LENGTH + target.getUTFLength(o.streamSegmentName));
             target.writeLong(o.getSequenceNumber());
             target.writeLong(o.streamSegmentId);
             target.writeUTF(o.streamSegmentName);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/PinSegmentOperation.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/logs/operations/PinSegmentOperation.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.server.logs.operations;
+
+import com.google.common.base.Preconditions;
+import io.pravega.common.io.serialization.RevisionDataInput;
+import io.pravega.common.io.serialization.RevisionDataOutput;
+import io.pravega.segmentstore.server.ContainerMetadata;
+
+import java.io.IOException;
+
+/**
+ * Log Operation that represents setting a Stream Segment as pinned.
+ */
+public class PinSegmentOperation extends MetadataOperation {
+
+    //region Members
+
+    private String streamSegmentName;
+    private long streamSegmentId;
+    private boolean pinned;
+
+    //endregion
+
+    //region Constructor
+
+    /**
+     * Creates a new instance of the PinSegmentOperation class for a non-transaction Segment.
+     *
+     * @param streamSegmentName Name of the Segment.
+     * @param streamSegmentId Id for this Segment.
+     * @param pinned If the Segment should be pinned.
+     */
+    public PinSegmentOperation(String streamSegmentName, long streamSegmentId, boolean pinned) {
+        this.streamSegmentName = streamSegmentName;
+        this.streamSegmentId = streamSegmentId;
+        this.pinned = pinned;
+    }
+
+    /**
+     * Deserialization constructor.
+     */
+    private PinSegmentOperation() {
+    }
+
+    //endregion
+
+    //region PinOperation implementation.
+
+    /**
+     * Gets a value indicating the Name of the StreamSegment.
+     * @return The Name of the StreamSegment.
+     */
+    public String getStreamSegmentName() {
+        return this.streamSegmentName;
+    }
+
+    /**
+     * Gets a value indicating the Id of the StreamSegment.
+     * @return The Id of the StreamSegment.
+     */
+    public long getStreamSegmentId() {
+        return this.streamSegmentId;
+    }
+
+    /**
+     * Gets a value indicating whether this Segment's Metadata is to be pinned to memory.
+     *
+     * @return True if pinned, false otherwise.
+     */
+    public boolean isPinned() {
+        return this.pinned;
+    }
+
+    /**
+     * Indicates that this Segment's Metadata is to be pinned to memory.
+     */
+    public void markPinned() {
+        this.pinned = true;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "%s, Id = %s, Name = %s, Pinned = %s",
+                super.toString(),
+                toString(getStreamSegmentId(), ContainerMetadata.NO_STREAM_SEGMENT_ID),
+                getStreamSegmentName(),
+                isPinned());
+    }
+
+    //endregion
+
+    static class Serializer extends OperationSerializer<PinSegmentOperation> {
+        private static final int STATIC_LENGTH = 4 * Long.BYTES + 2 * Byte.BYTES;
+
+        @Override
+        protected OperationBuilder<PinSegmentOperation> newBuilder() {
+            return new OperationBuilder<>(new PinSegmentOperation());
+        }
+
+        @Override
+        protected byte getWriteVersion() {
+            return 0;
+        }
+
+        @Override
+        protected void declareVersions() {
+            version(0).revision(0, this::write00, this::read00);
+        }
+
+        @Override
+        protected void beforeSerialization(PinSegmentOperation o) {
+            super.beforeSerialization(o);
+            Preconditions.checkState(o.streamSegmentId != ContainerMetadata.NO_STREAM_SEGMENT_ID, "StreamSegment Id has not been assigned.");
+        }
+
+        private void write00(PinSegmentOperation o, RevisionDataOutput target) throws IOException {
+            target.writeLong(o.getSequenceNumber());
+            target.writeLong(o.streamSegmentId);
+            target.writeUTF(o.streamSegmentName);
+            target.writeBoolean(o.pinned);
+        }
+
+        private void read00(RevisionDataInput source, OperationBuilder<PinSegmentOperation> b) throws IOException {
+            b.instance.setSequenceNumber(source.readLong());
+            b.instance.streamSegmentId = source.readLong();
+            b.instance.streamSegmentName = source.readUTF();
+            b.instance.pinned = source.readBoolean();
+        }
+    }
+}

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataCleanerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataCleanerTests.java
@@ -260,7 +260,8 @@ public class MetadataCleanerTests extends ThreadPooledTestSuite {
                     (s, sp, pin, timeout) -> Futures.failedFuture(new UnsupportedOperationException()),
                     (s, timeout) -> Futures.failedFuture(new UnsupportedOperationException()),
                     (s, timeout) -> Futures.failedFuture(new UnsupportedOperationException()),
-                    () -> Futures.failedFuture(new UnsupportedOperationException()));
+                    () -> Futures.failedFuture(new UnsupportedOperationException()),
+                    (s, sp, pin, timeout) -> Futures.failedFuture(new UnsupportedOperationException()));
 
             this.metadataStore = new TestMetadataStore(connector);
             this.cleaner = new MetadataCleaner(CONFIG, this.metadata, this.metadataStore, this.cleanedUpMetadata::addAll, executorService(), "");

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/MetadataStoreTestBase.java
@@ -892,7 +892,15 @@ public abstract class MetadataStoreTestBase extends ThreadPooledTestSuite {
                     }
                     return CompletableFuture.completedFuture(null);
                 },
-                runCleanup);
+                runCleanup,
+                (id, sp, pin, timeout) -> {
+                    Assert.assertNotEquals("PinSegmentOperation with no segment id.", ContainerMetadata.NO_STREAM_SEGMENT_ID, id);
+                    UpdateableSegmentMetadata sm = metadata.mapStreamSegmentId(sp.getName(), id);
+                    if (pin) {
+                        sm.markPinned();
+                    }
+                    return CompletableFuture.completedFuture(pin);
+                });
 
         return createTestContext(connector);
     }
@@ -950,8 +958,9 @@ public abstract class MetadataStoreTestBase extends ThreadPooledTestSuite {
         @Setter
         private LazyDeleteSegment lazyDeleteSegment;
 
-        TestConnector(UpdateableContainerMetadata metadata, MapSegmentId mapSegmentId, LazyDeleteSegment lazyDeleteSegment, Supplier<CompletableFuture<Void>> runCleanup) {
-            super(metadata, mapSegmentId, (name, timeout) -> CompletableFuture.completedFuture(null), lazyDeleteSegment, runCleanup);
+        TestConnector(UpdateableContainerMetadata metadata, MapSegmentId mapSegmentId, LazyDeleteSegment lazyDeleteSegment,
+                      Supplier<CompletableFuture<Void>> runCleanup, PinSegment pinSegment) {
+            super(metadata, mapSegmentId, (name, timeout) -> CompletableFuture.completedFuture(null), lazyDeleteSegment, runCleanup, pinSegment);
             reset();
         }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/ContainerMetadataUpdateTransactionTests.java
@@ -50,6 +50,7 @@ import io.pravega.segmentstore.server.logs.operations.DeleteSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.MergeSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.MetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.Operation;
+import io.pravega.segmentstore.server.logs.operations.PinSegmentOperation;
 import io.pravega.segmentstore.server.logs.operations.StorageMetadataCheckpointOperation;
 import io.pravega.segmentstore.server.logs.operations.StorageOperation;
 import io.pravega.segmentstore.server.logs.operations.StreamSegmentAppendOperation;
@@ -1162,6 +1163,75 @@ public class ContainerMetadataUpdateTransactionTests {
         txn2.commit(metadata);
         val truncatedMetadata = metadata.getStreamSegmentMetadata(metadata.getStreamSegmentId(truncateMap.getStreamSegmentName(), false));
         Assert.assertEquals("Unexpected startOffset for over-zealously truncated segment.", truncatedMetadata.getLength(), truncatedMetadata.getStartOffset());
+    }
+
+    /**
+     * Tests the preProcessOperation and acceptOperation methods with PinSegmentOperation operations.
+     */
+    @Test
+    public void testProcessPinSegmentOperation() throws ContainerException, StreamSegmentException {
+        long mapSequenceNumber = 1234;
+        UpdateableContainerMetadata metadata = createBlankMetadata();
+
+        // Part 1: recovery mode (no-op).
+        metadata.enterRecoveryMode();
+        val txn1 = createUpdateTransaction(metadata);
+        val pinnedSegment = new PinSegmentOperation("pinSegment", SEGMENT_ID, true);
+        // The operation is related to a non-existent Segment id, so it should fail.
+        AssertExtensions.assertThrows(MetadataUpdateException.class, () -> txn1.preProcessOperation(pinnedSegment));
+        Assert.assertNull("preProcessOperation modified the current transaction.", txn1.getStreamSegmentMetadata(pinnedSegment.getStreamSegmentId()));
+        Assert.assertNull("preProcessOperation modified the underlying metadata.", metadata.getStreamSegmentMetadata(pinnedSegment.getStreamSegmentId()));
+        // Now, let's create a Segment with that id.
+        StreamSegmentMapOperation mapOperation = createMap("pinSegment");
+        txn1.preProcessOperation(mapOperation);
+        // In recovery mode, the operation has already been written and has a segment id and a sequence number.
+        mapOperation.setStreamSegmentId(SEGMENT_ID);
+        mapOperation.setSequenceNumber(mapSequenceNumber);
+        // Now, it should be accepted.
+        txn1.acceptOperation(mapOperation);
+        txn1.commit(metadata);
+        Assert.assertEquals("preProcessOperation did modify the StreamSegmentId on the operation in recovery mode.",
+                SEGMENT_ID, mapOperation.getStreamSegmentId());
+        // In this case, we have not set the pinned flag to the map operation.
+        Assert.assertFalse("preProcessOperation did modify pinned flag on the operation in recovery mode.", mapOperation.isPinned());
+        Assert.assertFalse(txn1.getStreamSegmentMetadata(SEGMENT_ID).isPinned());
+        // With the Segment being mapped, we can now execute the PinSegmentOperation.
+        val txn2 = createUpdateTransaction(metadata);
+        txn2.preProcessOperation(pinnedSegment);
+        txn2.acceptOperation(pinnedSegment);
+        txn2.commit(metadata);
+        // After commit, the Segment should be pinned in metadata.
+        Assert.assertTrue(txn2.getStreamSegmentMetadata(SEGMENT_ID).isPinned());
+        Assert.assertTrue(metadata.getStreamSegmentMetadata(SEGMENT_ID).isPinned());
+
+        // Now without recovery mode.
+        metadata = createBlankMetadata();
+        long generatedSegmentId = 0;
+        val pinnedSegment2 = new PinSegmentOperation("pinSegment", generatedSegmentId, true);
+        val txn3 = createUpdateTransaction(metadata);
+        // The operation is related to a non-existent Segment id, so it should fail.
+        AssertExtensions.assertThrows(MetadataUpdateException.class, () -> txn3.preProcessOperation(pinnedSegment2));
+        Assert.assertNull("preProcessOperation modified the current transaction.", txn3.getStreamSegmentMetadata(pinnedSegment2.getStreamSegmentId()));
+        Assert.assertNull("preProcessOperation modified the underlying metadata.", metadata.getStreamSegmentMetadata(pinnedSegment2.getStreamSegmentId()));
+        // Now, let's create a Segment with that id.
+        mapOperation = createMap("pinSegment");
+        txn3.preProcessOperation(mapOperation);
+        // Now, it should be accepted.
+        txn3.acceptOperation(mapOperation);
+        txn3.commit(metadata);
+        Assert.assertEquals("preProcessOperation did modify the StreamSegmentId on the operation in recovery mode.",
+                generatedSegmentId, mapOperation.getStreamSegmentId());
+        // In this case, we have not set the pinned flag to the map operation.
+        Assert.assertFalse("preProcessOperation did modify pinned flag on the operation in recovery mode.", mapOperation.isPinned());
+        Assert.assertFalse(txn3.getStreamSegmentMetadata(generatedSegmentId).isPinned());
+        // With the Segment being mapped, we can now execute the PinSegmentOperation.
+        val txn4 = createUpdateTransaction(metadata);
+        txn4.preProcessOperation(pinnedSegment2);
+        txn4.acceptOperation(pinnedSegment2);
+        txn4.commit(metadata);
+        // After commit, the Segment should be pinned in metadata.
+        Assert.assertTrue(txn4.getStreamSegmentMetadata(generatedSegmentId).isPinned());
+        Assert.assertTrue(metadata.getStreamSegmentMetadata(generatedSegmentId).isPinned());
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/OperationComparer.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/OperationComparer.java
@@ -174,6 +174,8 @@ public class OperationComparer {
             assertSame(message, (CheckpointOperationBase) expected, (CheckpointOperationBase) actual);
         } else if (expected instanceof StreamSegmentMapOperation) {
             assertSame(message, (StreamSegmentMapOperation) expected, (StreamSegmentMapOperation) actual);
+        } else if (expected instanceof PinSegmentOperation) {
+            assertSame(message, (PinSegmentOperation) expected, (PinSegmentOperation) actual);
         } else if (expected instanceof UpdateAttributesOperation) {
             assertSame(message, (UpdateAttributesOperation) expected, (UpdateAttributesOperation) actual);
         } else {
@@ -187,6 +189,12 @@ public class OperationComparer {
         Assert.assertEquals(message + " Unexpected StreamSegmentLength.", expected.getLength(), actual.getLength());
         Assert.assertEquals(message + " Unexpected StreamSegmentName.", expected.getStreamSegmentName(), actual.getStreamSegmentName());
         AssertExtensions.assertMapEquals(message + "Unexpected attributes.", expected.getAttributes(), actual.getAttributes());
+        Assert.assertEquals("Unexpected Pinned.", expected.isPinned(), actual.isPinned());
+    }
+
+    private void assertSame(String message, PinSegmentOperation expected, PinSegmentOperation actual) {
+        Assert.assertEquals(message + " Unexpected StreamSegmentId.", expected.getStreamSegmentId(), actual.getStreamSegmentId());
+        Assert.assertEquals(message + " Unexpected StreamSegmentName.", expected.getStreamSegmentName(), actual.getStreamSegmentName());
         Assert.assertEquals("Unexpected Pinned.", expected.isPinned(), actual.isPinned());
     }
 

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/OperationTestsBase.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/OperationTestsBase.java
@@ -75,6 +75,7 @@ public abstract class OperationTestsBase<T extends Operation> {
         T op = createOperation(random);
         op.resetSequenceNumber(1234);
         Assert.assertEquals(1234, op.getSequenceNumber());
+        Assert.assertNotNull(op.toString());
     }
 
     /**

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/PinSegmentOperationTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/logs/operations/PinSegmentOperationTests.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.server.logs.operations;
+
+import java.util.Random;
+
+/**
+ * Unit tests for PinSegmentOperation class.
+ */
+public class PinSegmentOperationTests extends OperationTestsBase<PinSegmentOperation> {
+
+    @Override
+    protected PinSegmentOperation createOperation(Random random) {
+        return new PinSegmentOperation("pinSegmentOperation", 1234, true);
+    }
+}


### PR DESCRIPTION
**Change log description**  
Creates a new operation to pin a Segment to memory on demand (`PinSegmentOperation`). This allows to be certain that a Segment is actually pinned to memory whenever `MetadataStore::registerPinnedSegment()` is called.

**Purpose of the change**  
Fixes #6616.

**What the code does**  
A pinned Segment is guaranteed to not be evicted from in memory metadata during metadata cleanup. While this is true, we found the problem that a Segment may not be marked as pinned when it was supposed to be. The main reason is that the "pinned" flag is initially set by `MapStreamSegmentOperation`, which sets this flag in memory, but not persistently stored in metadata (like any other flags such as `sealed` or `deleted`). Apart from this, the `pinned` flag can also be "refreshed in memory" as it is copied over from one metadata update operation in a Segment to another. However, it may be the case that, upon a container recovery, the is no recent metadata update operation for a Segment beyond the last truncation point. To make things worse, MetadataCheckpoints neither store information about if a Segment is pinned or not. Therefore, the behavior of when a Segment may stop being pinned is unpredictable and depends basically on the activity of that Segment (i.e., frequent Segment metadata operations) as well as the frequency log truncations, container recoveries and metadata cleanups.

To make a pinned Segment actually pinned, we need a new operation to change that particular metadata flag explicitly (`PinSegmentOperation`). To this end, we have done the following changes:
- Added a new log operation to mark a Segment as "pinned" (`PinSegmentOperation`).
- In `MetadataStore::submitAssignment()`, in the case a Segment already exists, we check whether it needs to be pinned or not. If it needs to be pinned, we issue a new `PinSegmentOperation`.
- Submitting the actual `PinSegmentOperation` is done at `StreamSegmentContainer::pinSegment()`.
- We have added the necessary changes for this new operation in `ContainerMetadataUpdateTransaction`.
- We have also added `PinSegmentOperation` in `OperationSerializer`.

**How to verify it**  
Added new tests for the new operation and logic added. System tests are passing.

_Log inspection in system tests_:
One characteristic symptom of this issue was visible in `ContainerEventProcessor`, apparently since day 0. In some cases, the `ContainerEventProcessor` was being closed, perhaps after some period of inactivity and a restart, with the following messages:
```
(EXPECTED MESSAGES)
2022-03-07 06:11:36,141 36908 [core-2] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-2]: Closing EventProcessor.
2022-03-07 06:11:36,142 36909 [core-2] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-3]: Closing EventProcessor.
2022-03-07 06:11:36,144 36911 [core-15] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2]: Closing 
2022-03-07 06:11:36,144 36911 [core-15] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-3]: Closing 
2022-03-07 06:20:17,855 558622 [core-14] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2]: Closing 
2022-03-07 06:20:17,855 558622 [core-14] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-3]: Closing 
2022-03-07 06:20:17,858 558625 [core-7] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-2]: Closing EventProcessor.

(UNEXPECTED MESSAGES)
2022-03-07 06:20:17,858 558625 [core-7] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-1828]: Closing EventProcessor.
2022-03-07 08:19:10,955 30548 [core-23] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-87224]: Closing EventProcessor.
```
The `ContainerEventProcessor` segments used by SLTS GC should be always the same (ids 2 and 3). While this happens, there are cases in which we see segment ids associated with `ContainerEventProcessor` that are much newer than that (e.g., `1828`, `87224`). This is the root cause of the problem being fixed here and is related with the metadata of the original Segments 2 and 3 being evicted from memory when it was not expected. From this point onwards, if `ContainerEventProcessor` does anything else that is not just closing (e.g., appending, truncating, reading), we will start seeing the problems described in issue #6616.

Note that the above logs are related to a system test build of Pravega 0.10. However, that fact that Pravega 0.10 does not include PR #6527, seems to safeguard the system from hitting issue #6616. The reason may be that, by truncating the internal Segment on each processing iteration, `ContainerEventProcessor` may be just updating the "lastUpdate" time for the Segment's metadata, thus preventing it getting evicted from in-memory metadata (but it does not mean that the Segment is pinned to memory). Also, looking at `0.11` system test logs, we do see the same behavior:

```
2022-03-07 10:01:52,690 291063 [core-26] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2]: Closing EventProcessor.
2022-03-07 10:01:52,690 291063 [core-26] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-3]: Closing EventProcessor.
2022-03-07 10:01:52,698 291071 [core-17] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-2]: Closing EventProcessor.
2022-03-07 10:01:52,698 291071 [core-17] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-3]: Closing EventProcessor.
2022-03-07 10:06:13,998 552371 [core-28] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2]: Closing EventProcessor.
2022-03-07 10:06:13,998 552371 [core-28] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-3]: Closing EventProcessor. 
2022-03-07 10:06:14,004 552377 [core-19] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-2]: Closing EventProcessor.
2022-03-07 10:06:14,004 552377 [core-19] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-27134]: Closing EventProcessor.
2022-03-07 10:55:22,551 3500924 [core-27] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2]: Closing EventProcessor.
2022-03-07 10:55:22,551 3500924 [core-27] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-46369]: Closing EventProcessor.
```

Also note that this problem happens even though PR #6527 refreshes the `DirectSegmentAccess` continuously.

Finally, looking at the logs with this PR, we do not observe any occurrence of `ContainerEventProcessor` using any Segment id that are not the expected ones:

```
2022-03-07 16:42:46,827 33215 [core-1] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-3]: Closing EventProcessor.
2022-03-07 16:42:46,843 33231 [core-14] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-2]: Closing 
2022-03-07 16:42:46,843 33231 [core-14] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-3]: Closing EventProcessor.
2022-03-07 16:51:31,755 558143 [core-20] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2]: Closing EventProcessor.
2022-03-07 16:51:31,755 558143 [core-20] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-3]: Closing EventProcessor.
2022-03-07 16:51:31,755 558143 [core-27] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-2]: Closing EventProcessor.
2022-03-07 16:51:31,755 558143 [core-27] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-3]: Closing EventProcessor.
2022-03-07 17:32:24,377 3010765 [core-29] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-2]: Closing EventProcessor.
2022-03-07 16:43:07,662 32223 [core-10] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2]: Closing EventProcessor. 
2022-03-07 16:43:07,663 32224 [core-10] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-3]: Closing EventProcessor. 
2022-03-07 17:33:45,654 70928 [core-28] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2]: Closing EventProcessor. 
2022-03-07 17:33:45,655 70929 [core-28] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-3]: Closing EventProcessor. 
2022-03-07 16:53:01,918 81964 [core-30] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2]: Closing EventProcessor.
2022-03-07 16:53:01,918 81964 [core-30] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-3]: Closing EventProcessor. 
2022-03-07 17:42:27,058 81821 [core-2] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2]: Closing EventProcessor.
```

And we also see the new message related to pinning Segments:

```
2022-03-07 17:47:28,334 3914722 [core-2] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[0]: Segment 3 has been pinned to memory.
2022-03-07 17:47:28,334 3914722 [core-20] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[2]: Segment 3 has been pinned to memory.
2022-03-07 18:13:47,716 5494104 [core-19] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[1]: Segment 1 has been pinned to memory.
```

_Local issue reproduction_:
I have repeated the same experiment as described in #6616 with Pravega deployed locally. I have not been able to reproduce the problem after several restarts, and now we see that `ContainerEventProcessor` segments are always pinned:
```
2022-03-08 11:37:10,404 4669 [core-28] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[1]: Segment 1 (_system/containers/metadata_1) is pinned? true needs to be pinned? false.
2022-03-08 11:37:10,404 4669 [core-29] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[0]: Segment 1 (_system/containers/metadata_0) is pinned? true needs to be pinned? false.
2022-03-08 11:37:10,406 4671 [core-29] INFO  i.p.s.s.c.TableMetadataStore - MetadataStore[0]: Metadata Segment pinned. Name = '_system/containers/metadata_0', Id = '1'
2022-03-08 11:37:10,406 4671 [core-28] INFO  i.p.s.s.c.TableMetadataStore - MetadataStore[1]: Metadata Segment pinned. Name = '_system/containers/metadata_1', Id = '1'
2022-03-08 11:37:10,409 4674 [core-21] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[1]: Segment 2 (_system/containers/event_processor_GC.queue.1_1) is pinned? true needs to be pinned? false.
2022-03-08 11:37:10,437 4702 [core-28] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[0]: Segment 2 (_system/containers/event_processor_GC.queue.0_0) is pinned? true needs to be pinned? false.
2022-03-08 11:37:10,453 4718 [core-28] INFO  i.p.c.c.AbstractThreadPoolService - EventProcessor[0-2]: Started.
2022-03-08 11:37:10,453 4718 [core-28] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[0-2] Starting processing.
2022-03-08 11:37:10,453 4718 [core-21] INFO  i.p.c.c.AbstractThreadPoolService - EventProcessor[1-2]: Started.
2022-03-08 11:37:10,454 4719 [core-21] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[1-2] Starting processing.
2022-03-08 11:37:10,454 4719 [core-28] INFO  i.p.s.s.c.ContainerEventProcessorImpl - ContainerEventProcessor[0]: EventProcessor GC.queue.0 created successfully.
2022-03-08 11:37:10,458 4723 [storage-io-93] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[0]: Segment 3 (_system/containers/event_processor_GC.failed.queue.0_0) is pinned? true needs to be pinned? false.
2022-03-08 11:37:10,455 4720 [core-21] INFO  i.p.s.s.c.ContainerEventProcessorImpl - ContainerEventProcessor[1]: EventProcessor GC.queue.1 created successfully.
2022-03-08 11:37:10,462 4727 [storage-io-94] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[1]: Segment 3 (_system/containers/event_processor_GC.failed.queue.1_1) is pinned? true needs to be pinned? false.
2022-03-08 11:37:10,462 4727 [storage-io-93] INFO  i.p.s.s.c.ContainerEventProcessorImpl - ContainerEventProcessor[0]: EventProcessor GC.failed.queue.0 created successfully.
2022-03-08 11:37:10,462 4727 [storage-io-94] INFO  i.p.s.s.c.ContainerEventProcessorImpl - ContainerEventProcessor[1]: EventProcessor GC.failed.queue.1 created successfully.
2022-03-08 11:37:11,183 5448 [core-15] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[2]: Segment 1 (_system/containers/metadata_2) is pinned? true needs to be pinned? false.
2022-03-08 11:37:11,183 5448 [core-15] INFO  i.p.s.s.c.TableMetadataStore - MetadataStore[2]: Metadata Segment pinned. Name = '_system/containers/metadata_2', Id = '1'
2022-03-08 11:37:11,184 5449 [core-15] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[2]: Segment 2 (_system/containers/event_processor_GC.queue.2_2) is pinned? true needs to be pinned? false.
2022-03-08 11:37:11,184 5449 [core-15] INFO  i.p.c.c.AbstractThreadPoolService - EventProcessor[2-2]: Started.
2022-03-08 11:37:11,185 5450 [core-15] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[2-2] Starting processing.
2022-03-08 11:37:11,185 5450 [core-15] INFO  i.p.s.s.c.ContainerEventProcessorImpl - ContainerEventProcessor[2]: EventProcessor GC.queue.2 created successfully.
2022-03-08 11:37:11,188 5453 [storage-io-157] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[2]: Segment 3 (_system/containers/event_processor_GC.failed.queue.2_2) is pinned? true needs to be pinned? false.
2022-03-08 11:37:11,189 5454 [storage-io-157] INFO  i.p.s.s.c.ContainerEventProcessorImpl - ContainerEventProcessor[2]: EventProcessor GC.failed.queue.2 created successfully.
2022-03-08 11:37:11,454 5719 [core-14] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[1]: Segment 2 (_system/containers/event_processor_GC.queue.1_1) is pinned? true needs to be pinned? false.
2022-03-08 11:37:11,454 5719 [core-30] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[0]: Segment 2 (_system/containers/event_processor_GC.queue.0_0) is pinned? true needs to be pinned? false.
2022-03-08 11:37:11,553 5818 [core-16] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[3]: Segment 1 (_system/containers/metadata_3) is pinned? true needs to be pinned? false.
2022-03-08 11:37:11,553 5818 [core-16] INFO  i.p.s.s.c.TableMetadataStore - MetadataStore[3]: Metadata Segment pinned. Name = '_system/containers/metadata_3', Id = '1'
2022-03-08 11:37:11,553 5818 [core-14] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[3]: Segment 2 (_system/containers/event_processor_GC.queue.3_3) is pinned? true needs to be pinned? false.
2022-03-08 11:37:11,554 5819 [core-14] INFO  i.p.c.c.AbstractThreadPoolService - EventProcessor[3-2]: Started.
2022-03-08 11:37:11,554 5819 [core-14] INFO  i.p.s.s.c.ContainerEventProcessorImpl - EventProcessor[3-2] Starting processing.
2022-03-08 11:37:11,554 5819 [core-14] INFO  i.p.s.s.c.ContainerEventProcessorImpl - ContainerEventProcessor[3]: EventProcessor GC.queue.3 created successfully.
2022-03-08 11:37:11,555 5820 [storage-io-64] INFO  i.p.s.s.containers.MetadataStore - MetadataStore[3]: Segment 3 (_system/containers/event_processor_GC.failed.queue.3_3) is pinned? true needs to be pinned? false.
2022-03-08 11:37:11,556 5821 [storage-io-64] INFO  i.p.s.s.c.ContainerEventProcessorImpl - ContainerEventProcessor[3]: EventProcessor GC.failed.queue.3 created successfully.
```
_Backward compatibility_:
The only issue I have been able to detect is related to backward compatibility. That is, if we use this change, we introduce a new operation that previous versions will not be able to deserialize. Thus, if during a cluster upgrade, we have some instances that have already started and include this change and add a `PinSegmentOperation`, if there is a rollback to the prior version (without this change), it may cause the system to get stuck (we may need to remove that `PinSegmentOperation` manually via log repair tool):
```
Recovery FAILED: 275 DataFrame(s) containing 290 Operation(s) were able to be recovered.
io.pravega.segmentstore.server.DataCorruptionException: Deserialization failed.
	at io.pravega.segmentstore.server.logs.DataFrameReader.getNext(DataFrameReader.java:114)
	at io.pravega.segmentstore.server.logs.RecoveryProcessor.recoverAllOperations(RecoveryProcessor.java:171)
	at io.pravega.segmentstore.server.logs.RecoveryProcessor.performRecovery(RecoveryProcessor.java:103)
	at io.pravega.segmentstore.server.logs.DebugRecoveryProcessor.performRecovery(DebugRecoveryProcessor.java:51)
	at io.pravega.cli.admin.bookkeeper.ContainerRecoverCommand.performRecovery(ContainerRecoverCommand.java:78)
	at io.pravega.cli.admin.bookkeeper.ContainerRecoverCommand.execute(ContainerRecoverCommand.java:52)
	at io.pravega.cli.admin.AdminCLIRunner.execCommand(AdminCLIRunner.java:136)
	at io.pravega.cli.admin.AdminCLIRunner.processCommand(AdminCLIRunner.java:123)
	at io.pravega.cli.admin.AdminCLIRunner.interactiveMode(AdminCLIRunner.java:104)
	at io.pravega.cli.admin.AdminCLIRunner.doMain(AdminCLIRunner.java:89)
	at io.pravega.cli.admin.AdminCLIRunner.main(AdminCLIRunner.java:69)
Caused by: io.pravega.common.io.SerializationException: No serializer found for object type 11.
	at io.pravega.common.io.serialization.VersionedSerializer.ensureCondition(VersionedSerializer.java:168)
	at io.pravega.common.io.serialization.VersionedSerializer$MultiType.deserialize(VersionedSerializer.java:699)
	at io.pravega.segmentstore.server.logs.DataFrameReader.getNext(DataFrameReader.java:98)
```
An alternative to this may be to set the `pinned` flag in `MetadataCheckpoint` and see if `VersionedSerializer` can handler this compatibility problem.

