### PR TITLE
Fixed Attributes.isUnmodifiable has equality bug

### DIFF
--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/Attributes.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/Attributes.java
@@ -138,7 +138,7 @@ public class Attributes {
      * @return True if immutable, false otherwise.
      */
     public static boolean isUnmodifiable(AttributeId attributeId) {
-        return attributeId == ATTRIBUTE_SEGMENT_TYPE || attributeId == ATTRIBUTE_ID_LENGTH;
+        return attributeId.equals(ATTRIBUTE_SEGMENT_TYPE) || attributeId.equals(ATTRIBUTE_ID_LENGTH);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: anju_das <anju.das@dell.com>

**Change log description**  
Attributes.isUnmodifiable has equality bug. Here we have corrected the code to use equals for comparison.


**Purpose of the change**  
Fixes #5742

**What the code does**  
Determines whether the given attribute cannot be modified once originally set on the Segment.

**How to verify it**  
(Optional: steps to verify that the changes are effective)