### PR TITLE
Issue 6940: Change version on master branch to 0.14

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -77,7 +77,7 @@ snakeYamlVersion=1.33
 jdomVersion=2.0.6.1
 
 # Version and base tags can be overridden at build time
-pravegaVersion=0.13.0-SNAPSHOT
+pravegaVersion=0.14.0-SNAPSHOT
 pravegaBaseTag=pravega/pravega
 bookkeeperBaseTag=pravega/bookkeeper
 


### PR DESCRIPTION
**Change log description**  
As `r0.13` has been created, upgrade Pravega version in `gradle.properties` to `0.14.0-SNAPSHOT`.

**Purpose of the change**  
Fixes #6940.

**What the code does**  
Upgrade Pravega version in `gradle.properties`.

**How to verify it**  
Build must pass.
