### PR TITLE
Issue 6657 : Admin CLI : Run sanity test against LTS

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
@@ -283,13 +283,14 @@ public class UtilsWrapper {
                             Preconditions.checkArgument(Arrays.equals(testData, readData), "The arrays after reading the bytes are equal.");
                         })
                         .thenRunAsync(() -> chunkedSegmentStorage.getChunkStorage().delete(ChunkHandle.readHandle(chunkName)), chunkedSegmentStorage.getExecutor()),chunkedSegmentStorage.getExecutor())
-                .whenCompleteAsync((v, e) -> {
+                .handleAsync((v, e) -> {
                     if(isCreated.get()){
                      chunkedSegmentStorage.getChunkStorage().delete(ChunkHandle.readHandle(chunkName));
                     }
                     if(e != null){
                         throw new CompletionException(Exceptions.unwrap(e));
                     }
+                    return v;
                 }, chunkedSegmentStorage.getExecutor());
     }
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
@@ -16,6 +16,7 @@
 package io.pravega.segmentstore.storage.chunklayer;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import io.pravega.common.Exceptions;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.segmentstore.contracts.ExtendedChunkInfo;
@@ -269,7 +270,7 @@ public class UtilsWrapper {
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
     public CompletableFuture<Void> checkChunkSegmentStorageSanity(String chunkName, int dataSize) {
-        Preconditions.checkNotNull(chunkName, "chunkName");
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(chunkName), "chunk name must not be null or empty");
         Preconditions.checkArgument(chunkName.length() > 0, "chunkName");
         Preconditions.checkArgument(dataSize >= 0, "dataSize is not null!");
         byte[] testData = new byte[dataSize];

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
@@ -267,8 +267,8 @@ public class UtilsWrapper {
         byte[] readData = new byte[dataSize];
         InputStream inputStream = new ByteArrayInputStream(testData);
         Preconditions.checkNotNull(chunkName, "chunkName");
+        Preconditions.checkArgument(dataSize >= 0, "dataSize is not null!");
         AtomicBoolean isCreated = new AtomicBoolean();
-        CompletableFuture<Void> result = new CompletableFuture<>();
 
         return chunkedSegmentStorage.getChunkStorage().createWithContent(chunkName, testData.length, inputStream)
                 .thenComposeAsync(v -> {
@@ -280,7 +280,7 @@ public class UtilsWrapper {
                         .thenAcceptAsync(doesExists -> Preconditions.checkState(doesExists, "The given chunk doesn't exist!"), chunkedSegmentStorage.getExecutor())
                         .thenComposeAsync(v -> chunkedSegmentStorage.getChunkStorage().read(ChunkHandle.readHandle(chunkName), 0, readData.length, readData, 0), chunkedSegmentStorage.getExecutor())
                         .thenAcceptAsync(bytesRead -> {
-                            Preconditions.checkArgument(Arrays.equals(testData, readData), "The arrays after reading the bytes are equal.");
+                            Preconditions.checkArgument(Arrays.equals(testData, readData), "The arrays after reading the bytes are not equal.");
                         }, chunkedSegmentStorage.getExecutor())
                         .thenComposeAsync(v -> chunkedSegmentStorage.getChunkStorage().delete(ChunkHandle.writeHandle(chunkName)), chunkedSegmentStorage.getExecutor()),
                 chunkedSegmentStorage.getExecutor())

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
@@ -22,7 +22,6 @@ import io.pravega.segmentstore.contracts.ExtendedChunkInfo;
 import io.pravega.segmentstore.storage.metadata.BaseMetadataStore;
 
 import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
-import io.pravega.segmentstore.storage.metadata.StorageMetadataException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NonNull;
@@ -33,7 +32,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,7 +43,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.concurrent.CompletableFuture.completedStage;
 
 /**
  * This class contains various utils methods useful for administration of LTS.
@@ -271,7 +268,7 @@ public class UtilsWrapper {
      * If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    public CompletableFuture<Void> checkChunkSegmentStorageSanity (String chunkName, int dataSize) {
+    public CompletableFuture<Void> checkChunkSegmentStorageSanity(String chunkName, int dataSize) {
         Preconditions.checkNotNull(chunkName, "chunkName");
         Preconditions.checkArgument(chunkName.length() > 0, "chunkName");
         Preconditions.checkArgument(dataSize >= 0, "dataSize is not null!");
@@ -296,10 +293,10 @@ public class UtilsWrapper {
                         .thenComposeAsync(v -> chunkedSegmentStorage.getChunkStorage().delete(ChunkHandle.writeHandle(chunkName)), chunkedSegmentStorage.getExecutor()),
                 chunkedSegmentStorage.getExecutor())
                 .handleAsync((v, e) -> {
-                    if(isCreated.get()){
+                    if (isCreated.get()) {
                      chunkedSegmentStorage.getChunkStorage().delete(ChunkHandle.writeHandle(chunkName));
                     }
-                    if(e != null){
+                    if (e != null) {
                         throw new CompletionException(Exceptions.unwrap(e));
                     }
                     return v;

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
@@ -271,7 +271,6 @@ public class UtilsWrapper {
      */
     public CompletableFuture<Void> checkChunkSegmentStorageSanity(String chunkName, int dataSize) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(chunkName), "chunk name must not be null or empty");
-        Preconditions.checkArgument(chunkName.length() > 0, "chunkName");
         Preconditions.checkArgument(dataSize >= 0, "dataSize is not null!");
         byte[] testData = new byte[dataSize];
         byte[] readData = new byte[dataSize];

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapper.java
@@ -271,7 +271,7 @@ public class UtilsWrapper {
      */
     public CompletableFuture<Void> checkChunkSegmentStorageSanity(String chunkName, int dataSize) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(chunkName), "chunk name must not be null or empty");
-        Preconditions.checkArgument(dataSize >= 0, "dataSize is not null!");
+        Preconditions.checkArgument(dataSize >= 0, "dataSize should be positive integer");
         byte[] testData = new byte[dataSize];
         byte[] readData = new byte[dataSize];
         InputStream inputStream = new ByteArrayInputStream(testData);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapperTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapperTests.java
@@ -26,16 +26,15 @@ import lombok.Cleanup;
 import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -292,7 +291,6 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
         Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
-        val clazz = ChunkStorageException.class;
         doThrow(exceptionToThrow).when(spyChunkStorage).doCreateWithContent(any(), anyInt(), any());
 
         testSanity(spyChunkStorage, "Test Exception", ChunkStorageException.class);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapperTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapperTests.java
@@ -38,8 +38,7 @@ import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link UtilsWrapper}.
@@ -284,7 +283,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
     }
 
     @Test
-    public void testCheckChunkSegmentStorageSanity() throws Exception {
+    public void testSanityCreateChunk() throws Exception {
         val chunkName = "TestChunk";
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
@@ -295,7 +294,70 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         testSanity(spyChunkStorage, "Test Exception", ChunkStorageException.class);
     }
 
+    @Test
+    public void testSanityGetChunkInfo () throws Exception {
+        val chunkName = "TestChunk";
+        @Cleanup
+        BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
+        Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
+        val clazz = ChunkStorageException.class;
+        doThrow(exceptionToThrow).when(spyChunkStorage).doGetInfo(any());
+
+        testSanity(spyChunkStorage, "Test Exception", clazz);
+    }
+
+    @Test
+    public void testSanityWriteIntoChunk () throws Exception {
+        val chunkName = "TestChunk";
+        @Cleanup
+        BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
+        Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
+        val clazz = ChunkStorageException.class;
+        doThrow(exceptionToThrow).when(spyChunkStorage).doOpenWrite(any());
+
+        testSanity(spyChunkStorage, "Test Exception", clazz);
+
+    }
+
+    @Test
+    public void testSanityReadChunk () throws Exception {
+        val chunkName = "TestChunk";
+        @Cleanup
+        BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
+        Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
+        val clazz = ChunkStorageException.class;
+        doThrow(exceptionToThrow).when(spyChunkStorage).doRead(any(), anyLong(), anyInt(), any(), anyInt());
+
+        testSanity(spyChunkStorage, "Test Exception", clazz);
+    }
+
+    @Test
+    public void testSanityDeleteChunk () throws Exception {
+        val chunkName = "TestChunk";
+        @Cleanup
+        BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
+        Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
+        val clazz = ChunkStorageException.class;
+        doThrow(exceptionToThrow).when(spyChunkStorage).doDelete(any());
+
+        testSanity(spyChunkStorage, "Test Exception", clazz);
+    }
+
+//    @Test
+//    public void testSanityCheckChunkExists () throws Exception {
+//        val chunkName = "TestChunk";
+//        @Cleanup
+//        BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
+//        Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IllegalStateException("Test Exception"));
+//        val clazz = ChunkStorageException.class;
+//        doReturn(exceptionToThrow).when(spyChunkStorage).checkExists(any());
+//
+//        doReturn();
+//        testSanity(spyChunkStorage, "Test Exception", clazz);
+//    }
+
     private void testSanity(BaseChunkStorage spyChunkStorage, String message, Class classType) {
+        // Set up
         @Cleanup
         val metadataStore = new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
         @Cleanup
@@ -304,60 +366,13 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
 
         UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, 128, Duration.ZERO);
 
+        // Inject fault
         val result = wrapper.checkChunkSegmentStorageSanity("TestChunk", 100);
-        AssertExtensions.assertFutureThrows("Should throw an exception",
+        AssertExtensions.assertFutureThrows(message,
                 result,
                 ex -> {
                     val e = Exceptions.unwrap(ex);
                     return e.getClass().equals(classType) && e.getMessage().contains(message);
                 });
-    }
-
-    @Test
-    public void testCheckChunkSegmentStorageSanity1 () throws Exception {
-        val chunkName = "TestChunk";
-        @Cleanup
-        BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
-        Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
-        val clazz = ChunkStorageException.class;
-        doThrow(exceptionToThrow).when(spyChunkStorage).doGetInfo(any());
-
-        testSanity(spyChunkStorage, "", Exception.class);
-    }
-
-    @Test
-    public void testCheckChunkSegmentStorageSanity2 () throws Exception {
-        val chunkName = "TestChunk";
-        @Cleanup
-        BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
-        Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
-        val clazz = ChunkStorageException.class;
-        doThrow(exceptionToThrow).when(spyChunkStorage).doOpenWrite(any());
-
-        testSanity(spyChunkStorage, "", Exception.class);
-    }
-
-    @Test
-    public void testCheckChunkSegmentStorageSanity3 () throws Exception {
-        val chunkName = "TestChunk";
-        @Cleanup
-        BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
-        Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
-        val clazz = ChunkStorageException.class;
-        doThrow(exceptionToThrow).when(spyChunkStorage).doRead(any(), anyLong(), anyInt(), any(), anyInt());
-
-        testSanity(spyChunkStorage, "", Exception.class);
-    }
-
-    @Test
-    public void testCheckChunkSegmentStorageSanity4 () throws Exception {
-        val chunkName = "TestChunk";
-        @Cleanup
-        BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
-        Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
-        val clazz = ChunkStorageException.class;
-        doThrow(exceptionToThrow).when(spyChunkStorage).doDelete(any());
-
-        testSanity(spyChunkStorage, "", Exception.class);
     }
 }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapperTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapperTests.java
@@ -45,6 +45,9 @@ import static org.mockito.Mockito.*;
  */
 public class UtilsWrapperTests extends ThreadPooledTestSuite {
 
+    public static final int CONTAINER_ID = 42;
+    public static final int CONTAINER_EPOCH = 123;
+    public static final int BUFFER_SIZE = 128;
     Random random = new Random();
 
     @Test
@@ -82,11 +85,11 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         @Cleanup
         BaseMetadataStore metadataStore = new InMemoryMetadataStore(config, executorService());
         @Cleanup
-        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(42, chunkStorage, metadataStore, executorService(), config);
-        chunkedSegmentStorage.initialize(123);
+        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, chunkStorage, metadataStore, executorService(), config);
+        chunkedSegmentStorage.initialize(CONTAINER_EPOCH);
 
         // Insert metadata
-        TestUtils.insertMetadata(segmentName, 25, 123, lengthsInMetadata, lengthsInStorage, false, false, metadataStore, chunkedSegmentStorage);
+        TestUtils.insertMetadata(segmentName, 25, CONTAINER_EPOCH, lengthsInMetadata, lengthsInStorage, false, false, metadataStore, chunkedSegmentStorage);
         val chunkMetadataList = TestUtils.getChunkList(metadataStore, segmentName);
 
         // Delete few chunks
@@ -98,7 +101,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         }
 
         // Test
-        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, 128, Duration.ZERO);
+        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, BUFFER_SIZE, Duration.ZERO);
 
         // check the output
         checkExtendedChunkInfoList(wrapper, segmentName, shouldCheckStorage, lengthsInStorage, deletedChunkNames, chunkMetadataList);
