### PR TITLE
Issue 6810 user cli log level config

### DIFF
--- a/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
@@ -46,9 +46,6 @@ public class UserCLIRunner {
 
     @VisibleForTesting
     public static void doMain(String[] args) {
-        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-        context.getLoggerList().get(0).setLevel(Level.ERROR);
-
         System.out.println("Pravega User CLI Tool.");
         System.out.println("\tUsage instructions: https://github.com/pravega/pravega/wiki/Pravega-User-CLI\n");
         val config = InteractiveConfig.getDefault();

--- a/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Scanner;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 /**
@@ -39,7 +40,7 @@ public class UserCLIRunner {
     private static final String CMD_HELP = "help";
     private static final String CMD_EXIT = "exit";
 
-    private static boolean running = true;
+    private static final AtomicBoolean running = new AtomicBoolean(true);
 
     public static void main(String[] args) {
         doMain(args, System.in);
@@ -72,7 +73,7 @@ public class UserCLIRunner {
         System.out.println(String.format("%nType \"%s\" for list of commands, or \"%s\" to exit.", CMD_HELP, CMD_EXIT));
         @Cleanup
         Scanner input = new Scanner(interactiveStream);
-        while (running) {
+        while (running.get()) {
             System.out.print(System.lineSeparator() + "> ");
             String line = input.nextLine();
 
@@ -93,7 +94,7 @@ public class UserCLIRunner {
                 printHelp(null);
                 break;
             case CMD_EXIT:
-                running = false;
+                running.set(false);
                 break;
             default:
                 execCommand(pc);

--- a/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
@@ -23,6 +23,7 @@ import io.pravega.cli.user.config.ConfigCommand;
 import io.pravega.cli.user.config.InteractiveConfig;
 import lombok.Cleanup;
 import lombok.val;
+import org.junit.Assert;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
@@ -49,6 +50,8 @@ public class UserCLIRunner {
         System.out.println("Pravega User CLI Tool.");
         System.out.println("\tUsage instructions: https://github.com/pravega/pravega/wiki/Pravega-User-CLI\n");
         val config = InteractiveConfig.getDefault();
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        loggerContext.getLoggerList().get(0).setLevel(config.getLogLevel());
 
         // Output loaded config.
         System.out.println("Initial configuration:");
@@ -56,14 +59,14 @@ public class UserCLIRunner {
         initialConfigCmd.execute();
 
         if (args == null || args.length == 0) {
-            interactiveMode(config);
+            interactiveMode(config, loggerContext);
         } else {
             String commandLine = Arrays.stream(args).collect(Collectors.joining(" ", "", ""));
             processCommand(commandLine, config);
         }
     }
 
-    private static void interactiveMode(InteractiveConfig config) {
+    private static void interactiveMode(InteractiveConfig config, LoggerContext loggerContext) {
         // Continuously accept new commands as long as the user entered one.
         System.out.println(String.format("%nType \"%s\" for list of commands, or \"%s\" to exit.", CMD_HELP, CMD_EXIT));
         @Cleanup
@@ -71,6 +74,8 @@ public class UserCLIRunner {
         while (true) {
             System.out.print(System.lineSeparator() + "> ");
             String line = input.nextLine();
+
+            loggerContext.getLoggerList().get(0).setLevel(config.getLogLevel());
             processCommand(line, config);
         }
     }
@@ -102,6 +107,7 @@ public class UserCLIRunner {
                 // No command was found.
                 printHelp(pc);
             } else {
+
                 cmd.execute();
             }
         } catch (IllegalArgumentException ex) {

--- a/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
@@ -107,7 +107,6 @@ public class UserCLIRunner {
                 // No command was found.
                 printHelp(pc);
             } else {
-
                 cmd.execute();
             }
         } catch (IllegalArgumentException ex) {

--- a/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
@@ -40,7 +40,7 @@ public class UserCLIRunner {
     private static final String CMD_HELP = "help";
     private static final String CMD_EXIT = "exit";
 
-    private static final AtomicBoolean running = new AtomicBoolean(true);
+    private static final AtomicBoolean RUNNING = new AtomicBoolean(true);
 
     public static void main(String[] args) {
         doMain(args, System.in);
@@ -73,7 +73,7 @@ public class UserCLIRunner {
         System.out.println(String.format("%nType \"%s\" for list of commands, or \"%s\" to exit.", CMD_HELP, CMD_EXIT));
         @Cleanup
         Scanner input = new Scanner(interactiveStream);
-        while (running.get()) {
+        while (RUNNING.get()) {
             System.out.print(System.lineSeparator() + "> ");
             String line = input.nextLine();
 
@@ -94,7 +94,7 @@ public class UserCLIRunner {
                 printHelp(null);
                 break;
             case CMD_EXIT:
-                running.set(false);
+                RUNNING.set(false);
                 break;
             default:
                 execCommand(pc);

--- a/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
@@ -15,7 +15,6 @@
  */
 package io.pravega.cli.user;
 
-import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -23,7 +22,6 @@ import io.pravega.cli.user.config.ConfigCommand;
 import io.pravega.cli.user.config.InteractiveConfig;
 import lombok.Cleanup;
 import lombok.val;
-import org.junit.Assert;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;

--- a/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
@@ -16,7 +16,6 @@
 package io.pravega.cli.user.config;
 
 import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.LoggerContext;
 import com.google.common.collect.ImmutableMap;
 import io.pravega.cli.user.UserCLIRunner;
 import lombok.Builder;
@@ -57,13 +56,9 @@ public class InteractiveConfig {
     private String truststore;
     private long rolloverSizeBytes;
     private Level logLevel;
-    private LoggerContext loggerContext;
 
     public static InteractiveConfig getDefault() {
-        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-
         return InteractiveConfig.builder()
-                .loggerContext(loggerContext)
                 .controllerUri("localhost:9090")
                 .defaultSegmentCount(4)
                 .timeoutMillis(60000)
@@ -116,7 +111,6 @@ public class InteractiveConfig {
                 break;
             case LOGLEVEL:
                 setLogLevel(Level.toLevel(value));
-                loggerContext.getLoggerList().get(0).setLevel(logLevel);
                 break;
             default:
                 throw new IllegalArgumentException(String.format("Unrecognized property name '%s'.", propertyName));

--- a/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
@@ -29,7 +29,7 @@ import java.util.Map;
 @Data
 @Builder
 public class InteractiveConfig {
-    public static final String LOGLEVEL = "log-level";
+    public static final String LOG_LEVEL = "log-level";
     public static final String CONTROLLER_URI = "controller-uri";
     public static final String DEFAULT_SEGMENT_COUNT = "default-segment-count";
     public static final String TIMEOUT_MILLIS = "timeout-millis";
@@ -108,7 +108,7 @@ public class InteractiveConfig {
             case ROLLOVER_SIZE_BYTES:
                 setRolloverSizeBytes(Long.parseLong(value));
                 break;
-            case LOGLEVEL:
+            case LOG_LEVEL:
                 setLogLevel(Level.toLevel(value));
                 break;
             default:
@@ -130,7 +130,7 @@ public class InteractiveConfig {
                 .put(TLS_ENABLED, isTlsEnabled())
                 .put(TRUSTSTORE_JKS, getTruststore())
                 .put(ROLLOVER_SIZE_BYTES, getRolloverSizeBytes())
-                .put(LOGLEVEL, getLogLevel())
+                .put(LOG_LEVEL, getLogLevel())
                 .build();
     }
 }

--- a/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import io.pravega.cli.user.UserCLIRunner;
 import lombok.Builder;
 import lombok.Data;
-import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 

--- a/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
@@ -15,10 +15,13 @@
  */
 package io.pravega.cli.user.config;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 import com.google.common.collect.ImmutableMap;
 import io.pravega.cli.user.UserCLIRunner;
 import lombok.Builder;
 import lombok.Data;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
@@ -28,6 +31,7 @@ import java.util.Map;
 @Data
 @Builder
 public class InteractiveConfig {
+    public static final String LOGLEVEL = "log-level";
     public static final String CONTROLLER_URI = "controller-uri";
     public static final String DEFAULT_SEGMENT_COUNT = "default-segment-count";
     public static final String TIMEOUT_MILLIS = "timeout-millis";
@@ -52,9 +56,14 @@ public class InteractiveConfig {
     private boolean tlsEnabled;
     private String truststore;
     private long rolloverSizeBytes;
+    private Level logLevel;
+    private LoggerContext loggerContext;
 
     public static InteractiveConfig getDefault() {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+
         return InteractiveConfig.builder()
+                .loggerContext(loggerContext)
                 .controllerUri("localhost:9090")
                 .defaultSegmentCount(4)
                 .timeoutMillis(60000)
@@ -66,6 +75,7 @@ public class InteractiveConfig {
                 .tlsEnabled(false)
                 .truststore("")
                 .rolloverSizeBytes(0)
+                .logLevel(Level.ERROR)
                 .build();
     }
 
@@ -104,6 +114,10 @@ public class InteractiveConfig {
             case ROLLOVER_SIZE_BYTES:
                 setRolloverSizeBytes(Long.parseLong(value));
                 break;
+            case LOGLEVEL:
+                setLogLevel(Level.toLevel(value));
+                loggerContext.getLoggerList().get(0).setLevel(logLevel);
+                break;
             default:
                 throw new IllegalArgumentException(String.format("Unrecognized property name '%s'.", propertyName));
         }
@@ -123,6 +137,7 @@ public class InteractiveConfig {
                 .put(TLS_ENABLED, isTlsEnabled())
                 .put(TRUSTSTORE_JKS, getTruststore())
                 .put(ROLLOVER_SIZE_BYTES, getRolloverSizeBytes())
+                .put(LOGLEVEL, getLogLevel())
                 .build();
     }
 }

--- a/cli/user/src/test/java/io/pravega/cli/user/UserCLIRunnerTest.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/UserCLIRunnerTest.java
@@ -39,7 +39,6 @@ public class UserCLIRunnerTest {
     @Test
     public void testDoMain() {
         UserCLIRunner.doMain(new String[]{"scope", "wrongCommand"}, System.in);
-        UserCLIRunner.doMain(new String[]{"scope", "wrongCommand"}, System.in);
     }
 
     @Test

--- a/cli/user/src/test/java/io/pravega/cli/user/UserCLIRunnerTest.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/UserCLIRunnerTest.java
@@ -15,8 +15,15 @@
  */
 package io.pravega.cli.user;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 import io.pravega.cli.user.config.InteractiveConfig;
+import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 public class UserCLIRunnerTest {
 
@@ -31,7 +38,22 @@ public class UserCLIRunnerTest {
 
     @Test
     public void testDoMain() {
-        UserCLIRunner.doMain(new String[]{"scope", "wrongCommand"});
+        UserCLIRunner.doMain(new String[]{"scope", "wrongCommand"}, System.in);
+        UserCLIRunner.doMain(new String[]{"scope", "wrongCommand"}, System.in);
+    }
+
+    @Test
+    public void testDoMainInteractive() {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        Level previousLevel =  loggerContext.getLoggerList().get(0).getLevel();
+
+        try {
+            InputStream in = new ByteArrayInputStream("config set log-level=info\nexit\n".getBytes());
+            UserCLIRunner.doMain(new String[]{}, in);
+            Assert.assertEquals(loggerContext.getLoggerList().get(0).getLevel(), Level.INFO);
+        } finally {
+            loggerContext.getLoggerList().get(0).setLevel(previousLevel);
+        }
     }
 
     @Test
@@ -39,4 +61,5 @@ public class UserCLIRunnerTest {
         UserCLIRunner.printCommandDetails(Parser.parse("kvt create test", InteractiveConfig.getDefault()));
         UserCLIRunner.printCommandDetails(Parser.parse("wrong command", InteractiveConfig.getDefault()));
     }
+
 }

--- a/cli/user/src/test/java/io/pravega/cli/user/config/InteractiveConfigCommandTest.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/config/InteractiveConfigCommandTest.java
@@ -47,9 +47,11 @@ public class InteractiveConfigCommandTest {
         interactiveConfig.set(InteractiveConfig.TRUSTSTORE_JKS, testString);
         Assert.assertEquals(testString, interactiveConfig.getTruststore());
         Assert.assertNotNull(interactiveConfig.getAll());
+
+        Assert.assertEquals(InteractiveConfig.getDefault().getLogLevel(), Level.ERROR);
         interactiveConfig.set(InteractiveConfig.LOGLEVEL, "INFO");
         Assert.assertEquals(interactiveConfig.getLogLevel(), Level.INFO);
-        // Ensure the log level has been immediately applied
-        Assert.assertEquals(interactiveConfig.getLoggerContext().getLoggerList().get(0).getLevel(), Level.INFO);
+        interactiveConfig.set(InteractiveConfig.LOGLEVEL, "debug");
+        Assert.assertEquals(interactiveConfig.getLogLevel(), Level.DEBUG);
     }
 }

--- a/cli/user/src/test/java/io/pravega/cli/user/config/InteractiveConfigCommandTest.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/config/InteractiveConfigCommandTest.java
@@ -49,9 +49,9 @@ public class InteractiveConfigCommandTest {
         Assert.assertNotNull(interactiveConfig.getAll());
 
         Assert.assertEquals(InteractiveConfig.getDefault().getLogLevel(), Level.ERROR);
-        interactiveConfig.set(InteractiveConfig.LOGLEVEL, "INFO");
+        interactiveConfig.set(InteractiveConfig.LOG_LEVEL, "INFO");
         Assert.assertEquals(interactiveConfig.getLogLevel(), Level.INFO);
-        interactiveConfig.set(InteractiveConfig.LOGLEVEL, "debug");
+        interactiveConfig.set(InteractiveConfig.LOG_LEVEL, "debug");
         Assert.assertEquals(interactiveConfig.getLogLevel(), Level.DEBUG);
     }
 }

--- a/cli/user/src/test/java/io/pravega/cli/user/config/InteractiveConfigCommandTest.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/config/InteractiveConfigCommandTest.java
@@ -15,8 +15,10 @@
  */
 package io.pravega.cli.user.config;
 
+import ch.qos.logback.classic.Level;
 import org.junit.Assert;
 import org.junit.Test;
+
 
 public class InteractiveConfigCommandTest {
 
@@ -45,6 +47,9 @@ public class InteractiveConfigCommandTest {
         interactiveConfig.set(InteractiveConfig.TRUSTSTORE_JKS, testString);
         Assert.assertEquals(testString, interactiveConfig.getTruststore());
         Assert.assertNotNull(interactiveConfig.getAll());
+        interactiveConfig.set(InteractiveConfig.LOGLEVEL, "INFO");
+        Assert.assertEquals(interactiveConfig.getLogLevel(), Level.INFO);
+        // Ensure the log level has been immediately applied
+        Assert.assertEquals(interactiveConfig.getLoggerContext().getLoggerList().get(0).getLevel(), Level.INFO);
     }
-
 }


### PR DESCRIPTION
**Change log description**  
The Pravega CLI currently has a hard-coded log level of `ERROR`.  This makes it difficult to debug certain connection issues as useful logging is suppressed.  This PR introduces a new configuration value, `log-level`, allowing the user to set the log level interactively before issuing a command.

**Purpose of the change**  
Fixes #6810 

**What the code does**  
- Adds `log-level` to the `InteractiveConfig` with the default set to `ERROR` to make it backwards compatible.
- `UserCLIRunner` applies the log level to the environment before processing an interactive command
- Updates `InteractiveConfigCommandTest` to validate the log level config.
- Updates the interactive loop to be more testable but passing in the InputStream (rather than assuming `System.in`) and using a Boolean to know when to exit the interactive loop (rather than force exiting the JVM)
- Adds `testDoMainInteractive` to perform a full interactive test, something previously missing from the test suite.

**How to verify it**  
The following shows the `pravega-cli` using interactive commands with different `log-level` settings.  The logging for each command validates that the requested log level has been applied to the environment.

Using default `log-level`:
```
.\pravega-cli.bat
Pravega User CLI Tool.
        Usage instructions: https://github.com/pravega/pravega/wiki/Pravega-User-CLI

Initial configuration:
        controller-uri=localhost:9090
        default-segment-count=4
        timeout-millis=60000
        max-list-items=1000
        pretty-print=true
        auth-enabled=false
        auth-username=
        auth-password=
        tls-enabled=false
        truststore-location=
        rollover-size-bytes=0
        log-level=ERROR

Type "help" for list of commands, or "exit" to exit.

> stream create testing
Bad command syntax: Unexpected argument 'testing' at position 0: Unexpected format for 'testing'. Expected format '<scope-name>/<name>'..

Command usage:
        stream create scoped-stream-names: Creates one or more Streams.
          - scoped-stream-names : Names of the Scoped Streams to create.
Examples:
           stream create scope1/stream1 scope1/stream2 scope2/stream3
            -> Creates stream1 and stream2 in scope1 and stream3 in scope2.
```
Set `log-level` to `info`:
```
> config set log-level=info

> config list
        controller-uri=localhost:9090
        default-segment-count=4
        timeout-millis=60000
        max-list-items=1000
        pretty-print=true
        auth-enabled=false
        auth-username=
        auth-password=
        tls-enabled=false
        truststore-location=
        rollover-size-bytes=0
        log-level=INFO

> stream create testing
11:01:51.873 [main] INFO io.pravega.client.control.impl.ControllerImpl - Controller client connecting to server at localhost:9090
11:01:51.876 [main] INFO io.pravega.client.connection.impl.ConnectionPoolImpl - Shutting down connection pool
11:01:51.876 [main] INFO io.pravega.client.connection.impl.SocketConnectionFactoryImpl - Shutting down connection factory
Bad command syntax: Unexpected argument 'testing' at position 0: Unexpected format for 'testing'. Expected format '<scope-name>/<name>'..

Command usage:
        stream create scoped-stream-names: Creates one or more Streams.
          - scoped-stream-names : Names of the Scoped Streams to create.
Examples:
           stream create scope1/stream1 scope1/stream2 scope2/stream3
            -> Creates stream1 and stream2 in scope1 and stream3 in scope2.
```
Set `log-level` to `debug`:
```
> config set log-level=debug

> config list
        controller-uri=localhost:9090
        default-segment-count=4
        timeout-millis=60000
        max-list-items=1000
        pretty-print=true
        auth-enabled=false
        auth-username=
        auth-password=
        tls-enabled=false
        truststore-location=
        rollover-size-bytes=0
        log-level=DEBUG

> stream create testing
11:02:08.232 [main] DEBUG io.pravega.client.control.impl.ControllerImpl - Using a plaintext channel builder
11:02:08.242 [main] INFO io.pravega.client.control.impl.ControllerImpl - Controller client connecting to server at localhost:9090
11:02:08.243 [main] DEBUG io.pravega.client.control.impl.ControllerImpl - Controller client shutdown has been initiated. Channel status: channel.isTerminated():true
11:02:08.243 [main] INFO io.pravega.client.connection.impl.ConnectionPoolImpl - Shutting down connection pool
11:02:08.243 [main] INFO io.pravega.client.connection.impl.SocketConnectionFactoryImpl - Shutting down connection factory
Bad command syntax: Unexpected argument 'testing' at position 0: Unexpected format for 'testing'. Expected format '<scope-name>/<name>'..

Command usage:
        stream create scoped-stream-names: Creates one or more Streams.
          - scoped-stream-names : Names of the Scoped Streams to create.
Examples:
           stream create scope1/stream1 scope1/stream2 scope2/stream3
            -> Creates stream1 and stream2 in scope1 and stream3 in scope2.
```

Signed-off-by: David Maddison <david.maddison@dell.com>
