### PR TITLE
Experimental - Replicated chunk storage

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3StorageConfig.java
@@ -22,18 +22,25 @@ import io.pravega.common.util.ConfigBuilder;
 import io.pravega.common.util.ConfigurationException;
 import io.pravega.common.util.Property;
 import io.pravega.common.util.TypedProperties;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 /**
  * Configuration for the ExtendedS3 Storage component.
  */
 @Slf4j
+@Builder(toBuilder = true)
+@RequiredArgsConstructor
 public class ExtendedS3StorageConfig {
     //region Config Names
-
+    public static final Property<Boolean> REPLICATION_ENABLED = Property.named("replication.enabled", false);
     public static final Property<String> CONFIGURI = Property.named("connect.config.uri", "", "configUri");
     public static final Property<String> BUCKET = Property.named("bucket", "");
+    public static final Property<String> ALT_CONFIGURI = Property.named("alt.connect.config.uri", "", "configUri");
+    public static final Property<String> ALT_BUCKET = Property.named("alt.bucket", "");
     public static final Property<String> PREFIX = Property.named("prefix", "/");
     public static final Property<Boolean> USENONEMATCH = Property.named("noneMatch.enable", false, "useNoneMatch");
     public static final Property<Integer> SMALL_OBJECT_THRESHOLD = Property.named("concat.smallObject.threshold.size", 1024 * 1024, "smallObjectSizeLimitForConcat");
@@ -45,6 +52,11 @@ public class ExtendedS3StorageConfig {
 
     //region Members
 
+    private final String configUri;
+    private final String altConfigUri;
+    private final String altBucket;
+    @Getter
+    private final boolean replicationEnabled;
     /**
      *  The S3 complete client config of the EXTENDEDS3 REST interface
      */
@@ -101,10 +113,21 @@ public class ExtendedS3StorageConfig {
      */
     private ExtendedS3StorageConfig(TypedProperties properties) throws ConfigurationException {
         ConfigUri<S3Config> s3ConfigUri = new ConfigUri<S3Config>(S3Config.class);
-        this.s3Config = Preconditions.checkNotNull(s3ConfigUri.parseUri(properties.get(CONFIGURI)), "configUri");
-        this.accessKey = Preconditions.checkNotNull(s3Config.getIdentity(), "identity");
-        this.secretKey = Preconditions.checkNotNull(s3Config.getSecretKey(), "secretKey");
-        this.bucket = Preconditions.checkNotNull(properties.get(BUCKET), "bucket");
+        this.replicationEnabled = properties.getBoolean(REPLICATION_ENABLED);
+        this.configUri = properties.get(CONFIGURI);
+        this.altConfigUri = properties.get(CONFIGURI);
+        if (replicationEnabled) {
+            this.s3Config = null;
+            this.accessKey = null;
+            this.secretKey = null;
+            this.bucket = null;
+        } else {
+            this.s3Config = Preconditions.checkNotNull(s3ConfigUri.parseUri(configUri), "configUri");
+            this.accessKey = Preconditions.checkNotNull(s3Config.getIdentity(), "identity");
+            this.secretKey = Preconditions.checkNotNull(s3Config.getSecretKey(), "secretKey");
+            this.bucket = Preconditions.checkNotNull(properties.get(BUCKET), "bucket");
+        }
+        this.altBucket = null;
         String givenPrefix = Preconditions.checkNotNull(properties.get(PREFIX), "prefix");
         this.prefix = givenPrefix.endsWith(PATH_SEPARATOR) ? givenPrefix : givenPrefix + PATH_SEPARATOR;
         this.useNoneMatch = properties.getBoolean(USENONEMATCH);
@@ -118,6 +141,31 @@ public class ExtendedS3StorageConfig {
      */
     public static ConfigBuilder<ExtendedS3StorageConfig> builder() {
         return new ConfigBuilder<>(COMPONENT_CODE, ExtendedS3StorageConfig::new);
+    }
+
+    /**
+     * Get array of replica configs.
+     * @return Array of configs.
+     */
+    public ExtendedS3StorageConfig[] getReplicaConfigs() {
+        ConfigUri<S3Config> s3ConfigUri = new ConfigUri<S3Config>(S3Config.class);
+
+        val s3Config1 = Preconditions.checkNotNull(s3ConfigUri.parseUri(configUri), "configUri");
+        val config1 = this.toBuilder()
+                .s3Config(s3Config1)
+                .accessKey(Preconditions.checkNotNull(s3Config1.getIdentity(), "identity"))
+                .secretKey(Preconditions.checkNotNull(s3Config1.getSecretKey(), "secretKey"))
+                .bucket(Preconditions.checkNotNull(bucket))
+                .build();
+
+        val s3Config2 = Preconditions.checkNotNull(s3ConfigUri.parseUri(altConfigUri), "configUri");
+        val config2 = this.toBuilder()
+                .s3Config(s3Config1)
+                .accessKey(Preconditions.checkNotNull(s3Config1.getIdentity(), "identity"))
+                .secretKey(Preconditions.checkNotNull(s3Config1.getSecretKey(), "secretKey"))
+                .bucket(Preconditions.checkNotNull(altBucket))
+                .build();
+        return new ExtendedS3StorageConfig[] { config1, config2};
     }
 
     //endregion

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ReplicatedExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ReplicatedExtendedS3IntegrationTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.server.host;
+
+import com.emc.object.s3.S3Config;
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.segmentstore.storage.SimpleStorageFactory;
+import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.chunklayer.AsyncBaseChunkStorage;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorage;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorage;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
+import io.pravega.segmentstore.storage.chunklayer.ReplicatedChunkStorage;
+import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperConfig;
+import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperLogFactory;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
+import io.pravega.storage.extendeds3.ExtendedS3ChunkStorage;
+import io.pravega.storage.extendeds3.ExtendedS3StorageConfig;
+import io.pravega.storage.extendeds3.S3ClientMock;
+import io.pravega.storage.extendeds3.S3Mock;
+import io.pravega.test.common.TestUtils;
+import lombok.Getter;
+import org.junit.After;
+import org.junit.Before;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * End-to-end tests for SegmentStore, with integrated Extended S3 Storage and DurableDataLog.
+ */
+public class ReplicatedExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
+    //region Test Configuration and Setup
+
+    private String s3ConfigUri;
+    private S3Mock[] s3Mocks;
+
+    /**
+     * Starts BookKeeper.
+     */
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        s3ConfigUri = "http://127.0.0.1:" + TestUtils.getAvailableListenPort() + "?identity=x&secretKey=x";
+        s3Mocks = new S3Mock[2];
+        s3Mocks[0] = new S3Mock();
+        s3Mocks[1] = new S3Mock();
+        this.configBuilder.include(ExtendedS3StorageConfig.builder()
+                .with(ExtendedS3StorageConfig.CONFIGURI, s3ConfigUri)
+                .with(ExtendedS3StorageConfig.BUCKET, "testbucket"));
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Override
+    public void testEndToEnd() {
+    }
+
+    @Override
+    public void testFlushToStorage() {
+    }
+
+    @Override
+    public void testEndToEndWithFencing() {
+    }
+    //endregion
+
+    //region StreamSegmentStoreTestBase Implementation
+
+    @Override
+    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder configBuilder, int instanceId, boolean useChunkedSegmentStorage) {
+        ServiceBuilderConfig builderConfig = getBuilderConfig(configBuilder, instanceId);
+        return ServiceBuilder
+                .newInMemoryBuilder(builderConfig)
+                .withStorageFactory(setup -> new LocalReplicatedExtendedS3SimpleStorageFactory(setup.getConfig(ExtendedS3StorageConfig::builder), setup.getStorageExecutor()))
+                .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder),
+                        getBookkeeper().getZkClient(), setup.getCoreExecutor()));
+    }
+
+    private class LocalReplicatedExtendedS3SimpleStorageFactory implements SimpleStorageFactory {
+        private final ExtendedS3StorageConfig config;
+
+        @Getter
+        private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .journalSnapshotInfoUpdateFrequency(Duration.ofMillis(10))
+                .maxJournalUpdatesPerSnapshot(5)
+                .garbageCollectionDelay(Duration.ofMillis(10))
+                .garbageCollectionSleep(Duration.ofMillis(10))
+                .selfCheckEnabled(true)
+                .build();
+
+        @Getter
+        private final ScheduledExecutorService executor;
+
+        LocalReplicatedExtendedS3SimpleStorageFactory(ExtendedS3StorageConfig config, ScheduledExecutorService executor) {
+            this.config = Preconditions.checkNotNull(config, "config");
+            this.executor = Preconditions.checkNotNull(executor, "executor");
+        }
+
+        @Override
+        public Storage createStorageAdapter(int containerId, ChunkMetadataStore metadataStore) {
+            return new ChunkedSegmentStorage(containerId,
+                    createChunkStorage(),
+                    metadataStore,
+                    this.executor,
+                    this.chunkedSegmentStorageConfig);
+        }
+
+        /**
+         * Creates a new instance of a Storage adapter.
+         */
+        @Override
+        public Storage createStorageAdapter() {
+            throw new UnsupportedOperationException("SimpleStorageFactory requires ChunkMetadataStore");
+        }
+
+        @Override
+        public ChunkStorage createChunkStorage() {
+            URI uri = URI.create(s3ConfigUri);
+            S3Config s3Config = new S3Config(uri);
+
+            s3Config = s3Config
+                    .withRetryEnabled(false)
+                    .withInitialRetryDelay(1)
+                    .withProperty("com.sun.jersey.client.property.connectTimeout", 100);
+
+            // Create replicas
+            AsyncBaseChunkStorage[] replicas = new AsyncBaseChunkStorage[s3Mocks.length];
+            for (int i = 0; i < replicas.length; i++) {
+                S3ClientMock client = new S3ClientMock(s3Config, s3Mocks[i]);
+                replicas[i] = new ExtendedS3ChunkStorage(client, this.config, executorService(), true, false);
+            }
+            return new ReplicatedChunkStorage(replicas, executor);
+        }
+    }
+    //endregion
+}

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ReplicatedFlakyExtendedS3IntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/ReplicatedFlakyExtendedS3IntegrationTest.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.server.host;
+
+import com.emc.object.s3.S3Config;
+import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.server.store.ServiceBuilder;
+import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
+import io.pravega.segmentstore.storage.SimpleStorageFactory;
+import io.pravega.segmentstore.storage.Storage;
+import io.pravega.segmentstore.storage.chunklayer.ChunkNotFoundException;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorage;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorage;
+import io.pravega.segmentstore.storage.chunklayer.ChunkedSegmentStorageConfig;
+import io.pravega.segmentstore.storage.chunklayer.FlakinessPredicate;
+import io.pravega.segmentstore.storage.chunklayer.FlakyChunkStorage;
+import io.pravega.segmentstore.storage.chunklayer.ReplicatedChunkStorage;
+import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperConfig;
+import io.pravega.segmentstore.storage.impl.bookkeeper.BookKeeperLogFactory;
+import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
+import io.pravega.storage.extendeds3.ExtendedS3ChunkStorage;
+import io.pravega.storage.extendeds3.ExtendedS3StorageConfig;
+import io.pravega.storage.extendeds3.S3ClientMock;
+import io.pravega.storage.extendeds3.S3Mock;
+import io.pravega.test.common.TestUtils;
+import lombok.Getter;
+import org.junit.After;
+import org.junit.Before;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * End-to-end tests for SegmentStore, with integrated Extended S3 Storage and DurableDataLog.
+ */
+public class ReplicatedFlakyExtendedS3IntegrationTest extends BookKeeperIntegrationTestBase {
+    //region Test Configuration and Setup
+
+    private String s3ConfigUri;
+    private S3Mock[] s3Mocks;
+
+    /**
+     * Starts BookKeeper.
+     */
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        s3ConfigUri = "http://127.0.0.1:" + TestUtils.getAvailableListenPort() + "?identity=x&secretKey=x";
+        s3Mocks = new S3Mock[3];
+        s3Mocks[0] = new S3Mock();
+        s3Mocks[1] = new S3Mock();
+        s3Mocks[2] = new S3Mock();
+        this.configBuilder.include(ExtendedS3StorageConfig.builder()
+                .with(ExtendedS3StorageConfig.CONFIGURI, s3ConfigUri)
+                .with(ExtendedS3StorageConfig.BUCKET, "testbucket"));
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Override
+    public void testEndToEnd() {
+    }
+
+    @Override
+    public void testFlushToStorage() {
+    }
+
+    @Override
+    public void testEndToEndWithFencing() {
+    }
+    //endregion
+
+    //region StreamSegmentStoreTestBase Implementation
+
+    @Override
+    protected ServiceBuilder createBuilder(ServiceBuilderConfig.Builder configBuilder, int instanceId, boolean useChunkedSegmentStorage) {
+        ServiceBuilderConfig builderConfig = getBuilderConfig(configBuilder, instanceId);
+        return ServiceBuilder
+                .newInMemoryBuilder(builderConfig)
+                .withStorageFactory(setup -> new LocalReplicatedExtendedS3SimpleStorageFactory(setup.getConfig(ExtendedS3StorageConfig::builder), setup.getStorageExecutor()))
+                .withDataLogFactory(setup -> new BookKeeperLogFactory(setup.getConfig(BookKeeperConfig::builder),
+                        getBookkeeper().getZkClient(), setup.getCoreExecutor()));
+    }
+
+    private class LocalReplicatedExtendedS3SimpleStorageFactory implements SimpleStorageFactory {
+        private final ExtendedS3StorageConfig config;
+
+        @Getter
+        private final ChunkedSegmentStorageConfig chunkedSegmentStorageConfig = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                .journalSnapshotInfoUpdateFrequency(Duration.ofMillis(10))
+                .maxJournalUpdatesPerSnapshot(5)
+                .garbageCollectionDelay(Duration.ofMillis(10))
+                .garbageCollectionSleep(Duration.ofMillis(10))
+                .selfCheckEnabled(true)
+                .build();
+
+        @Getter
+        private final ScheduledExecutorService executor;
+
+        LocalReplicatedExtendedS3SimpleStorageFactory(ExtendedS3StorageConfig config, ScheduledExecutorService executor) {
+            this.config = Preconditions.checkNotNull(config, "config");
+            this.executor = Preconditions.checkNotNull(executor, "executor");
+        }
+
+        @Override
+        public Storage createStorageAdapter(int containerId, ChunkMetadataStore metadataStore) {
+            return new ChunkedSegmentStorage(containerId,
+                    createChunkStorage(),
+                    metadataStore,
+                    this.executor,
+                    this.chunkedSegmentStorageConfig);
+        }
+
+        /**
+         * Creates a new instance of a Storage adapter.
+         */
+        @Override
+        public Storage createStorageAdapter() {
+            throw new UnsupportedOperationException("SimpleStorageFactory requires ChunkMetadataStore");
+        }
+
+        @Override
+        public ChunkStorage createChunkStorage() {
+            URI uri = URI.create(s3ConfigUri);
+            S3Config s3Config = new S3Config(uri);
+
+            s3Config = s3Config
+                    .withRetryEnabled(false)
+                    .withInitialRetryDelay(1)
+                    .withProperty("com.sun.jersey.client.property.connectTimeout", 100);
+
+            // Create replicas
+            FlakyChunkStorage[] replicas = new FlakyChunkStorage[s3Mocks.length];
+            for (int i = 0; i < replicas.length; i++) {
+                S3ClientMock client = new S3ClientMock(s3Config, s3Mocks[i]);
+                replicas[i] = new FlakyChunkStorage(new ExtendedS3ChunkStorage(client, this.config, executorService(), true, false), executorService());
+            }
+            // These are set up so that
+            // Every 2nd read call fails on chunkStorage1
+            // Every 4th read call fails on both chunkStorage1, chunkStorage2
+            // chunkStorage3 never fails.
+            // This way at least one chunkstorage always succeeds.
+            // In other words, even with 0, 1 or 2 failures the overall call always succeeds.
+            replicas[0].addFlakiness(FlakinessPredicate.builder()
+                    .method("doRead.before")
+                    .matchPredicate(n -> n % 2 == 0)  // every alternate read fails (even numbered).
+                    //.matchPredicate( n -> false)
+                    .matchRegEx("") // match any chunk
+                    .action(() -> {
+                        throw new ChunkNotFoundException("chunk", "intentional");
+                    })
+                    .build());
+
+            // Every 2nd call comes to this instance, and every 4th fails.
+            replicas[1].addFlakiness(FlakinessPredicate.builder()
+                    .method("doRead.before")
+                    .matchPredicate(n -> n % 2 == 0)  // every alternate read fails (even numbered).
+                    .matchRegEx("") // match any chunk
+                    .action(() -> {
+                        throw new ChunkNotFoundException("chunk", "intentional");
+                    })
+                    .build());
+            // Every 2nd call fails to write.
+            replicas[1].addFlakiness(FlakinessPredicate.builder()
+                    .method("doWrite.before")
+                    .matchPredicate(n -> n % 2 == 0)  // every alternate read fails (even numbered).
+                    .matchRegEx("") // match any chunk
+                    .action(() -> {
+                        throw new ChunkNotFoundException("chunk", "intentional");
+                    })
+                    .build());
+
+            replicas[2].addFlakiness(FlakinessPredicate.builder()
+                    .method("doWrite.before")
+                    .matchPredicate(n -> n % 4 == 0)  // every alternate read fails (even numbered).
+                    .matchRegEx("") // match any chunk
+                    .action(() -> {
+                        throw new ChunkNotFoundException("chunk", "intentional");
+                    })
+                    .build());
+
+            // Always succeeds.
+            return new ReplicatedChunkStorage(replicas, executor);
+        }
+    }
+    //endregion
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/AsyncBaseChunkStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/AsyncBaseChunkStorage.java
@@ -73,6 +73,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
 
     private final AtomicBoolean closed;
 
+    @Getter
     private final Executor executor;
 
     /**
@@ -555,7 +556,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<ChunkInfo> doGetInfoAsync(String chunkName, OperationContext opContext);
+    abstract CompletableFuture<ChunkInfo> doGetInfoAsync(String chunkName, OperationContext opContext);
 
     /**
      * Creates a new chunk.
@@ -567,7 +568,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<ChunkHandle> doCreateAsync(String chunkName, OperationContext opContext);
+    abstract CompletableFuture<ChunkHandle> doCreateAsync(String chunkName, OperationContext opContext);
 
     /**
      * Creates a new chunk with provided content.
@@ -581,7 +582,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<ChunkHandle> doCreateWithContentAsync(String chunkName, int length, InputStream data, OperationContext opContext);
+    abstract CompletableFuture<ChunkHandle> doCreateWithContentAsync(String chunkName, int length, InputStream data, OperationContext opContext);
 
     /**
      * Determines whether named chunk exists in underlying storage.
@@ -593,7 +594,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<Boolean> checkExistsAsync(String chunkName, OperationContext opContext);
+    abstract CompletableFuture<Boolean> checkExistsAsync(String chunkName, OperationContext opContext);
 
     /**
      * Deletes a chunk.
@@ -606,7 +607,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<Void> doDeleteAsync(ChunkHandle handle, OperationContext opContext);
+    abstract CompletableFuture<Void> doDeleteAsync(ChunkHandle handle, OperationContext opContext);
 
     /**
      * Opens chunk for Read.
@@ -618,7 +619,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<ChunkHandle> doOpenReadAsync(String chunkName, OperationContext opContext);
+    abstract CompletableFuture<ChunkHandle> doOpenReadAsync(String chunkName, OperationContext opContext);
 
     /**
      * Opens chunk for Write (or modifications).
@@ -630,7 +631,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<ChunkHandle> doOpenWriteAsync(String chunkName, OperationContext opContext);
+    abstract CompletableFuture<ChunkHandle> doOpenWriteAsync(String chunkName, OperationContext opContext);
 
     /**
      * Reads a range of bytes from the underlying chunk.
@@ -648,7 +649,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<Integer> doReadAsync(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset, OperationContext opContext);
+    abstract CompletableFuture<Integer> doReadAsync(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset, OperationContext opContext);
 
     /**
      * Writes the given data to the chunk.
@@ -664,7 +665,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<Integer> doWriteAsync(ChunkHandle handle, long offset, int length, InputStream data, OperationContext opContext);
+    abstract CompletableFuture<Integer> doWriteAsync(ChunkHandle handle, long offset, int length, InputStream data, OperationContext opContext);
 
     /**
      * Concatenates two or more chunks using storage native functionality. (Eg. Multipart upload.)
@@ -677,7 +678,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<Integer> doConcatAsync(ConcatArgument[] chunks, OperationContext opContext);
+    abstract CompletableFuture<Integer> doConcatAsync(ConcatArgument[] chunks, OperationContext opContext);
 
     /**
      * Sets readonly attribute for the chunk.
@@ -691,7 +692,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<Void> doSetReadOnlyAsync(ChunkHandle handle, boolean isReadOnly, OperationContext opContext);
+    abstract CompletableFuture<Void> doSetReadOnlyAsync(ChunkHandle handle, boolean isReadOnly, OperationContext opContext);
 
     /**
      * Truncates a given chunk.
@@ -704,7 +705,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      * {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    protected CompletableFuture<Boolean> doTruncateAsync(ChunkHandle handle, long offset, OperationContext opContext) {
+    CompletableFuture<Boolean> doTruncateAsync(ChunkHandle handle, long offset, OperationContext opContext) {
         throw new UnsupportedOperationException();
     }
 
@@ -718,7 +719,7 @@ public abstract class AsyncBaseChunkStorage implements ChunkStorage {
      * @throws CompletionException           If the operation failed, it will be completed with the appropriate exception. Notable Exceptions:
      *                                       {@link ChunkStorageException} In case of I/O related exceptions.
      */
-    abstract protected CompletableFuture<Long> doGetUsedSpaceAsync(OperationContext opContext);
+    abstract CompletableFuture<Long> doGetUsedSpaceAsync(OperationContext opContext);
 
     /**
      * Validate chunk name.

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ReplicatedChunkStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ReplicatedChunkStorage.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import com.google.common.annotations.Beta;
+import com.google.common.base.Preconditions;
+import io.pravega.common.Exceptions;
+import io.pravega.common.Timer;
+import io.pravega.common.concurrent.Futures;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.time.Duration;
+import java.util.Vector;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Replicated Chunk Storage.
+ */
+@Slf4j
+@Beta
+public class ReplicatedChunkStorage extends AsyncBaseChunkStorage {
+    final AsyncBaseChunkStorage[] chunkStorages;
+    final AtomicReference<int[]> preferredOrder = new AtomicReference<>(null);
+    /**
+     * Constructor.
+     *
+     * @param chunkStorages Chunk storages.
+     * @param executor  An Executor for async operations.
+     */
+    public ReplicatedChunkStorage(AsyncBaseChunkStorage[] chunkStorages, Executor executor) {
+        super(executor);
+        this.chunkStorages = Preconditions.checkNotNull(chunkStorages, "chunkStorages");
+        val sequence = new int[chunkStorages.length];
+        for (int i = 0; i < chunkStorages.length; i++) {
+            sequence[i] = i;
+        }
+        this.preferredOrder.set(sequence);
+    }
+
+    @Override
+    public boolean supportsTruncation() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsAppend() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsConcat() {
+        return false;
+    }
+
+    @Override
+    protected CompletableFuture<ChunkInfo> doGetInfoAsync(String chunkName, OperationContext opContext) {
+        return executeAny((chunkStorage, innerContext) -> chunkStorage.doGetInfoAsync(chunkName, innerContext), opContext);
+    }
+
+    @Override
+    protected CompletableFuture<ChunkHandle> doCreateAsync(String chunkName, OperationContext opContext) {
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    protected CompletableFuture<ChunkHandle> doCreateWithContentAsync(String chunkName, int length, InputStream data, OperationContext opContext) {
+        try {
+            val copy = data.readAllBytes();
+            return executeAll((chunkStorage, innerContext) -> chunkStorage.doCreateWithContentAsync(chunkName, length, new ByteArrayInputStream(copy), innerContext), opContext, retValues -> retValues.get(0));
+        } catch (IOException e) {
+            return CompletableFuture.failedFuture(Exceptions.unwrap(e));
+        }
+    }
+
+    @Override
+    protected CompletableFuture<Boolean> checkExistsAsync(String chunkName, OperationContext opContext) {
+        return executeAny((chunkStorage, innerContext) -> chunkStorage.checkExistsAsync(chunkName, innerContext), opContext);
+    }
+
+    @Override
+    protected CompletableFuture<Void> doDeleteAsync(ChunkHandle handle, OperationContext opContext) {
+        return executeAll((chunkStorage, innerContext) -> chunkStorage.doDeleteAsync(handle, innerContext), opContext, retValues -> retValues.get(0));
+    }
+
+    @Override
+    protected CompletableFuture<ChunkHandle> doOpenReadAsync(String chunkName, OperationContext opContext) {
+        return executeAll((chunkStorage, innerContext) -> chunkStorage.doOpenReadAsync(chunkName, innerContext), opContext, retValues -> retValues.get(0));
+    }
+
+    @Override
+    protected CompletableFuture<ChunkHandle> doOpenWriteAsync(String chunkName, OperationContext opContext) {
+        return executeAll((chunkStorage, innerContext) -> chunkStorage.doOpenWriteAsync(chunkName, innerContext), opContext, retValues -> retValues.get(0));
+    }
+
+    @Override
+    protected CompletableFuture<Integer> doReadAsync(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset, OperationContext opContext) {
+        return executeAny((chunkStorage, innerContext) -> chunkStorage.doReadAsync(handle, fromOffset, length, buffer, bufferOffset, innerContext), opContext);
+    }
+
+    @Override
+    protected CompletableFuture<Integer> doWriteAsync(ChunkHandle handle, long offset, int length, InputStream data, OperationContext opContext) {
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    protected CompletableFuture<Integer> doConcatAsync(ConcatArgument[] chunks, OperationContext opContext) {
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    protected CompletableFuture<Void> doSetReadOnlyAsync(ChunkHandle handle, boolean isReadOnly, OperationContext opContext) {
+        return executeAll((chunkStorage, innerContext) -> chunkStorage.doSetReadOnlyAsync(handle, isReadOnly, innerContext), opContext, retValues -> retValues.get(0));
+    }
+
+    @Override
+    protected CompletableFuture<Boolean> doTruncateAsync(ChunkHandle handle, long offset, OperationContext opContext) {
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    protected CompletableFuture<Long> doGetUsedSpaceAsync(OperationContext opContext) {
+        return executeAll((chunkStorage, innerContext) -> chunkStorage.doGetUsedSpaceAsync(innerContext), opContext, retValues -> retValues.get(0));
+    }
+
+    private <R> CompletableFuture<R> executeAll(BiFunction<AsyncBaseChunkStorage, OperationContext, CompletableFuture<R>> toExecute, OperationContext operationContext, Function<Vector<CompletableFuture<R>>, CompletableFuture<R>> reducer) {
+        val futures = new Vector<CompletableFuture<R>>();
+        val  contexts = new OperationContext[chunkStorages.length];
+        for (int i = 0; i < chunkStorages.length; i++) {
+            val chunkStorage = chunkStorages[i];
+            contexts[i] = new OperationContext();
+            val future = toExecute.apply(chunkStorage, contexts[i]);
+            Preconditions.checkState(future != null);
+            futures.add(future);
+        }
+        Preconditions.checkState(null != futures && futures.size() == chunkStorages.length);
+        return Futures.allOf(futures)
+                .handleAsync( (v, e)  -> {
+                    long max = 0;
+                    for (val context: contexts) {
+                        max = Math.max(max, context.getInclusiveLatency().toMillis());
+                    }
+                    operationContext.setInclusiveLatency(Duration.ofMillis(max));
+                    if (null != e) {
+                        throw new CompletionException(Exceptions.unwrap(e));
+                    }
+                    return reducer.apply(futures).join();
+                }, getExecutor());
+    }
+
+    private <R> CompletableFuture<R> executeAny(BiFunction<AsyncBaseChunkStorage, OperationContext, CompletableFuture<R>> toExecute, OperationContext operationContext) {
+        val shouldContinue = new AtomicBoolean(true);
+        val index = new AtomicInteger(0);
+        val retValue = new AtomicReference<CompletableFuture<R>>(null);
+        val timer = new Timer();
+        return Futures.loop(
+                () -> shouldContinue.get() && index.get() < chunkStorages.length,
+                () -> {
+                    val innerOpContext = new OperationContext();
+                    val future = toExecute.apply(chunkStorages[index.get()], innerOpContext);
+                    retValue.set(future);
+                    return future.handleAsync( (v, e) -> {
+                        if (e == null) {
+                            shouldContinue.set(false);
+                            operationContext.setInclusiveLatency(timer.getElapsed());
+                            return v;
+                        } else {
+                            val ex = Exceptions.unwrap(e);
+                            if (isStorageUnavailable(ex)) {
+                                // Try with next instance.
+                                index.incrementAndGet();
+                            } else {
+                                throw new CompletionException(ex);
+                            }
+                        }
+                        return null;
+                    }, getExecutor());
+                },
+                r -> CompletableFuture.completedFuture(null),
+                getExecutor())
+        .thenComposeAsync( v -> retValue.get(), getExecutor());
+
+    }
+
+    private static boolean isStorageUnavailable(Throwable ex) {
+        return ex instanceof ChunkNotFoundException;
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/FlakinessPredicate.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/FlakinessPredicate.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.concurrent.Callable;
+import java.util.function.Function;
+
+/**
+ * Defines the flaky behavior matching given Predicate.
+ */
+@Builder
+@Data
+@RequiredArgsConstructor
+public class FlakinessPredicate {
+    @NonNull
+    final String matchRegEx;
+    @NonNull
+    final String method;
+    @NonNull
+    final Function<Integer, Boolean> matchPredicate;
+    @NonNull
+    final Callable action;
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/FlakyChunkStorage.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/FlakyChunkStorage.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import com.google.common.base.Preconditions;
+import lombok.Getter;
+import lombok.val;
+
+import java.io.InputStream;
+import java.util.concurrent.Executor;
+
+/**
+ * {@link ChunkStorage} implementation that fails predictably based on provided list of {@link FlakinessPredicate}.
+ */
+public class FlakyChunkStorage extends BaseChunkStorage {
+    @Getter
+    final BaseChunkStorage innerChunkStorage;
+    final FlakyInterceptor interceptor = new FlakyInterceptor();
+
+    public FlakyChunkStorage(BaseChunkStorage innerChunkStorage, Executor executor) {
+        super(executor);
+        this.innerChunkStorage = Preconditions.checkNotNull(innerChunkStorage, "innerChunkStorage");
+    }
+
+    public void addFlakiness(FlakinessPredicate predicate) {
+        interceptor.flakyPredicates.add(predicate);
+    }
+
+    @Override
+    protected int doWrite(ChunkHandle handle, long offset, int length, InputStream data) throws ChunkStorageException {
+        // Apply any interceptors with identifier 'doWrite.before' or 'doWrite.after'
+        interceptor.intercept(handle.getChunkName(), "doWrite.before");
+        val ret = innerChunkStorage.doWrite(handle, offset, length, data);
+        interceptor.intercept(handle.getChunkName(), "doWrite.after");
+        return ret;
+    }
+
+    @Override
+    protected int doConcat(ConcatArgument[] chunks) throws ChunkStorageException, UnsupportedOperationException {
+        // Apply any interceptors with identifier 'doConcat.before' or 'doConcat.after'
+        interceptor.intercept(chunks[0].getName(), "doConcat.before");
+        val ret = innerChunkStorage.doConcat(chunks);
+        interceptor.intercept(chunks[0].getName(), "doConcat.after");
+        return ret;
+    }
+
+    @Override
+    protected void doSetReadOnly(ChunkHandle handle, boolean isReadOnly) throws ChunkStorageException, UnsupportedOperationException {
+        // Apply any interceptors with identifier 'doSetReadOnly.before' or 'doSetReadOnly.after'
+        interceptor.intercept(handle.getChunkName(), "doSetReadOnly.before");
+        innerChunkStorage.doSetReadOnly(handle, isReadOnly);
+        interceptor.intercept(handle.getChunkName(), "doSetReadOnly.after");
+    }
+
+    @Override
+    protected ChunkHandle doCreateWithContent(String chunkName, int length, InputStream data) throws ChunkStorageException {
+        // Apply any interceptors with identifier 'doWrite.before' or 'doWrite.after'
+        interceptor.intercept(chunkName, "doWrite.before");
+        // Make sure you are calling methods on super class.
+        ChunkHandle handle = innerChunkStorage.doCreate(chunkName);
+        int bytesWritten = innerChunkStorage.doWrite(handle, 0, length, data);
+        if (bytesWritten < length) {
+            innerChunkStorage.doDelete(ChunkHandle.writeHandle(chunkName));
+            throw new ChunkStorageException(chunkName, "doCreateWithContent - invalid length returned");
+        }
+        val ret = handle;
+        interceptor.intercept(chunkName, "doWrite.after");
+        return ret;
+    }
+
+    @Override
+    protected boolean checkExists(String chunkName) throws ChunkStorageException {
+        // Apply any interceptors with identifier 'checkExists.before' or 'checkExists.after'
+        interceptor.intercept(chunkName, "checkExists.before");
+        val ret = innerChunkStorage.checkExists(chunkName);
+        interceptor.intercept(chunkName, "checkExists.after");
+        return ret;
+    }
+
+    @Override
+    protected void doDelete(ChunkHandle handle) throws ChunkStorageException {
+        // Apply any interceptors with identifier 'doDelete.before' or 'doDelete.after'
+        interceptor.intercept(handle.getChunkName(), "doDelete.before");
+        innerChunkStorage.doDelete(handle);
+        interceptor.intercept(handle.getChunkName(), "doDelete.after");
+    }
+
+    @Override
+    protected ChunkHandle doOpenRead(String chunkName) throws ChunkStorageException {
+        // Apply any interceptors with identifier 'doOpenRead.before' or 'doOpenRead.after'
+        interceptor.intercept(chunkName, "doOpenRead.before");
+        val ret = innerChunkStorage.doOpenRead(chunkName);
+        interceptor.intercept(chunkName, "doOpenRead.after");
+        return ret;
+    }
+
+    @Override
+    protected ChunkHandle doOpenWrite(String chunkName) throws ChunkStorageException {
+        // Apply any interceptors with identifier 'doOpenWrite.before' or 'doOpenWrite.after'
+        interceptor.intercept(chunkName, "doOpenWrite.before");
+        val ret = innerChunkStorage.doOpenWrite(chunkName);
+        interceptor.intercept(chunkName, "doOpenWrite.after");
+        return ret;
+    }
+
+    @Override
+    protected ChunkInfo doGetInfo(String chunkName) throws ChunkStorageException {
+        // Apply any interceptors with identifier 'doGetInfo.before' or 'doGetInfo.after'
+        interceptor.intercept(chunkName, "doGetInfo.before");
+        val ret = innerChunkStorage.doGetInfo(chunkName);
+        interceptor.intercept(chunkName, "doGetInfo.after");
+        return ret;
+    }
+
+    @Override
+    protected ChunkHandle doCreate(String chunkName) throws ChunkStorageException, IllegalArgumentException {
+        // Apply any interceptors with identifier 'doWrite.before' or 'doWrite.after'
+        interceptor.intercept(chunkName, "doWrite.before");
+        // Make sure you are calling methods on super class.
+        val ret = innerChunkStorage.doCreate(chunkName);
+        interceptor.intercept(chunkName, "doWrite.after");
+        return ret;
+    }
+
+    @Override
+    protected int doRead(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset) throws ChunkStorageException {
+        // Apply any interceptors with identifier 'doRead.before' or 'doRead.after'
+        interceptor.intercept(handle.getChunkName(), "doRead.before");
+        val ret = innerChunkStorage.doRead(handle, fromOffset, length, buffer, bufferOffset);
+        interceptor.intercept(handle.getChunkName(), "doRead.after");
+        return ret;
+    }
+
+    @Override
+    public boolean supportsTruncation() {
+        return innerChunkStorage.supportsTruncation();
+    }
+
+    @Override
+    public boolean supportsAppend() {
+        return innerChunkStorage.supportsAppend();
+    }
+
+    @Override
+    public boolean supportsConcat() {
+        return innerChunkStorage.supportsConcat();
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/FlakyInterceptor.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/FlakyInterceptor.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import lombok.val;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+/**
+ * Provides mechanism for implementation that fails predictably based on provided list of {@link FlakinessPredicate}.
+ */
+public class FlakyInterceptor {
+    /**
+     * Predicate to evaluate against each invocation.
+     */
+    final ArrayList<FlakinessPredicate> flakyPredicates = new ArrayList<>();
+
+    /**
+     * Keeps track of invocations.
+     */
+    final HashMap<String, Integer> invokeCounts = new HashMap<>();
+
+    FlakinessPredicate getMatchingPredicate(String resourceName, String method, int invocationCount) {
+        return flakyPredicates.stream()
+                .filter(predicate -> predicate.method.equals(method)
+                        && resourceName.contains(predicate.matchRegEx)
+                        && predicate.matchPredicate.apply(invocationCount))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public void intercept(String resourceName, String method) throws ChunkStorageException {
+        int invocationCount = 0;
+        if (!invokeCounts.containsKey(method)) {
+            invokeCounts.put(method, 0);
+        }
+        invocationCount = invokeCounts.get(method);
+        invokeCounts.put(method, invocationCount + 1);
+        val predicate = getMatchingPredicate(resourceName, method, invocationCount);
+        if (null != predicate) {
+            try {
+                predicate.action.call();
+            } catch (ChunkStorageException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new ChunkStorageException(resourceName, "Intentional Failure", e);
+            }
+        }
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/FlakySnapshotInfoStore.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/FlakySnapshotInfoStore.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.segmentstore.storage.mocks.InMemorySnapshotInfoStore;
+import lombok.SneakyThrows;
+import lombok.val;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link SnapshotInfoStore} implementation that fails predictably based on provided list of {@link FlakinessPredicate}.
+ */
+public class FlakySnapshotInfoStore extends InMemorySnapshotInfoStore {
+    final FlakyInterceptor interceptor = new FlakyInterceptor();
+
+    @Override
+    @SneakyThrows
+    public CompletableFuture<SnapshotInfo> getSnapshotId(int containerId) {
+        try {
+            interceptor.intercept(Integer.toString(containerId), "getSnapshotId.before");
+            val retValue = super.getSnapshotId(containerId);
+            interceptor.intercept(Integer.toString(containerId), "getSnapshotId.after");
+            return retValue;
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    @Override
+    @SneakyThrows
+    public CompletableFuture<Void> setSnapshotId(int containerId, SnapshotInfo checkpoint) {
+        try {
+            interceptor.intercept(Integer.toString(containerId), "setSnapshotId.before");
+            val retValue = super.setSnapshotId(containerId, checkpoint);
+            interceptor.intercept(Integer.toString(containerId), "setSnapshotId.after");
+            return retValue;
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ReplicatedSimpleStorageTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ReplicatedSimpleStorageTests.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.segmentstore.storage.mocks.InMemoryChunkStorage;
+import lombok.val;
+import org.junit.Test;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link ReplicatedChunkStorage} using {@link SimpleStorageTests}.
+ */
+public class ReplicatedSimpleStorageTests extends SimpleStorageTests {
+    @Override
+    protected ChunkStorage getChunkStorage() {
+        return getReplicatedChunkStorage(executorService());
+    }
+
+    private static ChunkStorage getReplicatedChunkStorage(ScheduledExecutorService executorService) {
+        // These are set up so that
+        // Every 2nd read call fails on chunkStorage1
+        // Every 4th read call fails on both chunkStorage1, chunkStorage2
+        // chunkStorage3 never fails.
+        // This way at least one chunkstorage always succeeds.
+        // In other words, even with 0, 1 or 2 failures the overall call always succeeds.
+        val chunkStorage1 = new FlakyChunkStorage(new InMemoryChunkStorage(executorService), executorService);
+        chunkStorage1.interceptor.flakyPredicates.add(FlakinessPredicate.builder()
+                        .method("doRead.before")
+                        .matchPredicate(n -> n % 2 == 0)  // every alternate read fails (even numbered).
+                        .matchRegEx("") // match any chunk
+                        .action(() -> {
+                            throw new ChunkNotFoundException("chunk", "intentional");
+                        })
+                        .build());
+
+        // Every 2nd call comes to this instance, and every 4th fails.
+        val chunkStorage2 = new FlakyChunkStorage(new InMemoryChunkStorage(executorService), executorService);
+        chunkStorage2.interceptor.flakyPredicates.add(FlakinessPredicate.builder()
+                .method("doRead.before")
+                .matchPredicate(n -> n % 2 == 0)  // every alternate read fails (even numbered).
+                .matchRegEx("") // match any chunk
+                .action(() -> {
+                    throw new ChunkNotFoundException("chunk", "intentional");
+                })
+                .build());
+
+        // Always succeeds.
+        val chunkStorage3 = new FlakyChunkStorage(new InMemoryChunkStorage(executorService), executorService);
+
+        val storages = new AsyncBaseChunkStorage[]{ chunkStorage1, chunkStorage2, chunkStorage3};
+        return new ReplicatedChunkStorage(storages, executorService);
+    }
+
+    /**
+     * Unit tests for {@link ReplicatedChunkStorage} using {@link ChunkedRollingStorageTests}.
+     */
+    public static class ReplicatedChunkStorageRollingStorageTests extends ChunkedRollingStorageTests {
+        @Override
+        protected ChunkStorage getChunkStorage() {
+            return getReplicatedChunkStorage(executorService());
+        }
+    }
+
+    /**
+     * Unit tests for {@link ReplicatedChunkStorage} using {@link ChunkStorageTests}.
+     */
+    public static class ReplicatedChunkStorageTests extends ChunkStorageTests {
+        @Override
+        protected ChunkStorage createChunkStorage() {
+            return getReplicatedChunkStorage(executorService());
+        }
+
+        @Test
+        public void testCapabilities() {
+            assertEquals(false, chunkStorage.supportsAppend());
+            assertEquals(false, chunkStorage.supportsTruncation());
+            assertEquals(false, chunkStorage.supportsConcat());
+        }
+    }
+
+    public static class ReplicatedChunkStorageSystemJournalTests extends SystemJournalTests {
+        @Override
+        protected ChunkStorage getChunkStorage() {
+            return getReplicatedChunkStorage(executorService());
+        }
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalOperationsTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalOperationsTests.java
@@ -22,7 +22,6 @@ import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
 import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
 import io.pravega.segmentstore.storage.mocks.InMemoryChunkStorage;
 import io.pravega.segmentstore.storage.mocks.InMemoryMetadataStore;
-import io.pravega.segmentstore.storage.mocks.InMemorySnapshotInfoStore;
 import io.pravega.segmentstore.storage.mocks.InMemoryTaskQueueManager;
 import io.pravega.shared.NameUtils;
 import io.pravega.test.common.ThreadPooledTestSuite;
@@ -32,7 +31,6 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.val;
 import org.junit.After;
 import org.junit.Assert;
@@ -43,15 +41,10 @@ import org.junit.rules.Timeout;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.function.Function;
 
 /**
  * Tests for testing bootstrap functionality with {@link SystemJournal}.
@@ -682,7 +675,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
     void testWithFlakyChunkStorage(ChunkedSegmentStorageConfig config, TestMethod test, TestScenarioProvider scenarioProvider, String interceptMethod1, String interceptMethod2, int[] primes) throws Exception {
         for (val prime1 : primes) {
             for (val prime2 : primes) {
-                FlakyChunkStorage flakyChunkStorage = new FlakyChunkStorage(executorService());
+                FlakyChunkStorage flakyChunkStorage = new FlakyChunkStorage(new InMemoryChunkStorage(executorService()), executorService());
                 flakyChunkStorage.interceptor.flakyPredicates.add(FlakinessPredicate.builder()
                         .method(interceptMethod1)
                         .matchPredicate(n -> n % prime1 == 0)
@@ -706,7 +699,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
 
     void testWithFlakyChunkStorage(ChunkedSegmentStorageConfig config, TestMethod test, TestScenarioProvider scenarioProvider, String interceptMethod, int[] primes) throws Exception {
         for (val prime : primes) {
-            FlakyChunkStorage flakyChunkStorage = new FlakyChunkStorage(executorService());
+            FlakyChunkStorage flakyChunkStorage = new FlakyChunkStorage(new InMemoryChunkStorage(executorService()), executorService());
             flakyChunkStorage.interceptor.flakyPredicates.add(FlakinessPredicate.builder()
                     .method(interceptMethod)
                     .matchPredicate(n -> n % prime == 0)
@@ -721,7 +714,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
 
     void testScenarioWithFlakySnapshotInfoStore(ChunkedSegmentStorageConfig config, TestMethod test, TestScenarioProvider scenarioProvider, String interceptMethod, int[] primes) throws Exception {
         for (val prime : primes) {
-            FlakyChunkStorage flakyChunkStorage = new FlakyChunkStorage(executorService());
+            FlakyChunkStorage flakyChunkStorage = new FlakyChunkStorage(new InMemoryChunkStorage(executorService()), executorService());
             val flakySnaphotInfoStore = new FlakySnapshotInfoStore();
             flakySnaphotInfoStore.interceptor.flakyPredicates
                     .add(FlakinessPredicate.builder()
@@ -741,7 +734,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
                                                 int[] primes) throws Exception {
         for (val prime1 : primes) {
             for (val prime2 : primes) {
-                FlakyChunkStorage flakyChunkStorage = new FlakyChunkStorage(executorService());
+                FlakyChunkStorage flakyChunkStorage = new FlakyChunkStorage(new InMemoryChunkStorage(executorService()), executorService());
                 val flakySnaphotInfoStore = new FlakySnapshotInfoStore();
                 flakySnaphotInfoStore.interceptor.flakyPredicates
                         .add(FlakinessPredicate.builder()
@@ -1409,149 +1402,6 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         public void close() throws Exception {
             garbageCollector.close();
             metadataStore.close();
-        }
-    }
-
-    /**
-     * Defines the flaky behavior for the FlakyChunkStorage.
-     */
-    @Builder
-    @Data
-    @RequiredArgsConstructor
-    static class FlakinessPredicate {
-        @NonNull
-        final String matchRegEx;
-        @NonNull
-        final String method;
-        @NonNull
-        final Function<Integer, Boolean> matchPredicate;
-        @NonNull
-        final Callable action;
-    }
-
-    static class FlakyInterceptor {
-        /**
-         * Predicate to evaluate against each invocation.
-         */
-        final ArrayList<FlakinessPredicate> flakyPredicates = new ArrayList<>();
-
-        /**
-         * Keeps track of invocations.
-         */
-        final HashMap<String, Integer> invokeCounts = new HashMap<>();
-
-        FlakinessPredicate getMatchingPredicate(String resourceName, String method, int invocationCount) {
-            return flakyPredicates.stream()
-                    .filter(predicate -> predicate.method.equals(method)
-                            && resourceName.contains(predicate.matchRegEx)
-                            && predicate.matchPredicate.apply(invocationCount))
-                    .findFirst()
-                    .orElse(null);
-        }
-
-        private void intercept(String resourceName, String method) throws ChunkStorageException {
-            int invocationCount = 0;
-            if (!invokeCounts.containsKey(method)) {
-                invokeCounts.put(method, 0);
-            }
-            invocationCount = invokeCounts.get(method);
-            invokeCounts.put(method, invocationCount + 1);
-            val predicate = getMatchingPredicate(resourceName, method, invocationCount);
-            if (null != predicate) {
-                try {
-                    predicate.action.call();
-                } catch (ChunkStorageException e) {
-                    throw e;
-                } catch (Exception e) {
-                    throw new ChunkStorageException(resourceName, "Intentional Failure", e);
-                }
-            }
-        }
-    }
-
-    /**
-     * {@link ChunkStorage} implementation that fails predictably based on provided list of {@link FlakinessPredicate}.
-     */
-    static class FlakyChunkStorage extends InMemoryChunkStorage {
-
-        final FlakyInterceptor  interceptor = new FlakyInterceptor();
-
-        FlakyChunkStorage(Executor executor) {
-            super(executor);
-        }
-
-        @Override
-        protected int doWrite(ChunkHandle handle, long offset, int length, InputStream data) throws ChunkStorageException {
-            // Apply any interceptors with identifier 'doWrite.before' or 'doWrite.after'
-            interceptor.intercept(handle.getChunkName(), "doWrite.before");
-            val ret = super.doWrite(handle, offset, length, data);
-            interceptor.intercept(handle.getChunkName(), "doWrite.after");
-            return ret;
-        }
-
-        @Override
-        protected ChunkHandle doCreateWithContent(String chunkName, int length, InputStream data) throws ChunkStorageException {
-            // Apply any interceptors with identifier 'doWrite.before' or 'doWrite.after'
-            interceptor.intercept(chunkName, "doWrite.before");
-            // Make sure you are calling methods on super class.
-            ChunkHandle handle = super.doCreate(chunkName);
-            int bytesWritten = super.doWrite(handle, 0, length, data);
-            if (bytesWritten < length) {
-                super.doDelete(ChunkHandle.writeHandle(chunkName));
-                throw new ChunkStorageException(chunkName, "doCreateWithContent - invalid length returned");
-            }
-            val ret = handle;
-            interceptor.intercept(chunkName, "doWrite.after");
-            return ret;
-        }
-
-        @Override
-        protected ChunkHandle doCreate(String chunkName) throws ChunkStorageException, IllegalArgumentException {
-            // Apply any interceptors with identifier 'doWrite.before' or 'doWrite.after'
-            interceptor.intercept(chunkName, "doWrite.before");
-            // Make sure you are calling methods on super class.
-            val ret = super.doCreate(chunkName);
-            interceptor.intercept(chunkName, "doWrite.after");
-            return ret;
-        }
-
-        @Override
-        protected int doRead(ChunkHandle handle, long fromOffset, int length, byte[] buffer, int bufferOffset) throws ChunkStorageException {
-            // Apply any interceptors with identifier 'doRead.before' or 'doRead.after'
-            interceptor.intercept(handle.getChunkName(), "doRead.before");
-            val ret = super.doRead(handle, fromOffset, length, buffer, bufferOffset);
-            interceptor.intercept(handle.getChunkName(), "doRead.after");
-            return ret;
-        }
-    }
-
-    static class FlakySnapshotInfoStore extends InMemorySnapshotInfoStore {
-        final FlakyInterceptor  interceptor = new FlakyInterceptor();
-
-        @Override
-        @SneakyThrows
-        public CompletableFuture<SnapshotInfo> getSnapshotId(int containerId) {
-            try {
-                interceptor.intercept(Integer.toString(containerId), "getSnapshotId.before");
-                val retValue = super.getSnapshotId(containerId);
-                interceptor.intercept(Integer.toString(containerId), "getSnapshotId.after");
-                return retValue;
-            }  catch (Exception e) {
-                return CompletableFuture.failedFuture(e);
-            }
-        }
-
-        @Override
-        @SneakyThrows
-        public CompletableFuture<Void> setSnapshotId(int containerId, SnapshotInfo checkpoint) {
-            try {
-                interceptor.intercept(Integer.toString(containerId), "setSnapshotId.before");
-                val retValue = super.setSnapshotId(containerId, checkpoint);
-                interceptor.intercept(Integer.toString(containerId), "setSnapshotId.after");
-                return retValue;
-            }  catch (Exception e) {
-                return CompletableFuture.failedFuture(e);
-            }
         }
     }
 


### PR DESCRIPTION
Experimental - 
**Change log description**  
1. Implement ReplicatedChunkStorage that wraps multiple instances of chunk storage acting as an ensemble.
Write quorum - all replicas must succeed.
Read quorum - at least one replica succeeds.
2. Hack ECS ChunkStorage factory to allow specifying multiple end points and create ensemble 
3. Add end to end integration test for ECS 
4. Refactor test code to pull out FlakyChunkStorage so that it cane be used widely in other tests. 

**Purpose of the change**  
(_e.g._, Fixes #666, Closes #1234)

**What the code does**  
(Detailed description of the code changes)

**How to verify it**  
(Optional: steps to verify that the changes are effective)
