### PR TITLE
Issue 6864: Disable Mkdocs gradle plugin by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -84,4 +84,4 @@ signing.secretKeyRingFile=
 # The version of Java to build the 'client' project and all its dependencies in.
 clientJavaVersion=8
 
-enableMkdocs=true
+enableMkdocs=false


### PR DESCRIPTION
**Change log description**  
Gradle fails to build in git-less release source bundles because Mkdocs plugin always assumes a valid git working tree.

Mkdocs plugin can be enabled on the command line with `./gradlew -PenableMkdocs=true mkdocsBuild` or `./gradlew -PenableMkdocs=true mkdocsServe`.

**Purpose of the change**  
Fixes #6864

**What the code does**  
Sets gradle property `enableMkdocs` to `false`.

**How to verify it**  
Make a new release tarball that lacks git and run a gradle task. For example: `git archive --format=zip v0.12.0-rc1 > /tmp/pravega.zip`, unzip and run a gradle task such as `./gradlew build`.