### PR TITLE
Issue 6711: Gradle fails when building Pravega locally in the IDE

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip


### PR DESCRIPTION
**Change log description**  
Upgrades Gradle wrapper to version 6.8.3.

**Purpose of the change**  
Fixes #6710.

**What the code does**  
Upgrades gradle to the last stable 6.x version to fix a problem that hits when building Pravega via IDE.

**How to verify it**  
With this change I can work with Pravega project in IDE.