@@ -144,14 +147,14 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         @Cleanup
         BaseMetadataStore metadataStore = new InMemoryMetadataStore(config, executorService());
         @Cleanup
-        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(42, chunkStorage, metadataStore, executorService(), config);
-        chunkedSegmentStorage.initialize(123);
+        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, chunkStorage, metadataStore, executorService(), config);
+        chunkedSegmentStorage.initialize(CONTAINER_EPOCH);
 
-        TestUtils.insertMetadata(segmentName, 25, 123, chunkLengths, chunkLengths, false, false, chunkedSegmentStorage.getMetadataStore(), chunkedSegmentStorage);
+        TestUtils.insertMetadata(segmentName, 25, CONTAINER_EPOCH, chunkLengths, chunkLengths, false, false, chunkedSegmentStorage.getMetadataStore(), chunkedSegmentStorage);
         val chunkMetadataList = TestUtils.getChunkList(chunkedSegmentStorage.getMetadataStore(), segmentName);
 
         // Test
-        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, 128, Duration.ZERO);
+        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, BUFFER_SIZE, Duration.ZERO);
 
         byte[][] expected = new byte[chunkMetadataList.size()][];
         int sum = 0;
@@ -198,17 +201,17 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         @Cleanup
         val metadataStore = new InMemoryMetadataStore(config, executorService());
         @Cleanup
