### PR TITLE
Issue 1684: Fail outstanding writes when stream is sealed. 

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -268,32 +268,25 @@ public final class EventStreamWriterImpl<Type> implements EventStreamWriter<Type
 
     @GuardedBy("writeSealLock")
     private void resend(List<PendingEvent> toResend) {
-        if (selector.isStreamSealed()) {
-            log.warn("Stream {} is sealed since no successor segments found", stream.getStreamName());
-            Exception e = new IllegalStateException("Resend of Events cannot proceed since the stream is sealed");
-            toResend.forEach(pendingEvent -> pendingEvent.getAckFuture()
-                    .completeExceptionally(e));
-        } else {
-            while (!toResend.isEmpty()) {
-                List<PendingEvent> unsent = new ArrayList<>();
-                boolean sendFailed = false;
-                log.info("Resending {} events", toResend.size());
-                for (PendingEvent event : toResend) {
-                    if (sendFailed) {
-                        unsent.add(event);
+        while (!toResend.isEmpty()) {
+            List<PendingEvent> unsent = new ArrayList<>();
+            boolean sendFailed = false;
+            log.info("Resending {} events", toResend.size());
+            for (PendingEvent event : toResend) {
+                if (sendFailed) {
+                    unsent.add(event);
+                } else {
+                    SegmentOutputStream segmentWriter = selector.getSegmentOutputStreamForKey(event.getRoutingKey());
+                    if (segmentWriter == null) {
+                        log.info("No writer for segment during resend.");
+                        unsent.addAll(selector.refreshSegmentEventWriters(segmentSealedCallBack));
+                        sendFailed = true;
                     } else {
-                        SegmentOutputStream segmentWriter = selector.getSegmentOutputStreamForKey(event.getRoutingKey());
-                        if (segmentWriter == null) {
-                            log.info("No writer for segment during resend.");
-                            unsent.addAll(selector.refreshSegmentEventWriters(segmentSealedCallBack));
-                            sendFailed = true;
-                        } else {
-                            segmentWriter.write(event);
-                        }
+                        segmentWriter.write(event);
                     }
                 }
-                toResend = unsent;
             }
+            toResend = unsent;
         }
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/SegmentSelector.java
@@ -111,11 +111,13 @@ public class SegmentSelector {
                     return null;
                 });
 
+        // If Successors is null that means Stream doesn't exist
         if (successors == null) {
             return Collections.emptyList();
         } else if (successors.getSegmentToPredecessor().isEmpty()) {
             log.warn("Stream {} is sealed since no successor segments found for segment {} ", sealedSegment.getStream(), sealedSegment);
             Exception e = new IllegalStateException("Writes cannot proceed since the stream is sealed");
+            // Remove all writers and fail all pending writes since Stream is sealed and no successor segment found
             removeAllWriters().forEach(pendingEvent -> pendingEvent.getAckFuture()
                                                                    .completeExceptionally(e));
             sealed.set(true);

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -337,6 +337,51 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
     }
 
     @Test
+    public void testResendFailedUponStreamSealed() {
+        String scope = "scope";
+        String streamName = "stream";
+        String routingKey = "RoutingKey";
+        StreamImpl stream = new StreamImpl(scope, streamName);
+        Segment segment1 = new Segment(scope, streamName, 0);
+        EventWriterConfig config = EventWriterConfig.builder().build();
+        SegmentOutputStreamFactory streamFactory = Mockito.mock(SegmentOutputStreamFactory.class);
+        Controller controller = Mockito.mock(Controller.class);
+
+        FakeSegmentOutputStream outputStream1 = new FakeSegmentOutputStream(segment1);
+        Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment1), any(), any(), any())).thenAnswer(i -> {
+            outputStream1.callBackForSealed = i.getArgument(1);
+            return outputStream1;
+        });
+
+        JavaSerializer<String> serializer = new JavaSerializer<>();
+        val empty = CompletableFuture.completedFuture(new StreamSegments(new TreeMap<>()));
+
+        Mockito.when(controller.getCurrentSegments(scope, streamName))
+                .thenReturn(getSegmentsFuture(segment1))
+                .thenReturn(empty);
+        @Cleanup
+        EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
+                config, executorService(), executorService(), null);
+        // When stream is not seal then we are able to write to the stream.
+        writer.writeEvent(routingKey, "Foo");
+        writer.writeEvent(routingKey, "Bar");
+
+        Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(empty);
+        val noFutures = CompletableFuture.completedFuture(new StreamSegmentsWithPredecessors(new HashMap<>(), ""));
+        Mockito.when(controller.getSuccessors(segment1)).thenReturn(noFutures);
+
+        assertEquals(2, outputStream1.unacked.size());
+        //invoke the sealed callback invocation simulating a netty call back with segment sealed exception.
+        outputStream1.sealed = true;
+        outputStream1.invokeSealedCallBack();
+
+        assertThrows("Stream should throw IllegalStateException", () -> writer.writeEvent(routingKey, "foo"), e -> e.getClass().equals(IllegalStateException.class));
+        assertThrows("Stream should be sealed", () -> writer.writeEvent(routingKey, "Bar"), e -> e.getMessage().contains("sealed"));
+        writer.close();
+    }
+
+
+    @Test
     public void testEndOfSegmentBackgroundRefresh() {
         String scope = "scope";
         String streamName = "stream";

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -362,7 +362,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
                 config, executorService(), executorService(), null);
-        // When stream is not seal then we are able to write to the stream.
+        //When stream is not seal then we are able to write to the stream.
         writer.writeEvent(routingKey, "Foo");
         writer.writeEvent(routingKey, "Bar");
 


### PR DESCRIPTION

**Change log description**  
Failing outstanding writes when stream is sealed. 

**Purpose of the change**  
To fix [#1684](https://github.com/pravega/pravega/issues/1684)

**What the code does**  
The code Checks if Stream is sealed then it will fail the outstanding writes and throws IllegalStateException("Resend of Events cannot proceed since the stream is sealed").
Otherwise it will resend and retry for write the event to the stream. 
The stream status is being set in refreshSegmentEventWritersUponSealed method in SegmentSelecter class. what this method is doing its checking if getSuccessor for any stream is empty then it will set sealed flag to true and that flag we are checking inside resend method through the isStreamSealed() in EventStreamWriterImpl.
And also added a Unit test for testing the required functionality.
for more info please have  a look to this github issue.
https://github.com/pravega/pravega/issues/1684

**How to verify it**  
All test should pass. 

Signed-off-by: a6dulaleem <abdul.aleem1@dell.com>
