### PR TITLE
Issue 6712: Corrupted BTreeIndex footer found after a segment container recovery when cache is full

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/WriteOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/WriteOperation.java
@@ -29,6 +29,7 @@ import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
 import io.pravega.segmentstore.storage.metadata.MetadataTransaction;
 import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
 import io.pravega.segmentstore.storage.metadata.StorageMetadataWritesFencedOutException;
+import io.pravega.shared.NameUtils;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
@@ -201,8 +202,10 @@ class WriteOperation implements Callable<CompletableFuture<Void>> {
             txn.setExternalCommitStep(() -> chunkedSegmentStorage.getSystemJournal().commitRecords(systemLogRecords));
         }
 
-        // if layout did not change then commit with lazyWrite.
-        return txn.commit(!didSegmentLayoutChange && chunkedSegmentStorage.getConfig().isLazyCommitEnabled())
+        // If layout did not change then commit with lazyWrite; only persist metadata always in case of Attribute Segments.
+        return txn.commit(!didSegmentLayoutChange
+                        && chunkedSegmentStorage.getConfig().isLazyCommitEnabled()
+                        && !NameUtils.isAttributeSegment(segmentMetadata.getName()))
                 .thenRunAsync(() -> isCommitted = true, chunkedSegmentStorage.getExecutor());
 
     }


### PR DESCRIPTION
**Change log description**  
Always flush SLTS metadata related Attribute Index Segments.

**Purpose of the change**  
Fixes #6712.

**What the code does**  
This PR forces to always flush SLTS metadata related to Attribute Index Segments, irrespective of `lazyWrite` option for SLTS metadata.

The rationale fot this is the following: The `BTreeIndex` is invokes `getLength()` method in `SegmentAttributeBTreeIndex` to get initialized and read the "footer" of the index. The length of the Attribute index Segment comes from the Storage Metadata Table Segment. If there is a partial write related to a previous failure writing to storage and then the `BTreeIndex.initialize()` method is invoked (e.g., after container restart), the `BTreeIndex` would just read that last, partial write to get initialized and it will fail with a `DataCorruptionException`. The main reason for this problem to happen is due to the side effect of using `lazyCommit` option in Segment Attribute Index chunks, given that `BTreeIndex` does not contain any reconciliation logic (as `SegmentAggregator` does) that could help to skip partial writes. 

**How to verify it**  
TBD.