-        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(42, chunkStorage, metadataStore, executorService(), config);
-        chunkedSegmentStorage.initialize(123);
+        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, chunkStorage, metadataStore, executorService(), config);
+        chunkedSegmentStorage.initialize(CONTAINER_EPOCH);
         val chunkSizes = new long[] {1};
 
         // Insert metadata
-        TestUtils.insertMetadata("a", 42, 10, chunkSizes, chunkSizes, true, true, chunkedSegmentStorage.getMetadataStore(), chunkedSegmentStorage);
-        TestUtils.insertMetadata("b", 42, 10, chunkSizes, chunkSizes, true, true, chunkedSegmentStorage.getMetadataStore(), chunkedSegmentStorage);
-        TestUtils.insertMetadata("c", 42, 10, chunkSizes, chunkSizes, true, true, chunkedSegmentStorage.getMetadataStore(), chunkedSegmentStorage);
+        TestUtils.insertMetadata("a", CONTAINER_ID, 10, chunkSizes, chunkSizes, true, true, chunkedSegmentStorage.getMetadataStore(), chunkedSegmentStorage);
+        TestUtils.insertMetadata("b", CONTAINER_ID, 10, chunkSizes, chunkSizes, true, true, chunkedSegmentStorage.getMetadataStore(), chunkedSegmentStorage);
+        TestUtils.insertMetadata("c", CONTAINER_ID, 10, chunkSizes, chunkSizes, true, true, chunkedSegmentStorage.getMetadataStore(), chunkedSegmentStorage);
 
         // Test
