### PR TITLE
Issue 6874: Flaky test SecureStreamMetadataTasksTest.readerGroupsTest is failing

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateReaderGroupTask.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/requesthandlers/UpdateReaderGroupTask.java
@@ -118,11 +118,19 @@ public class UpdateReaderGroupTask implements ReaderGroupTask<UpdateReaderGroupE
                                        return CompletableFuture.completedFuture(null);
                                    })
                                    .thenCompose(v -> streamMetadataStore.completeRGConfigUpdate(scope, readerGroup, rgConfigRecord, context, executor))
-                                           .thenAccept(v -> StreamMetrics.getInstance().controllerEventProcessorUpdateReaderGroupEvent(timer.getElapsed()));
+                                           .thenAccept(v -> {
+                                               log.info(">>>> Inside UpdateReaderGroupTask updating timer in metrics {} ", timer.getElapsed());
+                                               StreamMetrics.getInstance().controllerEventProcessorUpdateReaderGroupEvent(timer.getElapsed());
+                                               log.info(">>>> Inside UpdateReaderGroupTask metrics successfully updated ");
+                                           });
                                }
                                // We get here for non-transition updates
                                return streamMetadataStore.completeRGConfigUpdate(scope, readerGroup, rgConfigRecord, context, executor)
-                                       .thenAccept(v -> StreamMetrics.getInstance().controllerEventProcessorUpdateReaderGroupEvent(timer.getElapsed()));
+                                       .thenAccept(v -> {
+                                           log.info(">>>> Inside UpdateReaderGroupTask 2 updating timer in metrics {} ", timer.getElapsed());
+                                           StreamMetrics.getInstance().controllerEventProcessorUpdateReaderGroupEvent(timer.getElapsed());
+                                           log.info(">>>> Inside UpdateReaderGroupTask 2 metrics successfully updated ");
+                                       });
                            }
                            return CompletableFuture.completedFuture(null);
                        });

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -841,9 +841,8 @@ public abstract class RequestHandlersTest {
         future.join();
     }
 
-    @SneakyThrows
     @Test
-    public void scopeDeleteTest() {
+    public void scopeDeleteTest() throws Exception{
         final String testScope = "testScope";
         final String testStream = "testStream";
         final String testRG = "_RGTestRG";

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -950,7 +950,7 @@ public abstract class RequestHandlersTest {
         DeleteScopeEvent event = new DeleteScopeEvent(testScope, 123L, scopeId);
         CompletableFuture<Void> future = requestHandler.execute(event);
         future.join();
-        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_SCOPE_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_SCOPE_LATENCY) > 0, 10000);
     }
 
     @Test

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -950,7 +950,7 @@ public abstract class RequestHandlersTest {
         DeleteScopeEvent event = new DeleteScopeEvent(testScope, 123L, scopeId);
         CompletableFuture<Void> future = requestHandler.execute(event);
         future.join();
-        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_SCOPE_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_SCOPE_LATENCY) > 0, 10000);
     }
 
     @Test

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -841,7 +841,7 @@ public abstract class RequestHandlersTest {
     }
 
     @Test
-    public void scopeDeleteTest() throws Exception{
+    public void scopeDeleteTest() throws Exception {
         final String testScope = "testScope";
         final String testStream = "testStream";
         final String testRG = "_RGTestRG";

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -84,6 +84,7 @@ import io.pravega.shared.metrics.StatsProvider;
 import io.pravega.shared.protocol.netty.WireCommandType;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
+import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.curator.framework.CuratorFramework;
@@ -840,6 +841,7 @@ public abstract class RequestHandlersTest {
         future.join();
     }
 
+    @SneakyThrows
     @Test
     public void scopeDeleteTest() {
         final String testScope = "testScope";
@@ -948,7 +950,7 @@ public abstract class RequestHandlersTest {
         DeleteScopeEvent event = new DeleteScopeEvent(testScope, 123L, scopeId);
         CompletableFuture<Void> future = requestHandler.execute(event);
         future.join();
-        assertTrue(MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_SCOPE_LATENCY) > 0);
+        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_SCOPE_LATENCY) > 0, 10000);
     }
 
     @Test

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/RequestHandlersTest.java
@@ -84,7 +84,6 @@ import io.pravega.shared.metrics.StatsProvider;
 import io.pravega.shared.protocol.netty.WireCommandType;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.TestingServerStarter;
