### PR TITLE
Issue 6629: Reader creation failed in Standalone mode

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -378,7 +378,7 @@ public class ControllerService {
             final long createTimestamp, long requestId) {
         validate(streamConfig, createTimestamp);
         try {
-            NameUtils.validateUserStreamName(stream);
+            NameUtils.validateStreamName(stream);
         } catch (IllegalArgumentException | NullPointerException e) {
             log.error(requestId, "Create stream failed due to invalid stream name {}", stream);
             return CompletableFuture.completedFuture(

--- a/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithStreamTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/ControllerServiceWithStreamTest.java
@@ -189,6 +189,7 @@ public abstract class ControllerServiceWithStreamTest {
     @Test(timeout = 5000)
     public void createStreamTest() throws Exception {
         String stream = "create";
+        String createStream = "_readerGroupStream";
         final ScalingPolicy policy1 = ScalingPolicy.fixed(2);
         final StreamConfiguration configuration1 = StreamConfiguration.builder()
                                                                       .scalingPolicy(policy1).build();
@@ -207,14 +208,18 @@ public abstract class ControllerServiceWithStreamTest {
         Controller.CreateStreamStatus streamStatus = consumer.createStream(SCOPE, stream, configuration1, start, 0L).get();
         assertEquals(Controller.CreateStreamStatus.Status.SUCCESS, streamStatus.getStatus());
 
-        // there will be two invocations because we also create internal mark stream
-        verify(streamStore, times(2)).createStream(anyString(), anyString(), any(), anyLong(), any(), any());
+        // create stream starting with underscore
+        Controller.CreateStreamStatus createStreamStatus = consumer.createStream(SCOPE, createStream, configuration1, start, 0L).get();
+        assertEquals(Controller.CreateStreamStatus.Status.SUCCESS, createStreamStatus.getStatus());
+
+        // there will be two invocations per call because we also create internal mark stream
+        verify(streamStore, times(4)).createStream(anyString(), anyString(), any(), anyLong(), any(), any());
         
         streamStatus = consumer.createInternalStream(SCOPE, stream, configuration1, start, 0L).get();
         assertEquals(Controller.CreateStreamStatus.Status.STREAM_EXISTS, streamStatus.getStatus());
 
         // verify that create stream is not called again
-        verify(streamStore, times(2)).createStream(anyString(), anyString(), any(), anyLong(), any(), any());
+        verify(streamStore, times(4)).createStream(anyString(), anyString(), any(), anyLong(), any(), any());
     }
 
     @Test(timeout = 5000)

--- a/documentation/src/docs/beginner_dev_guide.md
+++ b/documentation/src/docs/beginner_dev_guide.md
@@ -124,8 +124,6 @@ Add the below snippet to dependencies section of build.gradle in the app directo
 // https://mvnrepository.com/artifact/io.pravega/pravega-client
 implementation group: 'io.pravega', name: 'pravega-client', version: '0.9.0'
 ```
-**Note:** The version of Pravega standalone should be same as the client version used above
-
 Invoke `gradle run` to run the project.
 
 

--- a/documentation/src/docs/beginner_dev_guide.md
+++ b/documentation/src/docs/beginner_dev_guide.md
@@ -124,6 +124,8 @@ Add the below snippet to dependencies section of build.gradle in the app directo
 // https://mvnrepository.com/artifact/io.pravega/pravega-client
 implementation group: 'io.pravega', name: 'pravega-client', version: '0.9.0'
 ```
+**Note:** The version of Pravega standalone should be same as the client version used above
+
 Invoke `gradle run` to run the project.
 
 


### PR DESCRIPTION
Signed-off-by: Shashwat Sharma <shashwat_sharma@dell.com>

**Change log description**  
Currently if the server is on the latest version and client is of any previous version older than Pravega 0.10.0, with the updated validation for `createStream()`, it fails as the call to create internal stream goes to `createStream()` method of `ControllerService.java` while creating a reader group. This breaks backward compatibility. So, in order to keep the compatibility intact, update the validation for the stream name is `createStream()` method.

**Purpose of the change**  
Fixes #6629 

**How to verify it**  
Use Pravega 0.9.0 or any earlier version as client and use this version of master to run Pravega in standalone mode and create a reader group and the create should be successful.