-        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, 128, Duration.ZERO);
+        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, BUFFER_SIZE, Duration.ZERO);
 
         wrapper.evictMetadataCache().join();
 
@@ -240,8 +243,8 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         @Cleanup
         val metadataStore = new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
         @Cleanup
-        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(42, chunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
-        chunkedSegmentStorage.initialize(123);
+        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, chunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+        chunkedSegmentStorage.initialize(CONTAINER_EPOCH);
 
         AssertExtensions.assertThrows("Should not allow null chunkStorage",
                 () -> new UtilsWrapper(null, 10, Duration.ZERO),
@@ -354,11 +357,11 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         @Cleanup
         val metadataStore = new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
         @Cleanup
-        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(42, spyChunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
-        chunkedSegmentStorage.initialize(123);
-        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, 128, Duration.ZERO);
+        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, spyChunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+        chunkedSegmentStorage.initialize(CONTAINER_EPOCH);
+        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, BUFFER_SIZE, Duration.ZERO);
 
-        doReturn(123).when(spyChunkStorage).doRead(any(), anyLong(), anyInt(), any(), anyInt());
+        doReturn(CONTAINER_EPOCH).when(spyChunkStorage).doRead(any(), anyLong(), anyInt(), any(), anyInt());
 
         testSanity(spyChunkStorage, "Bytes read are not equal to dataSize.", clazz);
     }