-import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.curator.framework.CuratorFramework;

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -84,7 +84,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import lombok.SneakyThrows;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -206,10 +205,9 @@ public abstract class ScaleRequestHandlerTest {
         }
     }
 
-    @SneakyThrows
     @SuppressWarnings("unchecked")
     @Test(timeout = 30000)
-    public void testScaleRequest() throws ExecutionException, InterruptedException {
+    public void testScaleRequest() throws Exception {
         AutoScaleTask requestHandler = new AutoScaleTask(streamMetadataTasks, streamStore, executor);
         ScaleOperationTask scaleRequestHandler = new ScaleOperationTask(streamMetadataTasks, streamStore, executor);
         StreamRequestHandler multiplexer = new StreamRequestHandler(requestHandler, scaleRequestHandler,

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -304,7 +304,7 @@ public abstract class ScaleRequestHandlerTest {
         assertTrue(activeSegments.size() == 3);
 
         assertFalse(Futures.await(multiplexer.process(new AbortEvent(scope, stream, 0, UUID.randomUUID(), 11L), () -> false)));
-        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_AUTO_SCALE_STREAM_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_AUTO_SCALE_STREAM_LATENCY) > 0, 10000);
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -84,6 +84,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import lombok.SneakyThrows;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -205,6 +206,7 @@ public abstract class ScaleRequestHandlerTest {
         }
     }
 
+    @SneakyThrows
     @SuppressWarnings("unchecked")
     @Test(timeout = 30000)
     public void testScaleRequest() throws ExecutionException, InterruptedException {
@@ -302,7 +304,7 @@ public abstract class ScaleRequestHandlerTest {
         assertTrue(activeSegments.size() == 3);
 
         assertFalse(Futures.await(multiplexer.process(new AbortEvent(scope, stream, 0, UUID.randomUUID(), 11L), () -> false)));
-        assertTrue(MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_AUTO_SCALE_STREAM_LATENCY) > 0);
+        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_AUTO_SCALE_STREAM_LATENCY) > 0, 10000);
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -304,7 +304,7 @@ public abstract class ScaleRequestHandlerTest {
         assertTrue(activeSegments.size() == 3);
 
         assertFalse(Futures.await(multiplexer.process(new AbortEvent(scope, stream, 0, UUID.randomUUID(), 11L), () -> false)));
-        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_AUTO_SCALE_STREAM_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_AUTO_SCALE_STREAM_LATENCY) > 0, 10000);
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -122,9 +122,8 @@ public abstract class TableMetadataTasksTest {
         }
     }
 
-    @SneakyThrows
     @Test(timeout = 30000)
-    public void testCreateKeyValueTable() throws ExecutionException, InterruptedException {
+    public void testCreateKeyValueTable() throws Exception {
         Assert.assertTrue(isScopeCreated);
         long creationTime = System.currentTimeMillis();
         KeyValueTableConfiguration kvtConfig = KeyValueTableConfiguration.builder().partitionCount(2).primaryKeyLength(4).secondaryKeyLength(4).build();

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -47,7 +47,6 @@ import io.pravega.test.common.AssertExtensions;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -53,7 +53,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 import lombok.Data;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.After;
 import org.junit.Assert;
@@ -152,9 +151,8 @@ public abstract class TableMetadataTasksTest {
                 e -> Exceptions.unwrap(e) instanceof RuntimeException);
     }
 
-    @SneakyThrows
     @Test(timeout = 30000)
-    public void testDeleteKeyValueTable() throws ExecutionException, InterruptedException {
+    public void testDeleteKeyValueTable() throws Exception {
         Assert.assertTrue(isScopeCreated);
         long creationTime = System.currentTimeMillis();
         KeyValueTableConfiguration kvtConfig = KeyValueTableConfiguration.builder().partitionCount(2).primaryKeyLength(4).secondaryKeyLength(4).build();

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -133,7 +133,7 @@ public abstract class TableMetadataTasksTest {
 
         assertTrue(Futures.await(processEvent((TableMetadataTasksTest.WriterMock) requestEventWriter)));
         assertEquals(CreateKeyValueTableStatus.Status.SUCCESS, createOperationFuture.join());
-        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_TABLE_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_TABLE_LATENCY) > 0, 10000);
         List<KVTSegmentRecord> segmentsList = kvtStore.getActiveSegments(SCOPE, kvtable1, null, executor).get();
         assertEquals(segmentsList.size(), kvtConfig.getPartitionCount());
 
@@ -173,7 +173,7 @@ public abstract class TableMetadataTasksTest {
         assertTrue(kvtMetadataTasks.isDeleted(SCOPE, kvtable1, null).join());
         assertFalse(kvtStore.checkTableExists(SCOPE, kvtable1, null, executor).join());
         assertFalse(kvtStore.isScopeSealed("testScope", null, executor).join());
-        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_TABLE_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_TABLE_LATENCY) > 0, 10000);
     }
 
     private CompletableFuture<Void> processEvent(TableMetadataTasksTest.WriterMock requestEventWriter) throws InterruptedException {

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -133,7 +133,7 @@ public abstract class TableMetadataTasksTest {
 
         assertTrue(Futures.await(processEvent((TableMetadataTasksTest.WriterMock) requestEventWriter)));
         assertEquals(CreateKeyValueTableStatus.Status.SUCCESS, createOperationFuture.join());
-        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_TABLE_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_TABLE_LATENCY) > 0, 10000);
         List<KVTSegmentRecord> segmentsList = kvtStore.getActiveSegments(SCOPE, kvtable1, null, executor).get();
         assertEquals(segmentsList.size(), kvtConfig.getPartitionCount());
 
