### PR TITLE
Issue 6894: Bump r0.12 to 0.12.1-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -70,7 +70,7 @@ jjwtVersion=0.9.1
 bouncyCastleVersion=1.70
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.12.0-SNAPSHOT
+pravegaVersion=0.12.1-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
**Change log description**  
Set Pravega version to 0.12.1-SNAPSHOT in branch r0.12.

**Purpose of the change**  
Fixes #6894.

**What the code does**  
Set Pravega version to 0.12.1-SNAPSHOT in branch r0.12.

**How to verify it**  
Build must pass.
