### PR TITLE
Issue 6745: Handle Controller connectivity with ZK

### DIFF
--- a/controller/src/main/java/io/pravega/controller/store/client/StoreClientFactory.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/StoreClientFactory.java
@@ -121,37 +121,15 @@ public class StoreClientFactory {
         @Override
         @Synchronized
         public ZooKeeper newZooKeeper(String connectString, int sessionTimeout, Watcher watcher, boolean canBeReadOnly) throws Exception {
-            // prevent creating a new client, stick to the same client created earlier
-            // this trick prevents curator from re-creating ZK client on session expiry
             if (client == null) {
                 Exceptions.checkNotNullOrEmpty(connectString, "connectString");
                 Preconditions.checkArgument(sessionTimeout > 0, "sessionTimeout should be a positive integer");
                 this.connectString = connectString;
                 this.sessionTimeout = sessionTimeout;
                 this.canBeReadOnly = canBeReadOnly;
-                this.client = new ZooKeeper(connectString, sessionTimeout, watcher, canBeReadOnly);
-            } else {
-                try {
-                    Preconditions.checkArgument(this.connectString.equals(connectString), "connectString differs");
-                    Preconditions.checkArgument(this.sessionTimeout == sessionTimeout, "sessionTimeout differs");
-                    Preconditions.checkArgument(this.canBeReadOnly == canBeReadOnly, "canBeReadOnly differs");
-                    this.client.register(watcher);
-                } catch (IllegalArgumentException e) {
-                    log.warn("Input argument for new ZooKeeper client ({}, {}, {}) changed with respect to existing client ({}, {}, {}).",
-                        connectString, sessionTimeout, canBeReadOnly, this.connectString, this.sessionTimeout, this.canBeReadOnly);
-                    closeClient(client);
-                }
             }
+            this.client = new ZooKeeper(this.connectString, this.sessionTimeout, watcher, this.canBeReadOnly);
             return this.client;
-        }
-
-        private void closeClient(ZooKeeper client) {
-            try {
-                client.close();
-            } catch (Exception e) {
-                // We prevent throwing uncontrolled exceptions here, which may lead Curator to retry indefinitely.
-                log.warn("Exception when closing ZooKeeper client. {}", e.getMessage());
-            }
         }
     }
 

--- a/controller/src/main/java/io/pravega/controller/store/client/StoreClientFactory.java
+++ b/controller/src/main/java/io/pravega/controller/store/client/StoreClientFactory.java
@@ -128,6 +128,8 @@ public class StoreClientFactory {
                 this.sessionTimeout = sessionTimeout;
                 this.canBeReadOnly = canBeReadOnly;
             }
+            // Ensure that a new instance of Zookeeper clients in Curator are always created
+            // So it can be resolved to a new IP in the case of a Zookeeper instance restart.
             this.client = new ZooKeeper(this.connectString, this.sessionTimeout, watcher, this.canBeReadOnly);
             return this.client;
         }

--- a/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
+++ b/controller/src/test/java/io/pravega/controller/store/client/StoreClientFactoryTest.java
@@ -93,7 +93,7 @@ public class StoreClientFactoryTest extends ThreadPooledTestSuite {
         client.getZookeeperClient().getZooKeeper().getTestable().injectSessionExpiration();
         sessionExpiry.join();
 
-        // Check that, once closed by the ZKClientFactory, the client throws an expected exception (SessionExpiredException).
-        AssertExtensions.assertThrows(KeeperException.SessionExpiredException.class, () -> client.getData().forPath(testZNode));
+        // Check that, once closed by the ZKClientFactory, the client throws an expected exception (ConnectionLossException).
+        AssertExtensions.assertThrows(KeeperException.ConnectionLossException.class, () -> client.getData().forPath(testZNode));
     }
 }


### PR DESCRIPTION
Signed-off-by: Shashwat Sharma <shashwat_sharma@dell.com>

**Change log description**  
Updated the code to return a new instance of Curator client in case of zk restarts.

**Purpose of the change**  
Fixes #6745 

**What the code does**  
Currently the controller doesn't create a new instance of the curator client if the client is not null and it uses the same client to re-establish the connection which is not correct as the system may assign a new IP to the hostname of the new ZooKeeper instance. We see the below log line and the controller doesn't get re-connected
`Input argument for new ZooKeeper client (ip:port, ip:port, ip:port, 10000, false) changed with respect to existing client (cluster-zookeeper-client:port, 10000, false)`

**How to verify it**  
Jenkins builds are passing
Performed experiments in Kubernetes with 3 zk instances that has been intentionally restarted one after another several times (40+ times) and the Controller is able to re-connect and resume it's operation. Used Admin-cli to perform a few more operation as creating scope/listing scope to verify this further.
