### PR TITLE
Issue 6713: Fixing flakiness in progressingWatermarkWithTimestampAggregationTimeout Test

### DIFF
--- a/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
@@ -536,8 +536,9 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
         assertEquals(150L, watermark2.getUpperTimeBound());
 
         AssertExtensions.assertEventuallyEquals(true, () -> {
-                Watermark w = watermarks.poll(20, TimeUnit.SECONDS);
-                return w.getLowerTimeBound() == 150 && w.getUpperTimeBound() == 150;
+                Watermark w = watermarks.poll();
+                boolean flag = w != null && w.getLowerTimeBound() == 150 && w.getUpperTimeBound() == 150;
+                return flag;
             }, 100000);
 
         // stream cut should be same

--- a/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
@@ -535,7 +535,10 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
         assertEquals(80L, watermark2.getLowerTimeBound());
         assertEquals(150L, watermark2.getUpperTimeBound());
 
-        AssertExtensions.assertEventuallyEquals(true, () -> { Watermark w = watermarks.poll(20, TimeUnit.SECONDS); return w.getLowerTimeBound()==150 && w.getUpperTimeBound() == 150; }, 100000);
+        AssertExtensions.assertEventuallyEquals(true, () -> {
+                Watermark w = watermarks.poll(20, TimeUnit.SECONDS);
+                return w.getLowerTimeBound() == 150 && w.getUpperTimeBound() == 150;
+            }, 100000);
 
         // stream cut should be same
         assertTrue(watermark2.getStreamCut().entrySet().stream().allMatch(x -> watermark1.getStreamCut().get(x.getKey()).equals(x.getValue())));

--- a/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
@@ -508,14 +508,14 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
                 new JavaSerializer<>(),
                 EventWriterConfig.builder().build());
         writer1.writeEvent("1").get();
-        writer1.noteTime(100L);
+        writer1.noteTime(80L);
 
         @Cleanup
         EventStreamWriter<String> writer2 = clientFactory.createEventWriter(streamName,
                 new JavaSerializer<>(),
                 EventWriterConfig.builder().build());
         writer2.writeEvent("2").get();
-        writer2.noteTime(102L);
+        writer2.noteTime(150L);
 
         // writer0, writer1 and writer2 should result in the first watermark with following time:
         // 1: 50L-102L
@@ -528,16 +528,14 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
 
         Watermark watermark1 = watermarks.poll();
         Watermark watermark2 = watermarks.poll();
-        Watermark watermark3 = watermarks.poll(10, TimeUnit.SECONDS);
 
         assertEquals(50L, watermark1.getLowerTimeBound());
-        assertEquals(102L, watermark1.getUpperTimeBound());
+        assertEquals(150L, watermark1.getUpperTimeBound());
 
-        assertEquals(100L, watermark2.getLowerTimeBound());
-        assertEquals(102L, watermark2.getUpperTimeBound());
+        assertEquals(80L, watermark2.getLowerTimeBound());
+        assertEquals(150L, watermark2.getUpperTimeBound());
 
-        assertEquals(102L, watermark3.getLowerTimeBound());
-        assertEquals(102L, watermark3.getUpperTimeBound());
+        AssertExtensions.assertEventuallyEquals(true, () -> { Watermark w = watermarks.poll(20, TimeUnit.SECONDS); return w.getLowerTimeBound()==150 && w.getUpperTimeBound() == 150; }, 100000);
 
         // stream cut should be same
         assertTrue(watermark2.getStreamCut().entrySet().stream().allMatch(x -> watermark1.getStreamCut().get(x.getKey()).equals(x.getValue())));
@@ -547,8 +545,7 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
         writer1.noteTime(90L);
 
         // no watermark should be emitted.