@@ -173,7 +173,7 @@ public abstract class TableMetadataTasksTest {
         assertTrue(kvtMetadataTasks.isDeleted(SCOPE, kvtable1, null).join());
         assertFalse(kvtStore.checkTableExists(SCOPE, kvtable1, null, executor).join());
         assertFalse(kvtStore.isScopeSealed("testScope", null, executor).join());
-        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_TABLE_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_TABLE_LATENCY) > 0, 10000);
     }
 
     private CompletableFuture<Void> processEvent(TableMetadataTasksTest.WriterMock requestEventWriter) throws InterruptedException {

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -694,6 +694,7 @@ public abstract class StreamMetadataTasksTest {
         Controller.UpdateReaderGroupResponse updateRGResponse = updateResponse.join();
         assertTrue(Controller.UpdateReaderGroupResponse.Status.SUCCESS.equals(updateRGResponse.getStatus()));
         assertEquals(1L, updateRGResponse.getGeneration());
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_UPDATE_READER_GROUP_LATENCY) > 0, 10000);
 
         listSubscribersResponse = streamMetadataTasks.listSubscribers(SCOPE, stream3, 0L).get();
         // rg4
@@ -717,7 +718,6 @@ public abstract class StreamMetadataTasksTest {
         assertEquals(subscriberToNonSubscriberConfig.getEndingStreamCuts().size(), responseRG3.getConfig().getEndingStreamCutsCount());
         AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_READER_GROUP_LATENCY) > 0, 10000);
         AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_READER_GROUP_LATENCY) > 0, 10000);
-        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_UPDATE_READER_GROUP_LATENCY) > 0, 10000);
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -484,9 +484,8 @@ public abstract class StreamMetadataTasksTest {
                 etr.getObject().getActiveEpoch(), 0L).join().getStatus(), Controller.ScaleStatusResponse.ScaleStatus.SUCCESS);
     }
 
-    @SneakyThrows
     @Test(timeout = 30000)
-    public void readerGroupsTest() throws InterruptedException, ExecutionException {
+    public void readerGroupsTest() throws Exception {
         // no subscribers found for existing Stream
         SubscribersResponse listSubscribersResponse = streamMetadataTasks.listSubscribers(SCOPE, stream1, 0L).get();
         assertEquals(SubscribersResponse.Status.SUCCESS, listSubscribersResponse.getStatus());

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -717,9 +717,9 @@ public abstract class StreamMetadataTasksTest {
         assertEquals(subscriberToNonSubscriberConfig.getAutomaticCheckpointIntervalMillis(), responseRG3.getConfig().getAutomaticCheckpointIntervalMillis());
         assertEquals(subscriberToNonSubscriberConfig.getStartingStreamCuts().size(), responseRG3.getConfig().getStartingStreamCutsCount());
         assertEquals(subscriberToNonSubscriberConfig.getEndingStreamCuts().size(), responseRG3.getConfig().getEndingStreamCutsCount());
-        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_READER_GROUP_LATENCY) > 0, 10000);
-        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_READER_GROUP_LATENCY) > 0, 10000);
-        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_UPDATE_READER_GROUP_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_READER_GROUP_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_READER_GROUP_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_UPDATE_READER_GROUP_LATENCY) > 0, 10000);
     }
 
     @Test(timeout = 30000)
