### PR TITLE
Issue #1886: readrange method introduced

### DIFF
--- a/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
+++ b/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
@@ -100,5 +100,17 @@ public interface RevisionedStreamClient<T> extends AutoCloseable {
      */
     @Override
     abstract void close();
+
+    /**
+     * Read all data from given start revision  to the end of the stream. The iterator returned will
+     * stop once it reaches the given end of the data that was in the stream at the time this method was
+     * called.
+     *
+     * @param startRevision The location the iterator should start at.
+     * @param endRevision The location the iterator should end at.
+     * @return An iterator over Revision, value pairs.
+     * @throws TruncatedDataException If the data at start no longer exists because it has been
+     *             truncated. IE: It is below {@link #fetchOldestRevision()}
+     */
     public Iterator<Entry<Revision, T>> readRange(Revision startRevision, Revision endRevision);
 }

--- a/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
+++ b/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
@@ -100,5 +100,5 @@ public interface RevisionedStreamClient<T> extends AutoCloseable {
      */
     @Override
     abstract void close();
-
+    public Iterator<Entry<Revision, T>> readRange(Revision startRevision, Revision endRevision);
 }

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -275,7 +275,7 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
                 log.debug("No new updates to be read from revision {}", endRevision);
             }
             if (startOffset > endOffset) {
-                throw new IllegalStateException("startoffset {} is grater than endOffset {}");
+                throw new IllegalStateException("startOffset {} is grater than endOffset {}");
             }
             log.debug("Creating iterator from {} until {} for segment {} ", startOffset, endOffset, segment);
             return new StreamIterator(startOffset, endOffset);

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -275,10 +275,7 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
                 log.debug("No new updates to be read from revision {}", endRevision);
             }
             if (startOffset > endOffset) {
-                tempOffset=startOffset;
-                startOffset=endOffset;
-                endOffset=tempOffset;
-                log.debug("Start offset is grater than endOffset, start and end offset is swapped");
+                throw new IllegalStateException("startoffset {} is grater than endOffset {}");
             }
             log.debug("Creating iterator from {} until {} for segment {} ", startOffset, endOffset, segment);
             return new StreamIterator(startOffset, endOffset);

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -481,7 +481,9 @@ public class RevisionedStreamClientTest {
         assertEquals("a", iterA.next().getValue());
         assertEquals("b", iterA.next().getValue());
         assertThrows(NoSuchElementException.class, () -> iterA.next().getValue());
-
+        Iterator<Entry<Revision, String>> iterB = client.readRange(r0, r0);
+        assertFalse(iterB.hasNext());
+        assertThrows(IllegalStateException.class, () -> client.readRange(rb, r0));
 }
 
 }