-        Watermark nullMark = watermarks.poll(10, TimeUnit.SECONDS);
-        assertNull(nullMark);
+        AssertExtensions.assertEventuallyEquals(null, () -> watermarks.poll(), 100000);
     }
 
     private void scale(Controller controller, Stream streamObj, StreamConfiguration configuration) {

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -63,19 +63,13 @@ public class AssertExtensions {
      * @throws Exception            If the is an assertion error, and exception from `eval`, or the thread is interrupted.
      */
     private static <T> void assertEventuallyEquals(T expected, Callable<T> eval, int checkIntervalMillis, long timeoutMillis) throws Exception {
+        T result = null;
         try {
-            TestUtils.await(() -> {
-                try {
-                    return (expected == null && eval.call() == null)
-                            || (expected != null && expected.equals(eval.call()));
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }, checkIntervalMillis, timeoutMillis);
+            result = TestUtils.awaitEvaluateExpr(expected, eval, checkIntervalMillis, timeoutMillis);
         } catch (TimeoutException e) {
-            throw new TimeoutException("Expected value: " + expected + " observed: " + eval.call());
+            throw new TimeoutException("Expected value: " + expected + " observed: " + result);
         }
-        assertEquals(expected, eval.call());
+        assertEquals(expected, result);
     }
 
     /**

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -60,7 +60,7 @@ public class AssertExtensions {
      * @param eval                  The function to test
      * @param checkIntervalMillis   The number of milliseconds to wait between two checks.
      * @param timeoutMillis         The timeout in milliseconds after which an assertion error should be thrown.
-     * @throws Exception            If the is an assertion error, and exception from `eval`, or the thread is interrupted.
+     * @throws Exception            If there is an assertion error, and exception from `eval`, or the thread is interrupted.
      */
     private static <T> void assertEventuallyEquals(T expected, Callable<T> eval, int checkIntervalMillis, long timeoutMillis) throws Exception {
         T result = null;

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -93,7 +93,7 @@ public class TestUtils {
         Supplier<Boolean> condition = null;
         long remainingMillis = timeoutMillis;
 
-        while (condition==null || !condition.get() && remainingMillis > 0) {
+        while (condition == null || !condition.get() && remainingMillis > 0) {
             try {
                 result = eval.call();
                 T finalResult = result;
@@ -107,7 +107,7 @@ public class TestUtils {
             remainingMillis -= checkFrequencyMillis;
         }
 
-        if (condition==null || !condition.get() && remainingMillis <= 0) {
+        if (condition == null || !condition.get() && remainingMillis <= 0) {
             throw new TimeoutException("Timeout expired prior to the condition becoming true.");
         }
 

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -86,8 +86,18 @@ public class TestUtils {
         }
     }
 
-    @SneakyThrows(InterruptedException.class)
-    public static <T> T awaitEvaluateExpr(T expected, Callable<T> eval, int checkFrequencyMillis, long timeoutMillis) throws TimeoutException {
+    /**
+     * Awaits the return value of the given expression to be equal to the expected value.
+     * @param <T>                  The type of the value to compare.
+     * @param expected             The expected return value.
+     * @param eval                 The function to test
+     * @param checkFrequencyMillis The number of millis to wait between successive checks of the condition.
+     * @param timeoutMillis        The maximum amount of time to wait.
+     * @throws Exception           If there is an assertion error, and exception from `eval`, or the thread is interrupted.
+     * @throws TimeoutException    If the condition was not met during the allotted time.
+     * @return the value returned by the function.
+     */
+    public static <T> T awaitEvaluateExpr(T expected, Callable<T> eval, int checkFrequencyMillis, long timeoutMillis) throws Exception, TimeoutException {
 
         T result = null;
         Supplier<Boolean> condition = null;


### PR DESCRIPTION
Signed-off-by: SrishT <Srishti.Thakkar@emc.com>

**Change log description**  
The integration test WatermarkingTest.progressingWatermarkWithTimestampAggregationTimeout has been failing intermittently because of its dependency on the timeout values, which is being fixed here.

**Purpose of the change**  
Fixes #6713 

**What the code does**  
Tries to overcome the dependence on a random timeout value for the generation of the subsequent watermark by making use of assertEventuallyEquals instead.

**How to verify it**  
All tests should pass
