### PR TITLE
Issue 6817 : Pravega-cli should pick up the default environment values from tls based configuration

### DIFF
--- a/cli/user/src/main/java/io/pravega/cli/user/Command.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/Command.java
@@ -84,7 +84,7 @@ public abstract class Command {
     }
 
     protected URI getControllerUri() {
-        return URI.create(getConfig().getControllerUri());
+        return URI.create((getConfig().isTlsEnabled() ? "tls://" : "tcp://") + getConfig().getControllerUri());
     }
 
     protected ClientConfig getClientConfig() {

--- a/cli/user/src/main/java/io/pravega/cli/user/Command.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/Command.java
@@ -84,7 +84,7 @@ public abstract class Command {
     }
 
     protected URI getControllerUri() {
-        return URI.create((getConfig().isTlsEnabled() ? "tls://" : "tcp://") + getConfig().getControllerUri());
+        return URI.create(getConfig().getControllerUri());
     }
 
     protected ClientConfig getClientConfig() {
@@ -95,8 +95,10 @@ public abstract class Command {
                     getConfig().getUserName()));
         }
         if (getConfig().isTlsEnabled()) {
-            clientConfigBuilder.trustStore(getConfig().getTruststore())
-                    .validateHostName(false);
+            if (getConfig().getTruststore() != null) {
+                clientConfigBuilder.trustStore(getConfig().getTruststore())
+                        .validateHostName(false);
+            }
         }
         return clientConfigBuilder.build();
     }

--- a/cli/user/src/main/java/io/pravega/cli/user/Command.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/Command.java
@@ -95,10 +95,8 @@ public abstract class Command {
                     getConfig().getUserName()));
         }
         if (getConfig().isTlsEnabled()) {
-            if (getConfig().getTruststore() != null) {
-                clientConfigBuilder.trustStore(getConfig().getTruststore())
-                        .validateHostName(false);
-            }
+            clientConfigBuilder.trustStore(getConfig().getTruststore())
+                    .validateHostName(false);
         }
         return clientConfigBuilder.build();
     }

