### PR TITLE
Issue 6925: Cherry-pick PR 6923 into branch r0.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,8 @@ allprojects {
             //failOnVersionConflict()
             force "com.google.guava:guava:" + guavaVersion
             force "com.google.protobuf:protobuf-java:" + protobufProtocVersion
-            force "io.grpc:grpc-context:" + grpcVersion
+            force "com.google.protobuf:protobuf-java-util:" + protobufProtocVersion
+	    force "io.grpc:grpc-context:" + grpcVersion
             force "commons-beanutils:commons-beanutils:" + commonsBeanutilsVersion
             force "org.apache.commons:commons-compress:" + apacheCommonsCompressVersion
             force "org.apache.commons:commons-lang3:" + commonsLang3Version
@@ -123,13 +124,22 @@ allprojects {
             force "io.netty:netty-transport:" + nettyVersion
             force "io.netty:netty-handler:" + nettyVersion
             force "io.netty:netty-codec:" + nettyVersion
+            force "io.netty:netty-codec-dns:" + nettyVersion
             force "io.netty:netty-codec-http:" + nettyVersion
             force "io.netty:netty-codec-http2:" + nettyVersion
             force "io.netty:netty-codec-socks:" + nettyVersion
             force "io.netty:netty-handler-proxy:" + nettyVersion
+            force "io.netty:netty-resolver-dns:" + nettyVersion
             force "io.netty:netty-transport-native-epoll:" + nettyVersion
             force "io.netty:netty-tcnative-boringssl-static:" + nettyBoringSSLVersion
             force "junit:junit:" + junitVersion
+            force "org.bouncycastle:bcprov-jdk15on:" + bouncyCastleVersion
+	    force "org.bouncycastle:bcpkix-jdk15on:" + bouncyCastleVersion
+	    force "org.apache.avro:avro:" + apacheAvroVersion
+	    force "org.jetbrains.kotlin:kotlin-stdlib-common:" + kotlinVersion
+	    force "org.jetbrains.kotlin:kotlin-stdlib:" + kotlinVersion
+	    force "org.yaml:snakeyaml:" + snakeYamlVersion
+	    force "org.jdom:jdom2:" + jdomVersion
             // Netty 4 uber jar
             exclude group: 'io.netty', module: 'netty-all'
             // Netty 3
@@ -304,6 +314,7 @@ project('shared:protocol') {
     dependencies {
         compile project(':common')
         compile group: 'io.netty', name: 'netty-handler', version: nettyVersion
+        compile group: 'io.netty', name: 'netty-tcnative-boringssl-static', version: nettyBoringSSLVersion
         compile group: 'com.google.guava', name: 'guava', version: guavaVersion
         testCompile project(':test:testcommon')
         testCompile group: 'org.slf4j', name: 'log4j-over-slf4j', version: slf4jApiVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xms1g
 
 #3rd party Versions
+apacheAvroVersion=1.11.1
 apacheCommonsCsvVersion=1.5
 apacheCommonsCompressVersion=1.21
 apacheCuratorVersion=5.2.0
@@ -43,9 +44,9 @@ grpcVersion=1.47.0
 gsonVersion=2.9.0
 guavaVersion=30.1-jre
 guiceVersion=4.0
-hadoopVersion=3.3.2
+hadoopVersion=3.3.4
 javaxServletApiVersion=4.0.0
-jacksonVersion=2.13.3
+jacksonVersion=2.13.4
 javaxwsrsApiVersion=2.1
 jaxbVersion=2.3.1
 activationVersion=1.2.0
@@ -57,10 +58,10 @@ marathonClientVersion=0.6.2
 micrometerVersion=1.2.0
 mockitoVersion=3.3.3
 jacocoVersion=0.8.5
-nettyVersion=4.1.73.Final
-nettyBoringSSLVersion=2.0.48.Final
+nettyVersion=4.1.82.Final
+nettyBoringSSLVersion=2.0.54.Final
 protobufGradlePlugin=0.8.15
-protobufProtocVersion=3.19.4
+protobufProtocVersion=3.21.7
 qosLogbackVersion=1.2.10
 swaggerJersey2JaxrsVersion=1.6.2
 slf4jApiVersion=1.7.25
@@ -68,6 +69,9 @@ gradleGitPluginVersion=4.1.1
 k8ClientVersion=15.0.1
 jjwtVersion=0.9.1
 bouncyCastleVersion=1.70
+kotlinVersion=1.7.20
+snakeYamlVersion=1.33
+jdomVersion=2.0.6.1
 
 # Version and base tags can be overridden at build time
 pravegaVersion=0.12.1-SNAPSHOT


### PR DESCRIPTION
**Change log description**  
Cherry-pick PR #6923 into branch r0.12.

**Purpose of the change**  
Fixes #6925.

**What the code does**  
See #6923.
(not added upgrades to GCP libraries, as Pravega 0.12 does not have GCP storage binding).

**How to verify it**  
See #6923.