@@ -978,7 +978,7 @@ public abstract class StreamMetadataTasksTest {
         CreateStreamResponse.CreateStatus s = streamResponse.get().getStatus();
         assertEquals(CreateStreamResponse.CreateStatus.EXISTS_ACTIVE, streamResponse.get().getStatus());
 
-        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_SCALE_STREAM_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_SCALE_STREAM_LATENCY) > 0, 10000);
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -717,9 +717,9 @@ public abstract class StreamMetadataTasksTest {
         assertEquals(subscriberToNonSubscriberConfig.getAutomaticCheckpointIntervalMillis(), responseRG3.getConfig().getAutomaticCheckpointIntervalMillis());
         assertEquals(subscriberToNonSubscriberConfig.getStartingStreamCuts().size(), responseRG3.getConfig().getStartingStreamCutsCount());
         assertEquals(subscriberToNonSubscriberConfig.getEndingStreamCuts().size(), responseRG3.getConfig().getEndingStreamCutsCount());
-        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_READER_GROUP_LATENCY) > 0, 10000);
-        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_READER_GROUP_LATENCY) > 0, 10000);
-        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_UPDATE_READER_GROUP_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_READER_GROUP_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_READER_GROUP_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_UPDATE_READER_GROUP_LATENCY) > 0, 10000);
     }
 
     @Test(timeout = 30000)
@@ -978,7 +978,7 @@ public abstract class StreamMetadataTasksTest {
         CreateStreamResponse.CreateStatus s = streamResponse.get().getStatus();
         assertEquals(CreateStreamResponse.CreateStatus.EXISTS_ACTIVE, streamResponse.get().getStatus());
 
-        AssertExtensions.assertEventuallyEquals( true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_SCALE_STREAM_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_SCALE_STREAM_LATENCY) > 0, 10000);
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -134,6 +134,7 @@ import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.Data;
 import lombok.Getter;
+import lombok.SneakyThrows;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -483,6 +484,7 @@ public abstract class StreamMetadataTasksTest {
                 etr.getObject().getActiveEpoch(), 0L).join().getStatus(), Controller.ScaleStatusResponse.ScaleStatus.SUCCESS);
     }
 
+    @SneakyThrows
     @Test(timeout = 30000)
     public void readerGroupsTest() throws InterruptedException, ExecutionException {
         // no subscribers found for existing Stream
@@ -715,9 +717,9 @@ public abstract class StreamMetadataTasksTest {
         assertEquals(subscriberToNonSubscriberConfig.getAutomaticCheckpointIntervalMillis(), responseRG3.getConfig().getAutomaticCheckpointIntervalMillis());
         assertEquals(subscriberToNonSubscriberConfig.getStartingStreamCuts().size(), responseRG3.getConfig().getStartingStreamCutsCount());
         assertEquals(subscriberToNonSubscriberConfig.getEndingStreamCuts().size(), responseRG3.getConfig().getEndingStreamCutsCount());
-        assertTrue(MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_READER_GROUP_LATENCY) > 0);
-        assertTrue(MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_READER_GROUP_LATENCY) > 0);
-        assertTrue(MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_UPDATE_READER_GROUP_LATENCY) > 0);
+        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_CREATE_READER_GROUP_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_DELETE_READER_GROUP_LATENCY) > 0, 10000);
+        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_UPDATE_READER_GROUP_LATENCY) > 0, 10000);
     }
 
     @Test(timeout = 30000)