--- a/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/UserCLIRunner.java
@@ -51,7 +51,7 @@ public class UserCLIRunner {
     public static void doMain(String[] args, InputStream interactiveStream) {
         System.out.println("Pravega User CLI Tool.");
         System.out.println("\tUsage instructions: https://github.com/pravega/pravega/wiki/Pravega-User-CLI\n");
-        val config = InteractiveConfig.getDefault();
+        val config = InteractiveConfig.getDefault(System.getenv());
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
         loggerContext.getLoggerList().get(0).setLevel(config.getLogLevel());
 

--- a/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
@@ -56,14 +56,16 @@ public class InteractiveConfig {
     private long rolloverSizeBytes;
     private Level logLevel;
 
-    public static InteractiveConfig getDefault() {
+    public static InteractiveConfig getDefault(Map<String, String> env) {
         //Default tls based configurations for pravega cli
         boolean tlsEnabled = false;
-        String systemEnvURI = System.getenv("PRAVEGA_CONTROLLER_URI");
+        String systemEnvURI = env.get("PRAVEGA_CONTROLLER_URI");
         String controllerURI = systemEnvURI != null ? systemEnvURI : "localhost:9090";
         if (controllerURI.startsWith("tls://")) {
             tlsEnabled = true;
             controllerURI = controllerURI.replace("tls://", "");
+        } else if (controllerURI.startsWith("tcp://")) {
+            controllerURI = controllerURI.replace("tcp://", "");
         }
         return InteractiveConfig.builder()
                 .controllerUri(controllerURI)

--- a/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
@@ -57,15 +57,13 @@ public class InteractiveConfig {
     private Level logLevel;
 
     public static InteractiveConfig getDefault() {
-        String controllerURI = "localhost:9090";
-        boolean tlsEnabled = false;
         //Default tls based configurations for pravega cli
-        if (System.getenv("PRAVEGA_CONTROLLER_URI") != null) {
-            controllerURI = System.getenv("PRAVEGA_CONTROLLER_URI");
-            if (controllerURI.startsWith("tls://")) {
-                tlsEnabled = true;
-                controllerURI = controllerURI.replace("tls://", "");
-            }
+        boolean tlsEnabled = false;
+        String systemEnvURI = System.getenv("PRAVEGA_CONTROLLER_URI");
+        String controllerURI = systemEnvURI != null ? systemEnvURI : "localhost:9090";
+        if (controllerURI.startsWith("tls://")) {
+            tlsEnabled = true;
+            controllerURI = controllerURI.replace("tls://", "");
         }
         return InteractiveConfig.builder()
                 .controllerUri(controllerURI)

--- a/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
@@ -59,7 +59,7 @@ public class InteractiveConfig {
     public static InteractiveConfig getDefault() {
         String controllerURI = "localhost:9090";
         boolean tlsEnabled = false;
-        //Default configurations corresponding to SDP for user-cli
+        //Default tls based configurations for pravega cli
         if (System.getenv("PRAVEGA_CONTROLLER_URI") != null) {
             controllerURI = System.getenv("PRAVEGA_CONTROLLER_URI");
             if (controllerURI.startsWith("tls://")) {

--- a/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
@@ -64,6 +64,7 @@ public class InteractiveConfig {
             controllerURI = System.getenv("PRAVEGA_CONTROLLER_URI");
             if (controllerURI.startsWith("tls://")) {
                 tlsEnabled = true;
+                controllerURI = controllerURI.replace("tls://", "");
             }
         }
         return InteractiveConfig.builder()

--- a/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
+++ b/cli/user/src/main/java/io/pravega/cli/user/config/InteractiveConfig.java
@@ -57,8 +57,17 @@ public class InteractiveConfig {
     private Level logLevel;
 
     public static InteractiveConfig getDefault() {
+        String controllerURI = "localhost:9090";
+        boolean tlsEnabled = false;
+        //Default configurations corresponding to SDP for user-cli
+        if (System.getenv("PRAVEGA_CONTROLLER_URI") != null) {
+            controllerURI = System.getenv("PRAVEGA_CONTROLLER_URI");
+            if (controllerURI.startsWith("tls://")) {
+                tlsEnabled = true;
+            }
+        }
         return InteractiveConfig.builder()
-                .controllerUri("localhost:9090")
+                .controllerUri(controllerURI)
                 .defaultSegmentCount(4)
                 .timeoutMillis(60000)
                 .maxListItems(1000)
@@ -66,7 +75,7 @@ public class InteractiveConfig {
                 .authEnabled(false)
                 .userName("")
                 .password("")
-                .tlsEnabled(false)
+                .tlsEnabled(tlsEnabled)
                 .truststore("")
                 .rolloverSizeBytes(0)
                 .logLevel(Level.ERROR)

--- a/cli/user/src/test/java/io/pravega/cli/user/TestUtils.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/TestUtils.java
@@ -22,6 +22,7 @@ import io.pravega.test.integration.utils.ClusterWrapper;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 /**
  * Class to contain convenient utilities for writing test cases.
@@ -88,7 +89,7 @@ public final class TestUtils {
      * @param tlsEnabled whether the cli requires TLS to access the cluster
      */
     public static InteractiveConfig createCLIConfig(String controllerUri, boolean authEnabled, boolean tlsEnabled) {
-        InteractiveConfig interactiveConfig = InteractiveConfig.getDefault();
+        InteractiveConfig interactiveConfig = InteractiveConfig.getDefault(Collections.singletonMap("TestKey", "TestValue"));
         interactiveConfig.setControllerUri(controllerUri);
         interactiveConfig.setDefaultSegmentCount(4);
         interactiveConfig.setMaxListItems(100);

--- a/cli/user/src/test/java/io/pravega/cli/user/UserCLIRunnerTest.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/UserCLIRunnerTest.java
@@ -24,6 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
 
 public class UserCLIRunnerTest {
 
@@ -57,8 +59,9 @@ public class UserCLIRunnerTest {
 
     @Test
     public void testCommandDetails() {
-        UserCLIRunner.printCommandDetails(Parser.parse("kvt create test", InteractiveConfig.getDefault()));
-        UserCLIRunner.printCommandDetails(Parser.parse("wrong command", InteractiveConfig.getDefault()));
+        Map<String, String> environment = Collections.singletonMap("TestKey", "TestValue");
+        UserCLIRunner.printCommandDetails(Parser.parse("kvt create test", InteractiveConfig.getDefault(environment)));
+        UserCLIRunner.printCommandDetails(Parser.parse("wrong command", InteractiveConfig.getDefault(environment)));
     }
 
 }

--- a/cli/user/src/test/java/io/pravega/cli/user/config/ConfigCommandTest.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/config/ConfigCommandTest.java
@@ -26,7 +26,7 @@ public class ConfigCommandTest {
 
     @Test
     public void testConfigCommand() {
-        InteractiveConfig config = InteractiveConfig.getDefault();
+        InteractiveConfig config = InteractiveConfig.getDefault(Collections.singletonMap("TestKey", "TestValue"));
         CommandArgs commandArgs = new CommandArgs(Arrays.asList("controller-uri=0",
                 "default-segment-count=1", "timeout-millis=2", "max-list-items=3", "pretty-print=true"), config);
         ConfigCommand.Set set = new ConfigCommand.Set(commandArgs);

--- a/cli/user/src/test/java/io/pravega/cli/user/config/InteractiveConfigCommandTest.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/config/InteractiveConfigCommandTest.java
@@ -19,7 +19,7 @@ import ch.qos.logback.classic.Level;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.Map;
 
 
@@ -28,7 +28,8 @@ public class InteractiveConfigCommandTest {
     @Test
     public void testSetConfig() {
         final String testString = "test";
-        InteractiveConfig interactiveConfig = InteractiveConfig.getDefault();
+        Map<String, String> envProperties = Collections.singletonMap("TestKey", "TestValue");
+        InteractiveConfig interactiveConfig = InteractiveConfig.getDefault(envProperties);
         interactiveConfig.setControllerUri(testString);
         Assert.assertEquals(testString, interactiveConfig.getControllerUri());
         interactiveConfig.setTimeoutMillis(0);
@@ -51,7 +52,7 @@ public class InteractiveConfigCommandTest {
         Assert.assertEquals(testString, interactiveConfig.getTruststore());
         Assert.assertNotNull(interactiveConfig.getAll());
 
-        Assert.assertEquals(InteractiveConfig.getDefault().getLogLevel(), Level.ERROR);
+        Assert.assertEquals(InteractiveConfig.getDefault(envProperties).getLogLevel(), Level.ERROR);
         interactiveConfig.set(InteractiveConfig.LOG_LEVEL, "INFO");
         Assert.assertEquals(interactiveConfig.getLogLevel(), Level.INFO);
         interactiveConfig.set(InteractiveConfig.LOG_LEVEL, "debug");
@@ -59,26 +60,18 @@ public class InteractiveConfigCommandTest {
     }
 
     @Test
-    public void testGetDefaultsForTlsEnv() throws NoSuchFieldException, IllegalAccessException {
-        Map<String, String> unmodifiableEnv = System.getenv();
-        Field field = unmodifiableEnv.getClass().getDeclaredField("m");
-        field.setAccessible(true);
-        Map<String, String> modifiableEnv = (Map<String, String>) field.get(unmodifiableEnv);
-        modifiableEnv.put("PRAVEGA_CONTROLLER_URI", "tls://testControllerURI");
-        InteractiveConfig interactiveConfig = InteractiveConfig.getDefault();
+    public void testGetDefaultsForTlsEnv() {
+        Map<String, String> envProperties = Collections.singletonMap("PRAVEGA_CONTROLLER_URI", "tls://testControllerURI");
+        InteractiveConfig interactiveConfig = InteractiveConfig.getDefault(envProperties);
         Assert.assertEquals("testControllerURI", interactiveConfig.getControllerUri());
         Assert.assertEquals(true, interactiveConfig.isTlsEnabled());
     }
 
     @Test
-    public void testGetDefaultsForNonTlsEnv() throws NoSuchFieldException, IllegalAccessException {
-        Map<String, String> unmodifiableEnv = System.getenv();
-        Field field = unmodifiableEnv.getClass().getDeclaredField("m");
-        field.setAccessible(true);
-        Map<String, String> modifiableEnv = (Map<String, String>) field.get(unmodifiableEnv);
-        modifiableEnv.put("PRAVEGA_CONTROLLER_URI", "localhost:9090");
-        InteractiveConfig interactiveConfig = InteractiveConfig.getDefault();
-        Assert.assertEquals("localhost:9090", interactiveConfig.getControllerUri());
+    public void testGetDefaultsForNonTlsEnv() {
+        Map<String, String> envProperties = Collections.singletonMap("PRAVEGA_CONTROLLER_URI", "tcp://testControllerURI");
+        InteractiveConfig interactiveConfig = InteractiveConfig.getDefault(envProperties);
+        Assert.assertEquals("testControllerURI", interactiveConfig.getControllerUri());
         Assert.assertEquals(false, interactiveConfig.isTlsEnabled());
     }
 }

--- a/cli/user/src/test/java/io/pravega/cli/user/config/InteractiveConfigCommandTest.java
+++ b/cli/user/src/test/java/io/pravega/cli/user/config/InteractiveConfigCommandTest.java
@@ -19,6 +19,9 @@ import ch.qos.logback.classic.Level;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+
 
 public class InteractiveConfigCommandTest {
 
@@ -53,5 +56,29 @@ public class InteractiveConfigCommandTest {
         Assert.assertEquals(interactiveConfig.getLogLevel(), Level.INFO);
         interactiveConfig.set(InteractiveConfig.LOG_LEVEL, "debug");
         Assert.assertEquals(interactiveConfig.getLogLevel(), Level.DEBUG);
+    }
+
+    @Test
+    public void testGetDefaultsForTlsEnv() throws NoSuchFieldException, IllegalAccessException {
+        Map<String, String> unmodifiableEnv = System.getenv();
+        Field field = unmodifiableEnv.getClass().getDeclaredField("m");
+        field.setAccessible(true);
+        Map<String, String> modifiableEnv = (Map<String, String>) field.get(unmodifiableEnv);
+        modifiableEnv.put("PRAVEGA_CONTROLLER_URI", "tls://testControllerURI");
+        InteractiveConfig interactiveConfig = InteractiveConfig.getDefault();
+        Assert.assertEquals("testControllerURI", interactiveConfig.getControllerUri());
+        Assert.assertEquals(true, interactiveConfig.isTlsEnabled());
+    }
+
+    @Test
+    public void testGetDefaultsForNonTlsEnv() throws NoSuchFieldException, IllegalAccessException {
+        Map<String, String> unmodifiableEnv = System.getenv();
+        Field field = unmodifiableEnv.getClass().getDeclaredField("m");
+        field.setAccessible(true);
+        Map<String, String> modifiableEnv = (Map<String, String>) field.get(unmodifiableEnv);
+        modifiableEnv.put("PRAVEGA_CONTROLLER_URI", "localhost:9090");
+        InteractiveConfig interactiveConfig = InteractiveConfig.getDefault();
+        Assert.assertEquals("localhost:9090", interactiveConfig.getControllerUri());
+        Assert.assertEquals(false, interactiveConfig.isTlsEnabled());
     }
 }


### PR DESCRIPTION
**Change log description**  
Added a conditional check to read the environment values and populate the same for controller-uri for tls

**Purpose of the change**  
Fixes: [#6817](https://github.com/pravega/pravega/issues/6817)

**What the code does**  
This PR adds the default values for the tls based configurations.

**How to verify it**  
On a tls environment, connect to pravega-cli and look for controller-uri and tls-enabled fields, it should display the default values as per the environment 
