### PR TITLE
Issue 6891: Fix the wrong ScaleType value

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
+++ b/client/src/main/java/io/pravega/client/stream/ScalingPolicy.java
@@ -44,11 +44,11 @@ public class ScalingPolicy implements Serializable {
         /**
          * Scale based on the rate in bytes specified in {@link ScalingPolicy#targetRate}.
          */
-        BY_RATE_IN_KBYTES_PER_SEC(io.pravega.shared.segment.ScaleType.NoScaling.getValue()),
+        BY_RATE_IN_KBYTES_PER_SEC(io.pravega.shared.segment.ScaleType.Throughput.getValue()),
         /**
          * Scale based on the rate in events specified in {@link ScalingPolicy#targetRate}.
          */
-        BY_RATE_IN_EVENTS_PER_SEC(io.pravega.shared.segment.ScaleType.NoScaling.getValue());
+        BY_RATE_IN_EVENTS_PER_SEC(io.pravega.shared.segment.ScaleType.EventRate.getValue());
 
         @Getter
         private final byte value;

--- a/client/src/test/java/io/pravega/client/stream/ScalingPolicyTest.java
+++ b/client/src/test/java/io/pravega/client/stream/ScalingPolicyTest.java
@@ -15,9 +15,11 @@
  */
 package io.pravega.client.stream;
 
+import io.pravega.shared.segment.ScaleType;
 import org.junit.Test;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
+import static org.junit.Assert.assertEquals;
 
 public class ScalingPolicyTest {
 
@@ -27,5 +29,17 @@ public class ScalingPolicyTest {
         assertThrows(RuntimeException.class, () -> ScalingPolicy.fixed(0));
         assertThrows(RuntimeException.class, () -> ScalingPolicy.byEventRate(0, 1, 1));
         assertThrows(RuntimeException.class, () -> ScalingPolicy.byDataRate(1, 0, 0));
+    }
+
+    @Test
+    public void testScaleType() {
+        ScalingPolicy.ScaleType fixedType = ScalingPolicy.fixed(1).getScaleType();
+        assertEquals(ScaleType.NoScaling.getValue(), fixedType.getValue());
+
+        ScalingPolicy.ScaleType eventRateType = ScalingPolicy.byEventRate(100, 2, 3).getScaleType();
+        assertEquals(ScaleType.EventRate.getValue(), eventRateType.getValue());
+
+        ScalingPolicy.ScaleType dataRateType = ScalingPolicy.byDataRate(100, 2, 3).getScaleType();
+        assertEquals(ScaleType.Throughput.getValue(), dataRateType.getValue());
     }
 }


### PR DESCRIPTION
**Change log description**  
Fix the wrong ScaleType value in the `ScalingPolicy.ScaleType`

**Purpose of the change**  
Fixes #6891

**What the code does**  
```java
        /**
         * Scale based on the rate in bytes specified in {@link ScalingPolicy#targetRate}.
         */
        BY_RATE_IN_KBYTES_PER_SEC(io.pravega.shared.segment.ScaleType.NoScaling.getValue()),
        /**
         * Scale based on the rate in events specified in {@link ScalingPolicy#targetRate}.
         */
        BY_RATE_IN_EVENTS_PER_SEC(io.pravega.shared.segment.ScaleType.NoScaling.getValue());
```
the enum value error, should `Throughput` 、`EventRate`.


**How to verify it**  
Build must pass with the new added testcase.