@@ -375,10 +378,10 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         @Cleanup
         val metadataStore = new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
         @Cleanup
-        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(42, chunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
-        chunkedSegmentStorage.initialize(123);
+        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, chunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+        chunkedSegmentStorage.initialize(CONTAINER_EPOCH);
 
-        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, 128, Duration.ZERO);
+        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, BUFFER_SIZE, Duration.ZERO);
 
         AssertExtensions.assertThrows("Null argument should throw an exception.",
                 () -> wrapper.checkChunkSegmentStorageSanity(null, 10),
@@ -440,10 +443,10 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         @Cleanup
         val metadataStore = new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
         @Cleanup
-        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(42, spyChunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
-        chunkedSegmentStorage.initialize(123);
+        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, spyChunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+        chunkedSegmentStorage.initialize(CONTAINER_EPOCH);
 
-        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, 128, Duration.ZERO);
+        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, BUFFER_SIZE, Duration.ZERO);
 
         wrapper.checkChunkSegmentStorageSanity(chunkName, 10).get();
         verify(spyChunkStorage).doCreateWithContent(anyString(), anyInt(), any());
@@ -454,10 +457,10 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         @Cleanup
         val metadataStore = new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService());
         @Cleanup
-        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(42, spyChunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
-        chunkedSegmentStorage.initialize(123);
+        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, spyChunkStorage, metadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+        chunkedSegmentStorage.initialize(CONTAINER_EPOCH);
 
-        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, 128, Duration.ZERO);
+        UtilsWrapper wrapper = new UtilsWrapper(chunkedSegmentStorage, BUFFER_SIZE, Duration.ZERO);
 
         // Inject fault
         val result = wrapper.checkChunkSegmentStorageSanity("TestChunk", 100);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapperTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapperTests.java
@@ -290,7 +290,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
      * @throws Exception Throws exception in case of any error.
      */
     @Test
