### PR TITLE
Issue 6889: Upgrading adoptOpenJDK and python3 to 3.10.5

### DIFF
--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM adoptopenjdk/openjdk11:jre-11.0.11_9-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.16.1_1-alpine
 
 RUN apk --update --no-cache add \
     #used in readiness and liveness probes

--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -19,7 +19,7 @@ RUN apk --update --no-cache add \
     #used in readiness and liveness probes
     curl \
     #used in wait_for function
-    python3=3.10.5-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/main \
+    python3=3.10.7-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
     #used in init_kubernetes
     jq \
     && ln -sf python3 /usr/bin/python

--- a/docker/pravega/Dockerfile
+++ b/docker/pravega/Dockerfile
@@ -19,7 +19,7 @@ RUN apk --update --no-cache add \
     #used in readiness and liveness probes
     curl \
     #used in wait_for function
-    python3 \
+    python3=3.10.5-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/main \
     #used in init_kubernetes
     jq \
     && ln -sf python3 /usr/bin/python


### PR DESCRIPTION
**Change log description**  
- AdoptOpenJDK `11.0.11_9-alpine` was last updated an year ago. Latest version is `11.0.16.1_1-alpine`
- Updated python3 from `3.9.5` to `3.10.5`. This version of Python fixes CVE-2015-20107 and CVE-2022-26488

**Purpose of the change**  
Fixes #6889

**What the code does**  

- Upgrades AdoptOpenJDK to latest
- Upgrades python3 from 3.9.5 to 3.10.5

**How to verify it**  
```
root@ubuntu2004:~/pravega# docker image list
REPOSITORY               TAG                            IMAGE ID       CREATED         SIZE
pravega/pravega          0.13.0-3144.f2bc628-SNAPSHOT   8ea567e58d4f   6 minutes ago   414MB
pravega/pravega          latest                         8ea567e58d4f   6 minutes ago   414MB
pravega/pravega          0.13.0-3143.d4dac84-SNAPSHOT   1857f8e69d28   3 hours ago     412MB
adoptopenjdk/openjdk11   jre-11.0.16.1_1-alpine         f7f1c841c501   18 hours ago    149MB
root@ubuntu2004:~/pravega# docker run -it --rm --entrypoint=/bin/sh pravega/pravega:latest
/opt/pravega # apk list | grep python
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.14/main: No such file or directory
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.14/community: No such file or directory
python3-3.10.5-r0 x86_64 {python3} (PSF-2.0) [installed]
/opt/pravega # 
```