@@ -976,7 +978,7 @@ public abstract class StreamMetadataTasksTest {
         CreateStreamResponse.CreateStatus s = streamResponse.get().getStatus();
         assertEquals(CreateStreamResponse.CreateStatus.EXISTS_ACTIVE, streamResponse.get().getStatus());
 
-        assertTrue(MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_SCALE_STREAM_LATENCY) > 0);
+        AssertExtensions.assertEventuallyEquals( true , () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_SCALE_STREAM_LATENCY) > 0, 10000);
     }
 
     @Test(timeout = 30000)

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -617,6 +617,7 @@ public abstract class StreamMetadataTasksTest {
         Controller.UpdateReaderGroupResponse updateResponseResult = updateResponse.join();
         assertEquals(Controller.UpdateReaderGroupResponse.Status.SUCCESS, updateResponseResult.getStatus());
         assertEquals(1L, updateResponseResult.getGeneration());
+        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_UPDATE_READER_GROUP_LATENCY) > 0, 10000);
 
         responseRG2 = streamMetadataTasks.getReaderGroupConfig(SCOPE, "rg2", 0L).get();
         assertEquals(ReaderGroupConfigResponse.Status.SUCCESS, responseRG2.getStatus());
@@ -694,7 +695,6 @@ public abstract class StreamMetadataTasksTest {
         Controller.UpdateReaderGroupResponse updateRGResponse = updateResponse.join();
         assertTrue(Controller.UpdateReaderGroupResponse.Status.SUCCESS.equals(updateRGResponse.getStatus()));
         assertEquals(1L, updateRGResponse.getGeneration());
-        AssertExtensions.assertEventuallyEquals(true, () -> MetricsTestUtil.getTimerMillis(MetricsNames.CONTROLLER_EVENT_PROCESSOR_UPDATE_READER_GROUP_LATENCY) > 0, 10000);
 
         listSubscribersResponse = streamMetadataTasks.listSubscribers(SCOPE, stream3, 0L).get();
         // rg4

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -134,7 +134,6 @@ import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.Data;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;

--- a/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/AssertExtensions.java
@@ -67,7 +67,7 @@ public class AssertExtensions {
         try {
             result = TestUtils.awaitEvaluateExpr(expected, eval, checkIntervalMillis, timeoutMillis);
         } catch (TimeoutException e) {
-            throw new TimeoutException("Expected value: " + expected + " observed: " + result);
+            throw e;
         }
         assertEquals(expected, result);
     }

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -120,7 +120,8 @@ public class TestUtils {
 
         if (condition == null || !condition.get() && remainingMillis <= 0) {
             log.info(">>>> Exception in TestUtils TimeoutExceptions thrown ");
-            throw new TimeoutException("Timeout expired prior to the condition becoming true.");
+           // throw new TimeoutException("Timeout expired prior to the condition becoming true.");
+            throw new TimeoutException("Timeout expired prior to the condition becoming true. Expected value: " + expected + " observed: " + result);
         }
 
         return result;

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -120,7 +120,6 @@ public class TestUtils {
 
         if (condition == null || !condition.get() && remainingMillis <= 0) {
             log.info(">>>> Exception in TestUtils TimeoutExceptions thrown ");
-           // throw new TimeoutException("Timeout expired prior to the condition becoming true.");
             throw new TimeoutException("Timeout expired prior to the condition becoming true. Expected value: " + expected + " observed: " + result);
         }
 

--- a/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
+++ b/test/testcommon/src/main/java/io/pravega/test/common/TestUtils.java
@@ -110,6 +110,7 @@ public class TestUtils {
                 condition = () -> (expected == null && finalResult == null)
                         || (expected != null && expected.equals(finalResult));
             } catch (Exception e) {
+                log.info(">>>> Exception in TestUtils time remaining {} and exception is {} ", remainingMillis, e);
                 throw new RuntimeException(e);
             }
 
@@ -118,6 +119,7 @@ public class TestUtils {
         }
 
         if (condition == null || !condition.get() && remainingMillis <= 0) {
+            log.info(">>>> Exception in TestUtils TimeoutExceptions thrown ");
             throw new TimeoutException("Timeout expired prior to the condition becoming true.");
         }
 


### PR DESCRIPTION
**Change log description**  
Fix flaky test SecureStreamMetadataTasksTest.readerGroupsTest 

**Purpose of the change**  
Fixes #6874 

**What the code does**  
Asserting using assertEventuallyEquals instead of assertTrue 

**How to verify it**  
Jenkins job should not have SecureStreamMetadataTasksTest failure
