### PR TITLE
Issue 6811: LTS - Disable lazy commit. Support rollback by porting serializers and flags to 0.12 branch.

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -378,6 +378,10 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
                 segmentMetadata.setOwnerEpoch(this.epoch);
                 segmentMetadata.setOwnershipChanged(true);
             }
+
+            // Unset atomic writes as this version does not support atomic writes.
+            segmentMetadata.setAtomicWrites(false);
+
             // Update and commit
             // If This instance is fenced this update will fail.
             txn.update(segmentMetadata);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollector.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/GarbageCollector.java
@@ -335,7 +335,7 @@ public class GarbageCollector implements AutoCloseable, StatsReporter {
                                     return CompletableFuture.completedFuture(null);
                                 }, storageExecutor)
                                 .thenComposeAsync(v -> this.addChunksToGarbage(txn.getVersion(), chunksToDelete), storageExecutor)
-                                .thenComposeAsync(v -> deleteBlockIndexEntriesForSegment(streamSegmentName, segmentMetadata.getStartOffset(), segmentMetadata.getLength()))
+                                .thenComposeAsync(v -> deleteBlockIndexEntriesForSegment(streamSegmentName, segmentMetadata.getStartOffset(), segmentMetadata.getLength()), storageExecutor)
                                 .thenComposeAsync(v -> {
                                     val innerTxn = metadataStore.beginTransaction(false, segmentMetadata.getName());
                                     innerTxn.delete(segmentMetadata.getName());

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/SegmentMetadata.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/SegmentMetadata.java
@@ -173,6 +173,15 @@ public class SegmentMetadata extends StorageMetadata {
     }
 
     /**
+     * Sets whether writes should be atomic.
+     * @param value Value to set.
+     * @return This instance so that these calls can be chained.
+     */
+    public SegmentMetadata setAtomicWrites(boolean value) {
+        return setFlag(StatusFlags.ATOMIC_WRITES, value);
+    }
+
+    /**
      * Gets active status.
      * @return True if active, false otherwise.
      */
@@ -202,6 +211,14 @@ public class SegmentMetadata extends StorageMetadata {
      */
     public boolean isStorageSystemSegment() {
         return getFlag(StatusFlags.SYSTEM_SEGMENT);
+    }
+
+    /**
+     * Gets whether writes are atomic.
+     * @return True if changed, false otherwise.
+     */
+    public boolean isAtomicWrite() {
+        return getFlag(StatusFlags.ATOMIC_WRITES);
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StatusFlags.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/metadata/StatusFlags.java
@@ -34,6 +34,11 @@ public final class StatusFlags {
     public static final int SEALED = 0x0002;
 
     /**
+     * Flag to indicate whether all writes are atomic.
+     */
+    public static final int ATOMIC_WRITES = 0x0004;
+
+    /**
      * Flag to indicate whether the segment is storage system segment.
      */
     public static final int SYSTEM_SEGMENT = 0x0010;

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -1025,6 +1025,8 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
 
         systemJournalAfter.bootstrap(epoch + 1, snapshotInfoStore).join();
 
+        val segmentMetadata = TestUtils.getSegmentMetadata(metadataStoreAfterCrash, systemSegmentName);
+        Assert.assertFalse(segmentMetadata.isAtomicWrite());
         TestUtils.checkSegmentLayout(metadataStoreAfterCrash, systemSegmentName, policy.getMaxLength(), 10);
         TestUtils.checkSegmentBounds(metadataStoreAfterCrash, systemSegmentName, 0, totalBytesWritten);
 
@@ -1040,7 +1042,8 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         SystemJournal systemJournalAfter2 = new SystemJournal(containerId, chunkStorage, metadataStoreAfterCrash2, garbageCollector3, config, executorService());
 
         systemJournalAfter2.bootstrap(epoch + 2, snapshotInfoStore).join();
-
+        val segmentMetadata2 = TestUtils.getSegmentMetadata(metadataStoreAfterCrash, systemSegmentName);
+        Assert.assertFalse(segmentMetadata2.isAtomicWrite());
         TestUtils.checkSegmentLayout(metadataStoreAfterCrash2, systemSegmentName, policy.getMaxLength(), 10);
     }
 

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/TestUtils.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/TestUtils.java
@@ -394,6 +394,40 @@ public class TestUtils {
                                                  long[] chunkLengthsInStorage,
                                                  boolean addIndex, boolean addIndexMetadata,
                                                  ChunkMetadataStore metadataStore, ChunkedSegmentStorage chunkedSegmentStorage) {
+        return insertMetadata(testSegmentName,
+                maxRollingLength,
+                ownerEpoch,
+                chunkLengthsInMetadata,
+                chunkLengthsInStorage,
+                addIndex,
+                addIndexMetadata,
+                metadataStore,
+                chunkedSegmentStorage,
+                StatusFlags.ACTIVE);
+    }
+
+    /**
+     * Insert Metadata as given.
+     *
+     * @param testSegmentName        Name of the segment
+     * @param maxRollingLength       Max rolling length.
+     * @param ownerEpoch             Owner epoch.
+     * @param chunkLengthsInMetadata Chunk lengths to set in metadata.
+     * @param chunkLengthsInStorage  Chunk lengths to set in storage.
+     * @param addIndex               Whether to add index.
+     * @param addIndexMetadata       Whether to add index metadata.
+     * @param metadataStore          Instance of {@link ChunkMetadataStore}
+     * @param chunkedSegmentStorage  Instance of {@link ChunkedSegmentStorage}.
+     * @param statusFlags            Status flags to set.
+     * @return {@link SegmentMetadata} representing segment.
+     */
+    public static SegmentMetadata insertMetadata(String testSegmentName, long maxRollingLength, int ownerEpoch,
+                                                 long[] chunkLengthsInMetadata,
+                                                 long[] chunkLengthsInStorage,
+                                                 boolean addIndex, boolean addIndexMetadata,
+                                                 ChunkMetadataStore metadataStore,
+                                                 ChunkedSegmentStorage chunkedSegmentStorage,
+                                                 int statusFlags) {
         Preconditions.checkArgument(maxRollingLength > 0, "maxRollingLength");
         Preconditions.checkArgument(ownerEpoch > 0, "ownerEpoch");
         try (val txn = metadataStore.beginTransaction(false, new String[]{testSegmentName})) {
@@ -440,6 +474,7 @@ public class TestUtils {
                     .firstChunk(firstChunk)
                     .lastChunk(lastChunk)
                     .length(length)
+                    .status(statusFlags)
                     .lastChunkStartOffset(startOfLast)
                     .build();
             segmentMetadata.setActive(true);


### PR DESCRIPTION
**Change log description**  
Issue 6811: LTS - Disable lazy commit for all segments. Support rollback by porting serializers and flags to 0.12 branch.

**Purpose of the change**  
Fix #6811

**What the code does**  
Support rollback by porting serializers and flags to 0.12 branch.
Append records are skipped over.
explicitly set `isAtomic `to false to avoid unexpected state transitions with this version.

**How to verify it**  
All tests should pass. Upgrade and rollback should pass.
