### PR TITLE
Issue 6748: Renaming getStreaminfo() and changing return type

### DIFF
--- a/client/src/main/java/io/pravega/client/admin/StreamManager.java
+++ b/client/src/main/java/io/pravega/client/admin/StreamManager.java
@@ -238,7 +238,7 @@ public interface StreamManager extends AutoCloseable {
      *
      * @param scopeName The scope of the stream.
      * @param streamName The stream name.
-     * @return stream information.
+     * @return A future representing {@link StreamInfo}.
      */
     @Beta
     CompletableFuture<StreamInfo> fetchStreamInfo(String scopeName, String streamName);

--- a/client/src/main/java/io/pravega/client/admin/StreamManager.java
+++ b/client/src/main/java/io/pravega/client/admin/StreamManager.java
@@ -241,7 +241,7 @@ public interface StreamManager extends AutoCloseable {
      * @return stream information.
      */
     @Beta
-    StreamInfo fetchStreamInfo(String scopeName, String streamName);
+    CompletableFuture<StreamInfo> fetchStreamInfo(String scopeName, String streamName);
 
     /**
      * Closes the stream manager.

--- a/client/src/main/java/io/pravega/client/admin/StreamManager.java
+++ b/client/src/main/java/io/pravega/client/admin/StreamManager.java
@@ -241,7 +241,7 @@ public interface StreamManager extends AutoCloseable {
      * @return stream information.
      */
     @Beta
-    StreamInfo getStreamInfo(String scopeName, String streamName);
+    StreamInfo fetchStreamInfo(String scopeName, String streamName);
 
     /**
      * Closes the stream manager.

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -290,11 +290,11 @@ public class StreamManagerImpl implements StreamManager {
     }
 
     @Override
-    public StreamInfo fetchStreamInfo(String scopeName, String streamName) {
+    public CompletableFuture<StreamInfo> fetchStreamInfo(String scopeName, String streamName) {
         NameUtils.validateUserStreamName(streamName);
         NameUtils.validateUserScopeName(scopeName);
         log.info("Fetching StreamInfo for scope/stream: {}/{}", scopeName, streamName);
-        return Futures.getThrowingException(fetchStreamInfo(Stream.of(scopeName, streamName)));
+        return fetchStreamInfo(Stream.of(scopeName, streamName));
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -290,11 +290,11 @@ public class StreamManagerImpl implements StreamManager {
     }
 
     @Override
-    public StreamInfo getStreamInfo(String scopeName, String streamName) {
+    public StreamInfo fetchStreamInfo(String scopeName, String streamName) {
         NameUtils.validateUserStreamName(streamName);
         NameUtils.validateUserScopeName(scopeName);
         log.info("Fetching StreamInfo for scope/stream: {}/{}", scopeName, streamName);
-        return Futures.getThrowingException(getStreamInfo(Stream.of(scopeName, streamName)));
+        return Futures.getThrowingException(fetchStreamInfo(Stream.of(scopeName, streamName)));
     }
 
     /**
@@ -303,7 +303,7 @@ public class StreamManagerImpl implements StreamManager {
      * @param stream The Stream.
      * @return A future representing {@link StreamInfo}.
      */
-    private CompletableFuture<StreamInfo> getStreamInfo(final Stream stream) {
+    private CompletableFuture<StreamInfo> fetchStreamInfo(final Stream stream) {
         // Fetch the stream configuration which includes the tags associated with the stream.
         CompletableFuture<StreamConfiguration> streamConfiguration = controller.getStreamConfiguration(stream.getScope(), stream.getStreamName());
         // Fetch the stream cut representing the current TAIL and current HEAD of the stream.

--- a/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
+++ b/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
@@ -267,7 +267,7 @@ public class StreamManagerImplTest {
                                                                                 .scalingPolicy(ScalingPolicy.fixed(3))
                                                                                 .build());
         // fetch StreamInfo.
-        StreamInfo info = streamManager.getStreamInfo(defaultScope, streamName);
+        StreamInfo info = streamManager.fetchStreamInfo(defaultScope, streamName);
 
         //validate results.
         assertEquals(defaultScope, info.getScope());
@@ -330,7 +330,7 @@ public class StreamManagerImplTest {
         streamManager.sealStream(defaultScope, streamName);
 
         //Fetch StreamInfo
-        StreamInfo info = streamManager.getStreamInfo(defaultScope, streamName);
+        StreamInfo info = streamManager.fetchStreamInfo(defaultScope, streamName);
 
         //validate results.
         assertEquals(defaultScope, info.getScope());

--- a/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
+++ b/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
@@ -74,6 +74,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import lombok.Cleanup;
 import org.junit.After;
@@ -267,7 +268,7 @@ public class StreamManagerImplTest {
                                                                                 .scalingPolicy(ScalingPolicy.fixed(3))
                                                                                 .build());
         // fetch StreamInfo.
-        StreamInfo info = streamManager.fetchStreamInfo(defaultScope, streamName);
+        StreamInfo info = streamManager.fetchStreamInfo(defaultScope, streamName).get();
 
         //validate results.
         assertEquals(defaultScope, info.getScope());
@@ -282,7 +283,7 @@ public class StreamManagerImplTest {
     }
 
     @Test(timeout = 10000)
-    public void testSealedStream() throws ConnectionFailedException {
+    public void testSealedStream() throws ConnectionFailedException, ExecutionException, InterruptedException {
         final String streamName = "stream";
         final Stream stream = new StreamImpl(defaultScope, streamName);
 
@@ -330,7 +331,7 @@ public class StreamManagerImplTest {
         streamManager.sealStream(defaultScope, streamName);
 
         //Fetch StreamInfo
-        StreamInfo info = streamManager.fetchStreamInfo(defaultScope, streamName);
+        StreamInfo info = streamManager.fetchStreamInfo(defaultScope, streamName).get();
 
         //validate results.
         assertEquals(defaultScope, info.getScope());

--- a/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
+++ b/client/src/test/java/io/pravega/client/admin/impl/StreamManagerImplTest.java
@@ -74,7 +74,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import lombok.Cleanup;
 import org.junit.After;
@@ -268,7 +267,7 @@ public class StreamManagerImplTest {
                                                                                 .scalingPolicy(ScalingPolicy.fixed(3))
                                                                                 .build());
         // fetch StreamInfo.
-        StreamInfo info = streamManager.fetchStreamInfo(defaultScope, streamName).get();
+        StreamInfo info = streamManager.fetchStreamInfo(defaultScope, streamName).join();
 
         //validate results.
         assertEquals(defaultScope, info.getScope());
@@ -283,7 +282,7 @@ public class StreamManagerImplTest {
     }
 
     @Test(timeout = 10000)
-    public void testSealedStream() throws ConnectionFailedException, ExecutionException, InterruptedException {
+    public void testSealedStream() throws ConnectionFailedException {
         final String streamName = "stream";
         final Stream stream = new StreamImpl(defaultScope, streamName);
 
@@ -331,7 +330,7 @@ public class StreamManagerImplTest {
         streamManager.sealStream(defaultScope, streamName);
 
         //Fetch StreamInfo
-        StreamInfo info = streamManager.fetchStreamInfo(defaultScope, streamName).get();
+        StreamInfo info = streamManager.fetchStreamInfo(defaultScope, streamName).join();
 
         //validate results.
         assertEquals(defaultScope, info.getScope());

--- a/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
@@ -187,7 +187,7 @@ public class MockStreamManager implements StreamManager, ReaderGroupManager {
     }
 
     @Override
-    public StreamInfo fetchStreamInfo(String scopeName, String streamName) {
+    public CompletableFuture<StreamInfo> fetchStreamInfo(String scopeName, String streamName) {
         throw new NotImplementedException("fetchStreamInfo");
     }
 

--- a/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
+++ b/client/src/test/java/io/pravega/client/stream/mock/MockStreamManager.java
@@ -187,8 +187,8 @@ public class MockStreamManager implements StreamManager, ReaderGroupManager {
     }
 
     @Override
-    public StreamInfo getStreamInfo(String scopeName, String streamName) {
-        throw new NotImplementedException("getStreamInfo");
+    public StreamInfo fetchStreamInfo(String scopeName, String streamName) {
+        throw new NotImplementedException("fetchStreamInfo");
     }
 
     @Override

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -176,7 +176,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
         // 3a. Fetch Segments using StreamCut.UNBOUNDED>
         ArrayList<SegmentRange> segmentsPostTruncation1 = Lists.newArrayList(batchClient.getSegments(Stream.of(SCOPE, STREAM), StreamCut.UNBOUNDED, StreamCut.UNBOUNDED).getIterator());
         // 3b. Fetch Segments using fetchStreamInfo() api.
-        StreamInfo streamInfo = streamManager.fetchStreamInfo(SCOPE, STREAM);
+        StreamInfo streamInfo = streamManager.fetchStreamInfo(SCOPE, STREAM).get();
         ArrayList<SegmentRange> segmentsPostTruncation2 = Lists.newArrayList(batchClient.getSegments(Stream.of(SCOPE, STREAM), streamInfo.getHeadStreamCut(), streamInfo.getTailStreamCut()).getIterator());
         // Validate results.
         validateSegmentCountAndEventCount(batchClient, segmentsPostTruncation1);

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -175,8 +175,8 @@ public class BatchClientTest extends ThreadPooledTestSuite {
         assertTrue("truncate stream", controllerWrapper.getController().truncateStream(SCOPE, STREAM, streamCut60L).join());
         // 3a. Fetch Segments using StreamCut.UNBOUNDED>
         ArrayList<SegmentRange> segmentsPostTruncation1 = Lists.newArrayList(batchClient.getSegments(Stream.of(SCOPE, STREAM), StreamCut.UNBOUNDED, StreamCut.UNBOUNDED).getIterator());
-        // 3b. Fetch Segments using getStreamInfo() api.
-        StreamInfo streamInfo = streamManager.getStreamInfo(SCOPE, STREAM);
+        // 3b. Fetch Segments using fetchStreamInfo() api.
+        StreamInfo streamInfo = streamManager.fetchStreamInfo(SCOPE, STREAM);
         ArrayList<SegmentRange> segmentsPostTruncation2 = Lists.newArrayList(batchClient.getSegments(Stream.of(SCOPE, STREAM), streamInfo.getHeadStreamCut(), streamInfo.getTailStreamCut()).getIterator());
         // Validate results.
         validateSegmentCountAndEventCount(batchClient, segmentsPostTruncation1);

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
@@ -164,10 +164,10 @@ public class StreamRecreationTest {
             assertEquals("Wrong event read in re-created stream", eventContent, readResult);
 
             // Delete the stream.
-            StreamInfo streamInfo = streamManager.fetchStreamInfo(myScope, myStream);
+            StreamInfo streamInfo = streamManager.fetchStreamInfo(myScope, myStream).get();
             assertFalse(streamInfo.isSealed());
             assertTrue("Unable to seal re-created stream.", streamManager.sealStream(myScope, myStream));
-            streamInfo = streamManager.fetchStreamInfo(myScope, myStream);
+            streamInfo = streamManager.fetchStreamInfo(myScope, myStream).get();
             assertTrue(streamInfo.isSealed());
             assertTrue("Unable to delete re-created stream.", streamManager.deleteStream(myScope, myStream));
         }

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
@@ -164,10 +164,10 @@ public class StreamRecreationTest {
             assertEquals("Wrong event read in re-created stream", eventContent, readResult);
 
             // Delete the stream.
-            StreamInfo streamInfo = streamManager.fetchStreamInfo(myScope, myStream).get();
+            StreamInfo streamInfo = streamManager.fetchStreamInfo(myScope, myStream).join();
             assertFalse(streamInfo.isSealed());
             assertTrue("Unable to seal re-created stream.", streamManager.sealStream(myScope, myStream));
-            streamInfo = streamManager.fetchStreamInfo(myScope, myStream).get();
+            streamInfo = streamManager.fetchStreamInfo(myScope, myStream).join();
             assertTrue(streamInfo.isSealed());
             assertTrue("Unable to delete re-created stream.", streamManager.deleteStream(myScope, myStream));
         }

--- a/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/StreamRecreationTest.java
@@ -164,10 +164,10 @@ public class StreamRecreationTest {
             assertEquals("Wrong event read in re-created stream", eventContent, readResult);
 
             // Delete the stream.
-            StreamInfo streamInfo = streamManager.getStreamInfo(myScope, myStream);
+            StreamInfo streamInfo = streamManager.fetchStreamInfo(myScope, myStream);
             assertFalse(streamInfo.isSealed());
             assertTrue("Unable to seal re-created stream.", streamManager.sealStream(myScope, myStream));
-            streamInfo = streamManager.getStreamInfo(myScope, myStream);
+            streamInfo = streamManager.fetchStreamInfo(myScope, myStream);
             assertTrue(streamInfo.isSealed());
             assertTrue("Unable to delete re-created stream.", streamManager.deleteStream(myScope, myStream));
         }

--- a/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
@@ -150,7 +150,7 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
 
         // Instantiate the batch client and assert it provides correct stream info.
         log.debug("Creating batch client.");
-        StreamInfo streamInfo = streamManager.getStreamInfo(SCOPE, stream.getStreamName());
+        StreamInfo streamInfo = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName());
         log.debug("Validating stream metadata fields.");
         assertEquals("Expected Stream name: ", STREAM, streamInfo.getStreamName());
         assertEquals("Expected Scope name: ", SCOPE, streamInfo.getScope());
@@ -162,7 +162,7 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
 
         // Emulate the behavior of Hadoop client: i) Get tail of Stream, ii) Read from current point until tail, iii) repeat.
         log.debug("Reading in batch iterations.");
-        StreamCut currentTailStreamCut = streamManager.getStreamInfo(SCOPE, stream.getStreamName()).getTailStreamCut();
+        StreamCut currentTailStreamCut = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).getTailStreamCut();
         int readEvents = 0;
         for (int i = 0; i < batchIterations; i++) {
             writeEvents(clientFactory, STREAM, totalEvents);
@@ -172,7 +172,7 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
             assertEquals("Expected number of segments: ", RG_PARALLELISM, ranges.size());
             readEvents += readFromRanges(ranges, batchClient);
             log.debug("Events read in parallel so far: {}.", readEvents);
-            currentTailStreamCut = streamManager.getStreamInfo(SCOPE, stream.getStreamName()).getTailStreamCut();
+            currentTailStreamCut = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).getTailStreamCut();
         }
 
         assertEquals("Expected events read: .", totalEvents * batchIterations, readEvents);
@@ -182,7 +182,7 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
         assertTrue(controller.truncateStream(SCOPE, STREAM, streamCut).join());
 
         // Test the batch client when we select to start reading a Stream from a truncation point.
-        StreamCut initialPosition = streamManager.getStreamInfo(SCOPE, stream.getStreamName()).getHeadStreamCut();
+        StreamCut initialPosition = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).getHeadStreamCut();
         List<SegmentRange> newRanges = Lists.newArrayList(batchClient.getSegments(stream, initialPosition, StreamCut.UNBOUNDED).getIterator());
         assertEquals("Expected events read: ", (totalEvents - offsetEvents) + totalEvents * batchIterations,
                     readFromRanges(newRanges, batchClient));

--- a/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/BatchClientSimpleTest.java
@@ -45,7 +45,6 @@ import io.pravega.test.system.framework.services.Service;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
@@ -115,7 +114,7 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
      */
     @Test
     @SuppressWarnings("deprecation")
-    public void batchClientSimpleTest() throws ExecutionException, InterruptedException {
+    public void batchClientSimpleTest() {
         final int totalEvents = RG_PARALLELISM * 100;
         final int offsetEvents = RG_PARALLELISM * 20;
         final int batchIterations = 4;
@@ -151,7 +150,7 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
 
         // Instantiate the batch client and assert it provides correct stream info.
         log.debug("Creating batch client.");
-        StreamInfo streamInfo = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).get();
+        StreamInfo streamInfo = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).join();
         log.debug("Validating stream metadata fields.");
         assertEquals("Expected Stream name: ", STREAM, streamInfo.getStreamName());
         assertEquals("Expected Scope name: ", SCOPE, streamInfo.getScope());
@@ -163,7 +162,7 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
 
         // Emulate the behavior of Hadoop client: i) Get tail of Stream, ii) Read from current point until tail, iii) repeat.
         log.debug("Reading in batch iterations.");
-        StreamCut currentTailStreamCut = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).get().getTailStreamCut();
+        StreamCut currentTailStreamCut = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).join().getTailStreamCut();
         int readEvents = 0;
         for (int i = 0; i < batchIterations; i++) {
             writeEvents(clientFactory, STREAM, totalEvents);
@@ -173,7 +172,7 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
             assertEquals("Expected number of segments: ", RG_PARALLELISM, ranges.size());
             readEvents += readFromRanges(ranges, batchClient);
             log.debug("Events read in parallel so far: {}.", readEvents);
-            currentTailStreamCut = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).get().getTailStreamCut();
+            currentTailStreamCut = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).join().getTailStreamCut();
         }
 
         assertEquals("Expected events read: .", totalEvents * batchIterations, readEvents);
@@ -183,7 +182,7 @@ public class BatchClientSimpleTest extends AbstractReadWriteTest {
         assertTrue(controller.truncateStream(SCOPE, STREAM, streamCut).join());
 
         // Test the batch client when we select to start reading a Stream from a truncation point.
-        StreamCut initialPosition = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).get().getHeadStreamCut();
+        StreamCut initialPosition = streamManager.fetchStreamInfo(SCOPE, stream.getStreamName()).join().getHeadStreamCut();
         List<SegmentRange> newRanges = Lists.newArrayList(batchClient.getSegments(stream, initialPosition, StreamCut.UNBOUNDED).getIterator());
         assertEquals("Expected events read: ", (totalEvents - offsetEvents) + totalEvents * batchIterations,
                     readFromRanges(newRanges, batchClient));


### PR DESCRIPTION
**Change log description**  

- `getStreamInfo()` sounds like a api call but it's a network call.
- As the name is ambiguous and API is still in beta so renaming it to `fetchStreamInfo()` and changed the return type to Completable Future.

**Purpose of the change**  
Fixes #6748 

**What the code does**
- Renamed `getStreamInfo()` to `fetchStreamInfo()` and returns a Completable Future.

**How to verify it**
- All tests should pass.
