### PR TITLE
Issue 6961: SLTS - Use more hierarchical organization of chunks.

### DIFF
--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageMockTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageMockTests.java
@@ -397,7 +397,7 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
         val list = taskQueueManager.drain(chunkedSegmentStorage.getGarbageCollector().getTaskQueueName(), 2);
         Assert.assertTrue(chunksListBefore.contains(list.get(0).getName()));
 
-        val nameTemplate = String.format("%s.E-%d-O-%d.", testSegmentName, chunkedSegmentStorage.getEpoch(), 8);
+        val nameTemplate = String.format("%s/E-%d-O-%d.", testSegmentName, chunkedSegmentStorage.getEpoch(), 8);
         Assert.assertTrue("New first chunk should be added to GC queue.", list.get(1).getName().startsWith(nameTemplate));
     }
 

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -165,7 +165,7 @@ public final class NameUtils {
     /**
      * Format for chunk name with segment name , epoch and offset.
      */
-    private static final String CHUNK_NAME_FORMAT_WITH_EPOCH_OFFSET = "%s.E-%d-O-%d.%s";
+    private static final String CHUNK_NAME_FORMAT_WITH_EPOCH_OFFSET = "%s/E-%d-O-%d.%s";
 
     /**
      * Format for name of read index block index entry.

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -175,7 +175,7 @@ public class NameUtilsTest {
                 "_system/containers/_sysjournal.epoch3.container2.file4");
         Assert.assertEquals(NameUtils.getSystemJournalSnapshotFileName(5, 6, 7),
                 "_system/containers/_sysjournal.epoch6.container5.snapshot7");
-        Assert.assertTrue(NameUtils.getSegmentChunkName("segment", 8, 9).startsWith("segment.E-8-O-9"));
+        Assert.assertTrue(NameUtils.getSegmentChunkName("segment", 8, 9).startsWith("segment/E-8-O-9"));
         Assert.assertEquals(NameUtils.getSegmentReadIndexBlockName("segment", 10), "segment.B-10");
     }
 


### PR DESCRIPTION
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
LTS - Use more hierarchical organization where each segment has its own directory with only its own chunks in it. 

**Purpose of the change**  
Fixes #6961 

**What the code does**  

- Use more hierarchical organization where each segment has its own directory with only its own chunks in it. 
- For backward compatibility purposes, the new naming scheme is applied only for new chunks after this version. Eventually old chunks with old naming scheme will be deleted. Obviously, there is no backward compatibility problem with fresh deployments.
- out of scope - This change does NOT change naming scheme for journals.

**How to verify it**  
All tests should pass.
Upgrade should pass.
