### PR TITLE
Issue 6905: LTS - Correctly pass executor to CompletableFuture Async calls.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/FixedKeyLengthTableSegmentLayout.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/tables/FixedKeyLengthTableSegmentLayout.java
@@ -243,7 +243,7 @@ class FixedKeyLengthTableSegmentLayout extends TableSegmentLayout {
                     log.debug("{}: Offset {} truncated while reading key '{}'. Retrying once.", this.traceObjectId, segmentOffset, attributeId);
                     return segment.getAttributes(Collections.singletonList(attributeId), false, timer.getRemaining())
                             .thenComposeAsync(attributeValues ->
-                                    getEntry(segment, attributeId, attributeValues.getOrDefault(attributeId, NO_OFFSET), timer));
+                                    getEntry(segment, attributeId, attributeValues.getOrDefault(attributeId, NO_OFFSET), timer), this.executor);
                 });
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollector.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollector.java
@@ -335,7 +335,7 @@ public class GarbageCollector implements AutoCloseable, StatsReporter {
                                     return CompletableFuture.completedFuture(null);
                                 }, storageExecutor)
                                 .thenComposeAsync(v -> this.addChunksToGarbage(txn.getVersion(), chunksToDelete), storageExecutor)
-                                .thenComposeAsync(v -> deleteBlockIndexEntriesForSegment(streamSegmentName, segmentMetadata.getStartOffset(), segmentMetadata.getLength()))
+                                .thenComposeAsync(v -> deleteBlockIndexEntriesForSegment(streamSegmentName, segmentMetadata.getStartOffset(), segmentMetadata.getLength()), storageExecutor)
                                 .thenComposeAsync(v -> {
                                     val innerTxn = metadataStore.beginTransaction(false, segmentMetadata.getName());
                                     innerTxn.delete(segmentMetadata.getName());


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
Issue 6905: LTS - Correctly pass executor to CompletableFuture.composeAsync calls.

**Purpose of the change**  
Fixes #6905 

**What the code does**  
Correctly pass executor to CompletableFuture.composeAsync calls.

**How to verify it**  
All tests should pass