--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -189,6 +189,7 @@ public class SynchronizerTest {
         public void truncateToRevision(Revision newStart) {
             throw new NotImplementedException("truncateToRevision");
         }
+
         @Override
         public Iterator<Entry<Revision, UpdateOrInit<RevisionedImpl>>> readRange(Revision startRevision, Revision endRevision) {
             return new Iterator<Entry<Revision, UpdateOrInit<RevisionedImpl>>>() {

--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -189,6 +189,31 @@ public class SynchronizerTest {
         public void truncateToRevision(Revision newStart) {
             throw new NotImplementedException("truncateToRevision");
         }
+        @Override
+        public Iterator<Entry<Revision, UpdateOrInit<RevisionedImpl>>> readRange(Revision startRevision, Revision endRevision) {
+            return new Iterator<Entry<Revision, UpdateOrInit<RevisionedImpl>>>() {
+                private int pos = startRevision.asImpl().getEventAtOffset();
+                @Override
+                public Entry<Revision, UpdateOrInit<RevisionedImpl>> next() {
+                    UpdateOrInit<RevisionedImpl> value;
+                    RevisionImpl revision = new RevisionImpl(segment, pos, pos);
+                    if (pos == 0) {
+                        value = new UpdateOrInit<>(init);
+                    } else {
+                        value = new UpdateOrInit<>(Collections.singletonList(updates[pos - 1]));
+                    }
+                    pos++;
+                    return new AbstractMap.SimpleImmutableEntry<>(revision, value);
+                }
+
+                @Override
+                public boolean hasNext() {
+                    return pos <= visableLength;
+                }
+            };
+        }
+
+
     }
 
     @Test(timeout = 20000)

--- a/controller/src/test/java/io/pravega/controller/server/bucket/WatermarkWorkflowTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/WatermarkWorkflowTest.java
@@ -100,7 +100,7 @@ public class WatermarkWorkflowTest {
         executor = ExecutorServiceHelpers.newScheduledThreadPool(10, "test");
 
         streamMetadataStore = StreamStoreFactory.createPravegaTablesStore(SegmentHelperMock.getSegmentHelperMockForTables(executor),
-                                                                          GrpcAuthHelper.getDisabledAuthHelper(), PRAVEGA_ZK_CURATOR_RESOURCE.client, executor);
+                GrpcAuthHelper.getDisabledAuthHelper(), PRAVEGA_ZK_CURATOR_RESOURCE.client, executor);
         ImmutableMap<BucketStore.ServiceType, Integer> map = ImmutableMap.of(BucketStore.ServiceType.RetentionService, 3,
                 BucketStore.ServiceType.WatermarkingService, 3);
         bucketStore = StreamStoreFactory.createZKBucketStore(map, PRAVEGA_ZK_CURATOR_RESOURCE.client, executor);
@@ -109,7 +109,7 @@ public class WatermarkWorkflowTest {
                 SegmentHelperMock.getSegmentHelperMock(), executor, "hostId", GrpcAuthHelper.getDisabledAuthHelper());
 
     }
-    
+
     @After
     public void tearDown() throws Exception {
         streamMetadataStore.close();
@@ -117,12 +117,12 @@ public class WatermarkWorkflowTest {
 
         streamMetadataStore.close();
     }
-    
+
     @Test(timeout = 10000L)
     public void testWatermarkClient() {
         Stream stream = new StreamImpl("scope", "stream");
         SynchronizerClientFactory clientFactory = spy(SynchronizerClientFactory.class);
-        
+
         @Cleanup
         MockRevisionedStreamClient revisionedClient = new MockRevisionedStreamClient();
         doAnswer(x -> revisionedClient).when(clientFactory).createRevisionedStreamClient(anyString(), any(), any());
@@ -148,7 +148,7 @@ public class WatermarkWorkflowTest {
 
         // iteration 2 : do not emit ==> w1 -> w1
         client.reinitialize();
-        // There is one watermark. All writers should be active and writers greater than last watermark should be participating 
+        // There is one watermark. All writers should be active and writers greater than last watermark should be participating
         assertEquals(revisionedClient.getMark(), MockRevision.EMPTY);
         assertEquals(revisionedClient.watermarks.size(), 1);
         assertEquals(client.getPreviousWatermark(), first);
@@ -157,12 +157,12 @@ public class WatermarkWorkflowTest {
         assertTrue(client.isWriterTracked(entry1.getKey()));
         assertFalse(client.isWriterParticipating(1L));
         assertTrue(client.isWriterParticipating(2L));
-        // dont emit a watermark. Everything stays same as before. 
+        // dont emit a watermark. Everything stays same as before.
         client.completeIteration(null);
-        
+
         // iteration 3 : emit ==> w1 -> w1 w2
         client.reinitialize();
-        // There is one watermark. All writers should be active and writers greater than last watermark should be participating 
+        // There is one watermark. All writers should be active and writers greater than last watermark should be participating
         assertEquals(revisionedClient.getMark(), MockRevision.EMPTY);
         assertEquals(revisionedClient.watermarks.size(), 1);
         assertEquals(client.getPreviousWatermark(), first);
@@ -187,7 +187,7 @@ public class WatermarkWorkflowTest {
         assertTrue(client.isWriterActive(entry0, 1000L));
         assertTrue(client.isWriterTracked(entry0.getKey()));
 
-        // dont emit a watermark but complete this iteration. 
+        // dont emit a watermark but complete this iteration.
         client.completeIteration(null);
 
         // iteration 6: emit ==> w1 w2 -> w1 w2 w3
@@ -213,7 +213,7 @@ public class WatermarkWorkflowTest {
         assertTrue(client.isWriterActive(entry4, 0L));
         assertFalse(client.isWriterParticipating(3L));
         assertTrue(client.isWriterParticipating(4L));
-        
+
         client.completeIteration(null);
 
         // iteration 8 : emit ==> w2 w3 -> w2 w3 w4
@@ -248,7 +248,7 @@ public class WatermarkWorkflowTest {
         assertFalse(Futures.delayedTask(() -> client.isWriterActive(entry1, 1L), Duration.ofSeconds(1), executor).join());
         assertTrue(client.isWriterTracked(entry1.getKey()));
 
-        // dont emit a watermark but complete this iteration. This should shrink the window again. 
+        // dont emit a watermark but complete this iteration. This should shrink the window again.
         client.completeIteration(null);
 
         // iteration 10
@@ -261,7 +261,7 @@ public class WatermarkWorkflowTest {
         assertFalse(client.isWriterParticipating(4L));
         assertTrue(client.isWriterParticipating(5L));
     }
-    
+
     @Test(timeout = 10000L)
     public void testWatermarkClientClose() {
         String scope = "scope1";
@@ -285,15 +285,15 @@ public class WatermarkWorkflowTest {
 
         String s = "failing creation";
         doThrow(new RuntimeException(s)).when(clientFactory).createRevisionedStreamClient(anyString(), any(), any());
-        AssertExtensions.assertThrows("constructor should throw", 
+        AssertExtensions.assertThrows("constructor should throw",
                 () -> new PeriodicWatermarking.WatermarkClient(stream, clientFactory), e -> e instanceof RuntimeException && s.equals(e.getMessage()));
-        
+
         @Cleanup
-        PeriodicWatermarking periodicWatermarking = new PeriodicWatermarking(streamMetadataStore, bucketStore, 
+        PeriodicWatermarking periodicWatermarking = new PeriodicWatermarking(streamMetadataStore, bucketStore,
                 sp -> clientFactory, executor, new RequestTracker(false));
         streamMetadataStore.createScope(scope, null, executor).join();
         streamMetadataStore.createStream(scope, streamName, StreamConfiguration.builder().scalingPolicy(
-                ScalingPolicy.fixed(2)).timestampAggregationTimeout(10000L).build(),
+                        ScalingPolicy.fixed(2)).timestampAggregationTimeout(10000L).build(),
                 System.currentTimeMillis(), null, executor).join();
         streamMetadataStore.createStream(scope, markStreamName, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(),
                 System.currentTimeMillis(), null, executor).join();
@@ -304,7 +304,7 @@ public class WatermarkWorkflowTest {
         Map<Long, Long> map1 = ImmutableMap.of(0L, 100L, 1L, 100L);
         streamMetadataStore.noteWriterMark(scope, streamName, writer1, 100L, map1, null, executor).join();
 
-        // 2. run watermarking workflow. 
+        // 2. run watermarking workflow.
         periodicWatermarking.watermark(stream).join();
         assertTrue(periodicWatermarking.checkExistsInCache(scope));
 
@@ -331,13 +331,13 @@ public class WatermarkWorkflowTest {
         }).when(clientFactory).createRevisionedStreamClient(anyString(), any(), any());
 
         @Cleanup
-        PeriodicWatermarking periodicWatermarking = new PeriodicWatermarking(streamMetadataStore, bucketStore, sp -> clientFactory, 
+        PeriodicWatermarking periodicWatermarking = new PeriodicWatermarking(streamMetadataStore, bucketStore, sp -> clientFactory,
                 executor, new RequestTracker(false));
 
         String streamName = "stream";
         String scope = "scope";
         streamMetadataStore.createScope(scope, null, executor).join();
-        streamMetadataStore.createStream(scope, streamName, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(3)).timestampAggregationTimeout(10000L).build(), 
+        streamMetadataStore.createStream(scope, streamName, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(3)).timestampAggregationTimeout(10000L).build(),
                 System.currentTimeMillis(), null, executor).join();
 
         streamMetadataStore.setState(scope, streamName, State.ACTIVE, null, executor).join();
@@ -349,8 +349,8 @@ public class WatermarkWorkflowTest {
         streamMetadataStore.completeUpdateConfiguration(scope, streamName, configRecord, null, executor).join();
 
         // 2. note writer1, writer2, writer3 marks
-        // writer 1 reports segments 0, 1. 
-        // writer 2 reports segments 1, 2, 
+        // writer 1 reports segments 0, 1.
+        // writer 2 reports segments 1, 2,
         // writer 3 reports segment 0, 2
         String writer1 = "writer1";
         Map<Long, Long> map1 = ImmutableMap.of(0L, 100L, 1L, 200L);
@@ -361,12 +361,12 @@ public class WatermarkWorkflowTest {
         String writer3 = "writer3";
         Map<Long, Long> map3 = ImmutableMap.of(2L, 100L, 0L, 200L);
         streamMetadataStore.noteWriterMark(scope, streamName, writer3, 102L, map3, null, executor).join();
-        
-        // 3. run watermarking workflow. 
+
+        // 3. run watermarking workflow.
         StreamImpl stream = new StreamImpl(scope, streamName);
         periodicWatermarking.watermark(stream).join();
-        
-        // verify that a watermark has been emitted. 
+
+        // verify that a watermark has been emitted.
         // this should emit a watermark that contains all three segments with offsets = 200L
         // and timestamp = 100L
         MockRevisionedStreamClient revisionedClient = revisionedStreamClientMap.get(NameUtils.getMarkStreamForStream(streamName));
@@ -377,7 +377,7 @@ public class WatermarkWorkflowTest {
         assertEquals(getSegmentOffset(watermark, 0L), 200L);
         assertEquals(getSegmentOffset(watermark, 1L), 200L);
         assertEquals(getSegmentOffset(watermark, 2L), 200L);
-        
+
         // send positions only on segment 1 and segment 2. nothing on segment 0.
         map1 = ImmutableMap.of(1L, 300L);
         streamMetadataStore.noteWriterMark(scope, streamName, writer1, 200L, map1, null, executor).join();
@@ -400,8 +400,8 @@ public class WatermarkWorkflowTest {
         // scale stream 0, 1, 2 -> 3, 4
         scaleStream(streamName, scope);
 
-        // writer 1 reports segments 0, 1. 
-        // writer 2 reports segments 1, 2 
+        // writer 1 reports segments 0, 1.
+        // writer 2 reports segments 1, 2
         // writer 3 reports segment 3
         map1 = ImmutableMap.of(0L, 300L, 1L, 400L);
         streamMetadataStore.noteWriterMark(scope, streamName, writer1, 302L, map1, null, executor).join();
@@ -410,7 +410,7 @@ public class WatermarkWorkflowTest {
         long segment3 = NameUtils.computeSegmentId(3, 1);
         long segment4 = NameUtils.computeSegmentId(4, 1);
         map3 = ImmutableMap.of(segment3, 100L);
-        // writer 3 has lowest reported time. 
+        // writer 3 has lowest reported time.
         streamMetadataStore.noteWriterMark(scope, streamName, writer3, 300L, map3, null, executor).join();
 
         // run watermark workflow. this will emit a watermark with time = 300L and streamcut = 3 -> 100L, 4 -> 0L
@@ -423,16 +423,16 @@ public class WatermarkWorkflowTest {
         assertEquals(getSegmentOffset(watermark, segment3), 100L);
         assertEquals(getSegmentOffset(watermark, segment4), 0L);
 
-        // report complete positions from writers. 
+        // report complete positions from writers.
         // writer 1 reports 0, 1, 2
         // writer 2 reports 0, 1, 2
-        // writer 3 doesnt report. 
+        // writer 3 doesnt report.
         map1 = ImmutableMap.of(0L, 400L, 1L, 400L);
         streamMetadataStore.noteWriterMark(scope, streamName, writer1, 400L, map1, null, executor).join();
         map2 = ImmutableMap.of(1L, 100L, 2L, 400L);
         streamMetadataStore.noteWriterMark(scope, streamName, writer2, 401L, map2, null, executor).join();
 
-        // run watermark workflow. there shouldn't be a watermark emitted because writer 3 is active and has not reported a time. 
+        // run watermark workflow. there shouldn't be a watermark emitted because writer 3 is active and has not reported a time.
         periodicWatermarking.watermark(stream).join();
         assertEquals(revisionedClient.watermarks.size(), 3);
 
@@ -447,9 +447,9 @@ public class WatermarkWorkflowTest {
         assertFalse(writer3Mark.isAlive());
         assertEquals(writer3Mark.getTimestamp(), 300L);
 
-        // now a watermark should be generated. Time should be advanced. But watermark's stream cut is already ahead of writer's 
+        // now a watermark should be generated. Time should be advanced. But watermark's stream cut is already ahead of writer's
         // positions so stream cut should not advance.
-        // Also writer 3 being inactive and shutdown, should be removed. 
+        // Also writer 3 being inactive and shutdown, should be removed.
         periodicWatermarking.watermark(stream).join();
         assertEquals(revisionedClient.watermarks.size(), 4);
         watermark = revisionedClient.watermarks.get(3).getValue();
@@ -461,7 +461,7 @@ public class WatermarkWorkflowTest {
         AssertExtensions.assertFutureThrows("Writer 3 should have been removed from store",
                 streamMetadataStore.getWriterMark(scope, streamName, writer3, null, executor),
                 e -> Exceptions.unwrap(e) instanceof StoreException.DataNotFoundException);
-        
+
         // writer 1, 2 and 3 report marks. With writer 3 reporting mark on segment 4. Writer3 will get added again
         map1 = ImmutableMap.of(0L, 500L, 1L, 500L);
         streamMetadataStore.noteWriterMark(scope, streamName, writer1, 500L, map1, null, executor).join();
@@ -492,38 +492,38 @@ public class WatermarkWorkflowTest {
 
         doAnswer(x -> {
             String name = x.getArgument(0);
-            return revisionedStreamClientMap.compute(name, (s, rsc) -> new MockRevisionedStreamClient(() -> 
+            return revisionedStreamClientMap.compute(name, (s, rsc) -> new MockRevisionedStreamClient(() ->
                     streamMetadataStore.getActiveSegments(scope, name, null, executor).join().get(0).segmentId()));
         }).when(clientFactory).createRevisionedStreamClient(anyString(), any(), any());
 
         @Cleanup
-        PeriodicWatermarking periodicWatermarking = new PeriodicWatermarking(streamMetadataStore, bucketStore, 
+        PeriodicWatermarking periodicWatermarking = new PeriodicWatermarking(streamMetadataStore, bucketStore,
                 sp -> clientFactory, executor, new RequestTracker(false));
 
         streamMetadataStore.createScope(scope, null, executor).join();
-        streamMetadataStore.createStream(scope, streamName, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(2)).timestampAggregationTimeout(10000L).build(), 
+        streamMetadataStore.createStream(scope, streamName, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(2)).timestampAggregationTimeout(10000L).build(),
                 System.currentTimeMillis(), null, executor).join();
-        streamMetadataStore.createStream(scope, markStreamName, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(), 
+        streamMetadataStore.createStream(scope, markStreamName, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(1)).build(),
                 System.currentTimeMillis(), null, executor).join();
         streamMetadataStore.setState(scope, markStreamName, State.ACTIVE, null, executor).join();
         streamMetadataStore.setState(scope, streamName, State.ACTIVE, null, executor).join();
-        
+
         // 1. note writer1 marks
-        // writer 1 reports segments 0, 1. 
+        // writer 1 reports segments 0, 1.
         String writer1 = "writer1";
         Map<Long, Long> map1 = ImmutableMap.of(0L, 100L, 1L, 100L);
         streamMetadataStore.noteWriterMark(scope, streamName, writer1, 100L, map1, null, executor).join();
-        
-        // 2. run watermarking workflow. 
+
+        // 2. run watermarking workflow.
         periodicWatermarking.watermark(stream).join();
         assertTrue(periodicWatermarking.checkExistsInCache(stream));
 
-        // verify that a watermark has been emitted. 
+        // verify that a watermark has been emitted.
         MockRevisionedStreamClient revisionedClient = revisionedStreamClientMap.get(markStreamName);
         assertEquals(revisionedClient.watermarks.size(), 1);
         Watermark watermark = revisionedClient.watermarks.get(0).getValue();
         assertEquals(watermark.getLowerTimeBound(), 100L);
-        
+
         // delete and recreate stream and its mark stream
         streamMetadataStore.deleteStream(scope, markStreamName, null, executor).join();
         streamMetadataStore.deleteStream(scope, streamName, null, executor).join();
@@ -535,19 +535,19 @@ public class WatermarkWorkflowTest {
         streamMetadataStore.setState(scope, markStreamName, State.ACTIVE, null, executor).join();
 
         // 1. note writer1 marks
-        // writer 1 reports segments 0, 1. 
+        // writer 1 reports segments 0, 1.
         map1 = ImmutableMap.of(2L, 10L, 3L, 10L);
         streamMetadataStore.noteWriterMark(scope, streamName, writer1, 10L, map1, null, executor).join();
 
         // 2. run watermarking workflow. this should fail and revisioned stream client should be invalidated in the cache.
         periodicWatermarking.watermark(stream).join();
         assertFalse(periodicWatermarking.checkExistsInCache(stream));
-        
+
         // 3. run watermarking workflow again.
         periodicWatermarking.watermark(stream).join();
         assertTrue(periodicWatermarking.checkExistsInCache(stream));
 
-        // verify that a watermark has been emitted. 
+        // verify that a watermark has been emitted.
         revisionedClient = revisionedStreamClientMap.get(markStreamName);
         assertEquals(revisionedClient.segment, 1L);
         assertEquals(revisionedClient.watermarks.size(), 1);
@@ -582,14 +582,14 @@ public class WatermarkWorkflowTest {
         String scope = "scope";
         streamMetadataStoreSpied.createScope(scope, null, executor).join();
         streamMetadataStoreSpied.createStream(scope, streamName, StreamConfiguration.builder().scalingPolicy(ScalingPolicy.fixed(3))
-                                                                               .timestampAggregationTimeout(3000L).build(),
+                        .timestampAggregationTimeout(3000L).build(),
                 System.currentTimeMillis(), null, executor).join();
 
         streamMetadataStoreSpied.setState(scope, streamName, State.ACTIVE, null, executor).join();
 
         // 2. note writer1, writer2, writer3 marks
-        // writer 1 reports segments 0, 1. 
-        // writer 2 reports segments 1, 2, 
+        // writer 1 reports segments 0, 1.
+        // writer 2 reports segments 1, 2,
         // writer 3 reports segment 0, 2
         String writer1 = "writer1";
         streamMetadataStoreSpied.noteWriterMark(scope, streamName, writer1, 102L,
@@ -601,11 +601,11 @@ public class WatermarkWorkflowTest {
         streamMetadataStoreSpied.noteWriterMark(scope, streamName, writer3, 100L,
                 ImmutableMap.of(0L, 0L, 1L, 0L, 2L, 100L), null, executor).join();
 
-        // 3. run watermarking workflow. 
+        // 3. run watermarking workflow.
         StreamImpl stream = new StreamImpl(scope, streamName);
         periodicWatermarking.watermark(stream).join();
 
-        // verify that a watermark has been emitted. 
+        // verify that a watermark has been emitted.
         MockRevisionedStreamClient revisionedClient = revisionedStreamClientMap.get(NameUtils.getMarkStreamForStream(streamName));
         assertEquals(revisionedClient.watermarks.size(), 1);
 
@@ -626,14 +626,14 @@ public class WatermarkWorkflowTest {
         assertEquals(revisionedClient.watermarks.size(), 1);
         verify(streamMetadataStoreSpied, never()).removeWriter(anyString(), anyString(), anyString(), any(), any(), any());
         verify(bucketStoreSpied, never()).removeStreamFromBucketStore(any(), anyString(), anyString(), any());
-        
+
         // call watermark after a delay of 5 more seconds. The writer3 should timeout because it has a timeout of 3 seconds.
         Futures.delayedFuture(() -> periodicWatermarking.watermark(stream), 5000L, executor).join();
 
         verify(streamMetadataStoreSpied, times(1)).removeWriter(anyString(), anyString(), anyString(), any(), any(), any());
         verify(bucketStoreSpied, never()).removeStreamFromBucketStore(any(), anyString(), anyString(), any());
-        
-        // watermark should be emitted. without considering writer3 
+
+        // watermark should be emitted. without considering writer3
         assertEquals(revisionedClient.watermarks.size(), 2);
         Watermark watermark = revisionedClient.watermarks.get(1).getValue();
         assertEquals(watermark.getLowerTimeBound(), 200L);
@@ -648,14 +648,14 @@ public class WatermarkWorkflowTest {
         verify(streamMetadataStoreSpied, times(1)).removeWriter(anyString(), anyString(), anyString(), any(), any(), any());
         verify(bucketStoreSpied, never()).removeStreamFromBucketStore(any(), anyString(), anyString(), any());
 
-        // now introduce more delays and see all writers are removed and stream is discontinued from watermarking computation. 
+        // now introduce more delays and see all writers are removed and stream is discontinued from watermarking computation.
         Futures.delayedFuture(() -> periodicWatermarking.watermark(stream), 5000L, executor).join();
 
         // verify that stream is discontinued from tracking for watermarking
         verify(streamMetadataStoreSpied, times(3)).removeWriter(anyString(), anyString(), anyString(), any(), any(), any());
         verify(bucketStoreSpied, times(1)).removeStreamFromBucketStore(any(), anyString(), anyString(), any());
 
-        // call note time for writer3 and verify that watermark is emitted. 
+        // call note time for writer3 and verify that watermark is emitted.
         streamMetadataStoreSpied.noteWriterMark(scope, streamName, writer3, 300L,
                 ImmutableMap.of(0L, 300L, 1L, 0L, 2L, 0L), null, executor).join();
         periodicWatermarking.watermark(stream).join();
@@ -667,10 +667,10 @@ public class WatermarkWorkflowTest {
         assertEquals(getSegmentOffset(watermark, 1L), 200L);
         assertEquals(getSegmentOffset(watermark, 2L), 100L);
     }
-    
+
     private long getSegmentOffset(Watermark watermark, long segmentId) {
         return watermark.getStreamCut().entrySet().stream().filter(x -> x.getKey().getSegmentId() == segmentId)
-                        .findFirst().get().getValue();
+                .findFirst().get().getValue();
     }
 
     private void scaleStream(String streamName, String scope) {
@@ -692,7 +692,7 @@ public class WatermarkWorkflowTest {
     static class MockRevisionedStreamClient implements RevisionedStreamClient<Watermark> {
         private final long segment;
         private final Supplier<Long> segmentSupplier;
-        
+
         private final AtomicInteger revCounter = new AtomicInteger(0);
         private Revision mark;
         private final List<Map.Entry<Revision, Watermark>> watermarks = new ArrayList<>();
@@ -726,6 +726,15 @@ public class WatermarkWorkflowTest {
             checkValid();
             int index = start.equals(MockRevision.EMPTY) ? 0 : ((MockRevision) start).id + 1;
             return watermarks.stream().filter(x -> ((MockRevision) x.getKey()).id >= index).iterator();
+        }
+
+        @Override
+        @Synchronized
+        public Iterator<Map.Entry<Revision, Watermark>> readRange(Revision start, Revision end) throws TruncatedDataException {
+            checkValid();
+            int startIndex = start.equals(MockRevision.EMPTY) ? 0 : ((MockRevision) start).id + 1;
+            int endIndex = end.equals(MockRevision.EMPTY) ? 0 : ((MockRevision) start).id;
+            return watermarks.subList(startIndex, endIndex).iterator();
         }
 
         @Override
@@ -783,7 +792,7 @@ public class WatermarkWorkflowTest {
         public void close() {
 
         }
-        
+
         private void checkValid() {
             long segId  = segmentSupplier.get();
             if (segId != segment) {
@@ -791,11 +800,11 @@ public class WatermarkWorkflowTest {
             }
         }
     }
-    
+
     @EqualsAndHashCode
     static class MockRevision implements Revision {
         static final MockRevision EMPTY = new MockRevision(Integer.MIN_VALUE);
-        
+
         private final int id;
 
         MockRevision(int id) {
@@ -806,7 +815,7 @@ public class WatermarkWorkflowTest {
         public RevisionImpl asImpl() {
             return null;
         }
-        
+
         @Override
         public int compareTo(@NonNull Revision o) {
             return Integer.compare(id, ((MockRevision) o).id);


### PR DESCRIPTION
**Change log description**
Issue 1886 RevisionedStreamClient should have a readRange() call.

**Purpose of the change**  
Fixes #1886

**What the code does**  
Read data between two revisions. 

**How to verify it**  
All tests should pass
