### PR TITLE
Issue 6688: LTS - Fix integer overflow in TruncateOperation.

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/TruncateOperation.java
@@ -144,7 +144,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
             String oldChunkName = segmentMetadata.getFirstChunk();
             String newChunkName = chunkedSegmentStorage.getNewChunkName(handle.getSegmentName(), segmentMetadata.getStartOffset());
             val startOffsetInChunk = segmentMetadata.getStartOffset() - segmentMetadata.getFirstChunkStartOffset();
-            val newLength = Math.toIntExact(currentMetadata.getLength() - startOffsetInChunk);
+            val newLength = currentMetadata.getLength() - startOffsetInChunk;
             log.debug("{} truncate - relocating first chunk op={}, segment={}, offset={} old={} new={} relocatedBytes={}.",
                     chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(),
                     offset, oldChunkName, newChunkName, newLength);
@@ -192,7 +192,7 @@ class TruncateOperation implements Callable<CompletableFuture<Void>> {
         return CompletableFuture.completedFuture(null);
     }
 
-    private CompletableFuture<Void> copyBytes(ChunkHandle writeHandle, ChunkHandle readHandle, long startOffset, int length) {
+    private CompletableFuture<Void> copyBytes(ChunkHandle writeHandle, ChunkHandle readHandle, long startOffset, long length) {
         val bytesToRead = new AtomicLong(length);
         val readAtOffset = new AtomicLong(startOffset);
         val writeAtOffset = new AtomicLong(0);

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageTests.java
@@ -3001,6 +3001,42 @@ public class ChunkedSegmentStorageTests extends ThreadPooledTestSuite {
                 new long[]{3L * Integer.MAX_VALUE + 3L});
     }
 
+    // This is a time-consuming test and should be eventually made optional
+    @Test
+    public void testRelocateHugeChunks() throws Exception {
+        val config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .relocateOnTruncateEnabled(true)
+                .maxBufferSizeForChunkDataTransfer(128 * 1024 * 128)
+                .build();
+        @Cleanup
+        TestContext testContext = getTestContext(config);
+        String testSegmentName = "testSegmentName";
+
+        testContext.insertMetadata(testSegmentName, 10L * Integer.MAX_VALUE, 1, new long[]{
+                10L * Integer.MAX_VALUE,
+                10L * Integer.MAX_VALUE,
+                10L * Integer.MAX_VALUE
+        });
+
+        // Truncate inside the 1st chunk
+        testTruncate(testContext,
+                testSegmentName,
+                10L * Integer.MAX_VALUE,
+                9L * Integer.MAX_VALUE - 1,
+                3,
+                30L * Integer.MAX_VALUE,
+                1L * Integer.MAX_VALUE + 1);
+
+        // Truncate inside the 3rd chunk
+        testTruncate(testContext,
+                testSegmentName,
+                10L * Integer.MAX_VALUE,
+                29L * Integer.MAX_VALUE - 1,
+                1,
+                30L * Integer.MAX_VALUE,
+                1L * Integer.MAX_VALUE + 1);
+    }
+
     @Test
     public void testWritesWithFlakyMetadataStore() throws Exception {
         val primes = new int[] { 2, 3, 5, 7, 11};

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/mocks/InMemorySimpleStorageTests.java
@@ -102,6 +102,12 @@ public class InMemorySimpleStorageTests extends SimpleStorageTests {
             // Allocating such huge byte arrays is not desirable with InMemoryChunkStorage.
         }
 
+        @Override
+        public void testRelocateHugeChunks(){
+            // Do not execute this test because it creates very large chunks (few multiples of Integer.MAX_VALUE).
+            // Allocating such huge byte arrays is not desirable with InMemoryChunkStorage.
+        }
+
         public class InMemorySimpleStorageTestContext extends ChunkedSegmentStorageTests.TestContext {
             InMemorySimpleStorageTestContext(ScheduledExecutorService executorService) throws Exception {
                 super(executorService);


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Fix integer overflow in TruncateOperation.

**Purpose of the change**  
Fixes #6688 

**What the code does**  
Fix integer overflow in TruncateOperation.

**How to verify it**  
Unit tests should pass.
