### PR TITLE
Issue 2166: Improve logging for outstanding checkpoint

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -152,7 +152,7 @@ public class CheckpointState {
             positions.putAll(position);
             if (readers.isEmpty()) {
                 uncheckpointedHosts.remove(checkpointId);
-
+                log.info("Completed checkpointing for Checkpoint : {} by all readers", checkpointId);
                 //store last checkpoint position if it is not a stream-cut (silent checkpoint)
                 if (!isCheckpointSilent(checkpointId)) {
                     //checkpoint operation completed for all readers, update the last checkpoint position.
@@ -194,6 +194,16 @@ public class CheckpointState {
         return checkpoints.stream()
                           .filter(checkpoint -> !(isCheckpointSilent(checkpoint) || isCheckpointComplete(checkpoint)))
                           .collect(Collectors.toList());
+    }
+
+    /**
+     * Get the map of CheckpointId to list of readers blocking that checkpoint.
+     * @return the map.
+     */
+    Map<String, List<String>> getReaderBlockingCheckpointsMap(){
+        return  uncheckpointedHosts.entrySet().stream()
+                                   .filter(checkpoint -> !(isCheckpointSilent(checkpoint.getKey()) || isCheckpointComplete(checkpoint.getKey())))
+                                   .collect(Collectors.toMap(Map.Entry::getKey,Map.Entry::getValue));
     }
 
     void clearCheckpointsBefore(String checkpointId) {

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -200,10 +200,10 @@ public class CheckpointState {
      * Get the map of CheckpointId to list of readers blocking that checkpoint.
      * @return the map.
      */
-    Map<String, List<String>> getReaderBlockingCheckpointsMap(){
+    Map<String, List<String>> getReaderBlockingCheckpointsMap() {
         return  uncheckpointedHosts.entrySet().stream()
                                    .filter(checkpoint -> !(isCheckpointSilent(checkpoint.getKey()) || isCheckpointComplete(checkpoint.getKey())))
-                                   .collect(Collectors.toMap(Map.Entry::getKey,Map.Entry::getValue));
+                                   .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     void clearCheckpointsBefore(String checkpointId) {

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamReaderImpl.java
@@ -280,7 +280,7 @@ public final class EventStreamReaderImpl<Type> implements EventStreamReader<Type
             // process the checkpoint we're at
             position = refreshAndGetPosition();
             groupState.checkpoint(atCheckpoint, position);
-            log.info("Reader {} completed checkpoint {}", groupState.getReaderId(), atCheckpoint);
+            log.info("Reader {} completed checkpoint {} at postion {}", groupState.getReaderId(), atCheckpoint, position);
             releaseSegmentsIfNeeded(position);
             groupState.updateTruncationStreamCutIfNeeded();
         }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -164,8 +164,9 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
                 log.warn("Current outstanding checkpoints are : {}, " +
                                  "maxOutstandingCheckpointRequest: {}, currentOutstandingCheckpointRequest: {}, errorMessage: {} {}, readers blocking checkpoint are: {}",
                          outstandingCheckpoints, maxOutstandingCheckpointRequest, currentOutstandingCheckpointRequest, rejectMessage,
-                         maxOutstandingCheckpointRequest, checkpointState.getReaderBlockingCheckpointsMap());
+                         maxOutstandingCheckpointRequest);
 
+                log.warn(" readers oustanding checkpoints {} ",checkpointState.getReaderBlockingCheckpointsMap());
                 return false;
             } else {
                 updates.add(new CreateCheckpoint(checkpointName));

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -166,7 +166,7 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
                          outstandingCheckpoints, maxOutstandingCheckpointRequest, currentOutstandingCheckpointRequest, rejectMessage,
                          maxOutstandingCheckpointRequest);
 
-                log.warn(" readers oustanding checkpoints {} ",checkpointState.getReaderBlockingCheckpointsMap());
+                log.warn(" readers outstanding checkpoints {} ", checkpointState.getReaderBlockingCheckpointsMap());
                 return false;
             } else {
                 updates.add(new CreateCheckpoint(checkpointName));

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -163,10 +163,8 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
             if (currentOutstandingCheckpointRequest >= maxOutstandingCheckpointRequest) {
                 log.warn("Current outstanding checkpoints are : {}, " +
                                  "maxOutstandingCheckpointRequest: {}, currentOutstandingCheckpointRequest: {}, errorMessage: {} {}, readers blocking checkpoint are: {}",
-                         outstandingCheckpoints, maxOutstandingCheckpointRequest, currentOutstandingCheckpointRequest, rejectMessage,
-                         maxOutstandingCheckpointRequest);
+                         outstandingCheckpoints, maxOutstandingCheckpointRequest, currentOutstandingCheckpointRequest, rejectMessage, maxOutstandingCheckpointRequest, checkpointState.getReaderBlockingCheckpointsMap());
 
-                log.warn(" readers outstanding checkpoints {} ", checkpointState.getReaderBlockingCheckpointsMap());
                 return false;
             } else {
                 updates.add(new CreateCheckpoint(checkpointName));
@@ -175,6 +173,7 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
 
         });
         if (!canPerformCheckpoint) {
+            log.warn(rejectMessage);
             return Futures.failedFuture(new MaxNumberOfCheckpointsExceededException(rejectMessage));
         }
 
@@ -223,6 +222,7 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
         if (map.isEmpty()) {
             log.info("All the events between start and end of stream cuts are already read by {}, nothing more to read", getGroupName());
         }
+        log.debug("Checkpointing for {} is completed successfully", checkpointName);
         return new CheckpointImpl(checkpointName, map);
     }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -173,7 +173,6 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
 
         });
         if (!canPerformCheckpoint) {
-            log.warn(rejectMessage);
             return Futures.failedFuture(new MaxNumberOfCheckpointsExceededException(rejectMessage));
         }
 

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -162,9 +162,9 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
             int currentOutstandingCheckpointRequest = outstandingCheckpoints.size();
             if (currentOutstandingCheckpointRequest >= maxOutstandingCheckpointRequest) {
                 log.warn("Current outstanding checkpoints are : {}, " +
-                                 "maxOutstandingCheckpointRequest: {}, currentOutstandingCheckpointRequest: {}, errorMessage: {} {}",
+                                 "maxOutstandingCheckpointRequest: {}, currentOutstandingCheckpointRequest: {}, errorMessage: {} {}, readers blocking checkpoint are: {}",
                          outstandingCheckpoints, maxOutstandingCheckpointRequest, currentOutstandingCheckpointRequest, rejectMessage,
-                         maxOutstandingCheckpointRequest);
+                         maxOutstandingCheckpointRequest,checkpointState.getReaderBlockingCheckpointsMap());
 
                 return false;
             } else {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -164,7 +164,7 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
                 log.warn("Current outstanding checkpoints are : {}, " +
                                  "maxOutstandingCheckpointRequest: {}, currentOutstandingCheckpointRequest: {}, errorMessage: {} {}, readers blocking checkpoint are: {}",
                          outstandingCheckpoints, maxOutstandingCheckpointRequest, currentOutstandingCheckpointRequest, rejectMessage,
-                         maxOutstandingCheckpointRequest,checkpointState.getReaderBlockingCheckpointsMap());
+                         maxOutstandingCheckpointRequest, checkpointState.getReaderBlockingCheckpointsMap());
 
                 return false;
             } else {

--- a/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
@@ -160,9 +160,9 @@ public class CheckpointStateTest {
     @Test
     public void testGetReaderBlockingCheckpointsMap() {
         CheckpointState state = new CheckpointState();
-        state.beginNewCheckpoint("1", ImmutableSet.of("a","b"), Collections.emptyMap());
+        state.beginNewCheckpoint("1", ImmutableSet.of("a", "b"), Collections.emptyMap());
         state.beginNewCheckpoint("2" + SILENT, ImmutableSet.of("a"), Collections.emptyMap());
-        state.beginNewCheckpoint("3", ImmutableSet.of("a","b"), Collections.emptyMap());
+        state.beginNewCheckpoint("3", ImmutableSet.of("a", "b"), Collections.emptyMap());
         // Silent checkpoint should not be counted as part of CheckpointState#getOutstandingCheckpoints.
 
         assertEquals(2, state.getReaderBlockingCheckpointsMap().size());

--- a/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
@@ -157,6 +157,33 @@ public class CheckpointStateTest {
         assertNotEquals(lastCheckpointPosition, ImmutableMap.of(getSegment("S1"), 3L));
     }
 
+    @Test
+    public void testGetReaderBlockingCheckpointsMap() {
+        CheckpointState state = new CheckpointState();
+        state.beginNewCheckpoint("1", ImmutableSet.of("a","b"), Collections.emptyMap());
+        state.beginNewCheckpoint("2" + SILENT, ImmutableSet.of("a"), Collections.emptyMap());
+        state.beginNewCheckpoint("3", ImmutableSet.of("a","b"), Collections.emptyMap());
+        // Silent checkpoint should not be counted as part of CheckpointState#getOutstandingCheckpoints.
+
+        assertEquals(2, state.getReaderBlockingCheckpointsMap().size());
+
+        // Complete checkpoint "1" by reader 'a'.
+        state.readerCheckpointed("1", "a", ImmutableMap.of(getSegment("S1"), 1L));
+        // Checkpoint "1" is not completed by reader "b"
+        assertEquals("b", state.getReaderBlockingCheckpointsMap().get("1").get(0));
+        assertFalse(state.isCheckpointComplete("1"));
+        // CheckpointState#getReaderBlockingCheckpointsMap contains 2 entries
+        assertEquals(2, state.getReaderBlockingCheckpointsMap().size());
+
+        // Complete checkpoint "1" by reader 'b'.
+        state.readerCheckpointed("1", "b", ImmutableMap.of(getSegment("S1"), 1L));
+
+        // Only checkpoint "3" is outstanding as checkpoints "1" is complete and silent checkpoints are ignored.
+        assertEquals(1, state.getReaderBlockingCheckpointsMap().size());
+        assertTrue(state.isCheckpointComplete("1"));
+        assertFalse(state.isCheckpointComplete("3"));
+    }
+
     private Segment getSegment(String name) {
         return new Segment("ExampleScope", name, 0);
     }

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -50,10 +50,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -65,7 +63,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
-import lombok.val;
 import org.junit.Before;
 import org.junit.After;
 import org.junit.Test;
@@ -531,10 +528,12 @@ public class ReaderGroupImplTest {
             assertTrue("expecting MaxNumberOfCheckpointsExceededException", e.getCause() instanceof MaxNumberOfCheckpointsExceededException);
         }
     }
+    
     private void createScopeAndStream(String scope, String stream, MockController controller) {
         controller.createScope(scope).join();
         controller.createStream(scope, stream, configStream).join();
     }
+
     private StreamCut createStreamCut(String streamName, int numberOfSegments) {
         Map<Segment, Long> positions = new HashMap<>();
         IntStream.of(numberOfSegments).forEach(segNum -> positions.put(new Segment(SCOPE, streamName, segNum), 10L));

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -31,12 +31,18 @@ import io.pravega.client.state.Update;
 import io.pravega.client.stream.Checkpoint;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReaderSegmentDistribution;
+import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
+import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.ReaderGroupState.ClearCheckpointsBefore;
+import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
+import io.pravega.client.stream.mock.MockController;
+import io.pravega.client.stream.mock.MockSegmentStreamFactory;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.shared.NameUtils;
+import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.InlineExecutor;
 import java.util.Arrays;
@@ -44,8 +50,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -57,6 +65,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
+import lombok.val;
 import org.junit.Before;
 import org.junit.After;
 import org.junit.Test;
@@ -104,7 +113,9 @@ public class ReaderGroupImplTest {
 
     private Serializer<InitialUpdate<ReaderGroupState>> initSerializer = new ReaderGroupStateInitSerializer();
     private Serializer<Update<ReaderGroupState>> updateSerializer = new ReaderGroupStateUpdatesSerializer();
-
+    private final StreamConfiguration configStream = StreamConfiguration.builder()
+                                                                  .scalingPolicy(ScalingPolicy.fixed(1))
+                                                                  .build();
     @SuppressWarnings("unchecked")
     @Before
     public void setUp() throws Exception {
@@ -484,6 +495,46 @@ public class ReaderGroupImplTest {
         assertEquals(Long.MAX_VALUE, endSegmentMap.get(new Segment(SCOPE, "s1", 0)).longValue());
     }
 
+        @Test(timeout = 10000)
+    public void initiateCheckpointOutstandingCheckPoint() throws Exception {
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", 12345);
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController mkController = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
+        createScopeAndStream("scope", "stream", mkController);
+        MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
+
+        @Cleanup
+        SynchronizerClientFactory syncClientFactory = new ClientFactoryImpl("scope", mkController, connectionFactory, streamFactory,
+                streamFactory, streamFactory, streamFactory);
+        SynchronizerConfig syncConfig = SynchronizerConfig.builder().build();
+        Map<SegmentWithRange, Long> segments = new HashMap<>();
+        Segment s1 = new Segment("scope", "stream", 1);
+        Segment s2 = new Segment("scope", "stream", 2);
+        segments.put(new SegmentWithRange(s1, 0.0, 0.5), 1L);
+        segments.put(new SegmentWithRange(s2, 0.5, 1.0), 2L);
+        createScopeAndStream("scope", NameUtils.getStreamForReaderGroup(GROUP_NAME), mkController);
+        readerGroup = new ReaderGroupImpl("scope", GROUP_NAME, syncConfig, initSerializer,
+                updateSerializer, syncClientFactory, mkController, connectionPool);
+
+        @Cleanup("shutdown")
+        InlineExecutor executor = new InlineExecutor();
+        StateSynchronizer<ReaderGroupState> rgStateSynchronizer = readerGroup.getSynchronizer();
+        rgStateSynchronizer.initialize(new ReaderGroupState.ReaderGroupStateInit(
+                ReaderGroupConfig.builder().stream(Stream.of("scope", "stream")).maxOutstandingCheckpointRequest(1).build(), segments, Collections.emptyMap(), false));
+        CheckpointState rgState = rgStateSynchronizer.getState().getCheckpointState();
+        rgState.beginNewCheckpoint("1", ImmutableSet.of("a", "b"), Collections.emptyMap());
+        CompletableFuture<Checkpoint> result = readerGroup.initiateCheckpoint("test", executor);
+        assertTrue("expecting a checkpoint failure", result.isCompletedExceptionally());
+        try {
+            result.get();
+        } catch (InterruptedException | ExecutionException e) {
+            assertTrue("expecting MaxNumberOfCheckpointsExceededException", e.getCause() instanceof MaxNumberOfCheckpointsExceededException);
+        }
+    }
+    private void createScopeAndStream(String scope, String stream, MockController controller) {
+        controller.createScope(scope).join();
+        controller.createStream(scope, stream, configStream).join();
+    }
     private StreamCut createStreamCut(String streamName, int numberOfSegments) {
         Map<Segment, Long> positions = new HashMap<>();
         IntStream.of(numberOfSegments).forEach(segNum -> positions.put(new Segment(SCOPE, streamName, segNum), 10L));


### PR DESCRIPTION
Signed-off-by: Shwetha N <shwetha.n1@dell.com>

**Change log description**  
Maximum outstanding checkpoint warning message gives info only about blocked checkpoints not on the readers who are actually blocking it.
In one of use case, we could see that though all readers successfully acknowledge the checkpoints, while triggering new initiate checkpoint call it still complains with checkpoints being blocked but here, we have lack of info on the readers who is actually blocking these checkpoints

**Purpose of the change**  
#6977 

**What the code does**  
Added logs which gives more clarity on readers who are blocking the checkpoints.

**How to verify it**  
All tests should pass