-    public void testSanityCreateChunk() throws Exception {
+    public void testSanityWhenCreateChunkThrows() throws Exception {
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
         Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
@@ -304,7 +304,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
      * @throws Exception Throws exception in case of any error.
      */
     @Test
-    public void testSanityGetChunkInfo() throws Exception {
+    public void testSanityWhenGetChunkInfoThrows() throws Exception {
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
         Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
@@ -319,7 +319,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
      * @throws Exception Throws exception in case of any error.
      */
     @Test
-    public void testSanityWriteIntoChunk() throws Exception {
+    public void testSanityWhenWriteIntoChunkThrows() throws Exception {
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
         Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
@@ -327,7 +327,6 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         doThrow(exceptionToThrow).when(spyChunkStorage).doOpenWrite(any());
 
         testSanity(spyChunkStorage, "Test Exception", clazz);
-
     }
 
     /**
@@ -335,7 +334,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
      * @throws Exception Throws exception in case of any error.
      */
     @Test
-    public void testSanityCheckChunkExists() throws Exception {
+    public void testSanityWhenCheckChunkExistsThrows() throws Exception {
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
         val clazz = IllegalStateException.class;
@@ -350,7 +349,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
      * @throws Exception Throws exception in case of any error.
      */
     @Test
-    public void testSanityDataEquals() throws Exception {
+    public void testSanityDataEqualityFails() throws Exception {
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
         val clazz = IllegalStateException.class;
@@ -370,7 +369,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
      * Test to check if the dataSize and the chunkName is not null.
      */
     @Test
-    public void testSanityInValidChunkName() {
+    public void testSanityWhenInValidChunkNameThrows() {
         val emptyChunkName = "";
         @Cleanup
         BaseChunkStorage chunkStorage = new InMemoryChunkStorage(executorService());
@@ -406,7 +405,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
      * @throws Exception Throws exception in case of any error.
      */
     @Test
-    public void testSanityReadChunk() throws Exception {
+    public void testSanityWhenReadChunkThrows() throws Exception {
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
         Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
@@ -421,7 +420,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
      * @throws Exception Throws exception in case of any error.
      */
     @Test
-    public void testSanityDeleteChunk() throws Exception {
+    public void testSanityWhenDeleteChunkThrows() throws Exception {
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
         Exception exceptionToThrow = new ChunkStorageException("test", "Test Exception", new IOException("Test Exception"));
@@ -436,7 +435,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
      * @throws Exception Throws exception in case of any error.
      */
     @Test
-    public void testSanityCheckPass() throws Exception {
+    public void testSanityWhenCheckPassThrows() throws Exception {
         val chunkName = "TestChunk";
         @Cleanup
         BaseChunkStorage spyChunkStorage = spy(new InMemoryChunkStorage(executorService()));
@@ -452,6 +451,12 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
         verify(spyChunkStorage).doCreateWithContent(anyString(), anyInt(), any());
     }
 
+    /**
+     * To injecting fault to check the chunkSegmentStorage sanity.
+     * @param spyChunkStorage spy for {@link BaseChunkStorage}.
+     * @param message message thrown by the test exception.
+     * @param classType class type of the exception thrown.
+     */
     private void testSanity(BaseChunkStorage spyChunkStorage, String message, Class classType) {
         // Set up
         @Cleanup

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapperTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/UtilsWrapperTests.java
@@ -384,7 +384,7 @@ public class UtilsWrapperTests extends ThreadPooledTestSuite {
 
         AssertExtensions.assertThrows("Null argument should throw an exception.",
                 () -> wrapper.checkChunkSegmentStorageSanity(null, 10),
-                ex -> ex instanceof NullPointerException);
+                ex -> ex instanceof IllegalArgumentException);
 
         AssertExtensions.assertThrows("Null argument should throw an exception.",
                 () -> wrapper.checkChunkSegmentStorageSanity(emptyChunkName, 10),


### PR DESCRIPTION
**Change log description**  
Adding a new method checkChunkSegmentStorageSanity to the UtlilsWrapper class that performs sanity operations on chunk like create chunk, write to the chunk, check if the chunk exists, read back contents to the chunk and delete the chunk. 

**Purpose of the change**  
 Implements the UtilsWrapper functionality for #6657 

**What the code does**  
1 . The code adds following method to UtlisWrapper class.

```
public CompletableFuture<Void> checkChunkSegmentStorageSanity() {
// Create globally unique name for chunk
// Create + Write a chunk 
// Check chunk exists 
// Read back chunk contents
// Delete chunk
// Check chunk doesn't exist
}
```
2. Further, it tests the chunk sanity in the UtilsWrapperTest for chunk creation, correctly retrieving the chunk info, writing/ making modifications to the chunk, check if it exists, verifying the dataSize of the bytes read, verifying that the chunkName and dataSize is not null, reading contents appropriately and deleting the chunk.

**How to verify it**  
All the test should pass.