### PR TITLE
Add plublish maven when gradle version is greater or equal than 7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,7 @@ allprojects {
 	    force "org.jetbrains.kotlin:kotlin-stdlib-common:" + kotlinVersion
 	    force "org.jetbrains.kotlin:kotlin-stdlib:" + kotlinVersion
 	    force "org.yaml:snakeyaml:" + snakeYamlVersion
+            force "com.fasterxml.woodstox:woodstox-core:" + woodstoxVersion
 	    force "org.jdom:jdom2:" + jdomVersion
             // Netty 4 uber jar
             exclude group: 'io.netty', module: 'netty-all'

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,7 @@ guavaVersion=30.1-jre
 guiceVersion=4.0
 hadoopVersion=3.3.4
 javaxServletApiVersion=4.0.0
-jacksonVersion=2.13.4
+jacksonVersion=2.14.0
 javaxwsrsApiVersion=2.1
 jaxbVersion=2.3.1
 activationVersion=1.2.0
@@ -57,7 +57,7 @@ junitVersion=4.13.2
 # Before upgrading Lombok, please check https://github.com/pravega/pravega/issues/6945
 lombokVersion=1.18.12
 marathonClientVersion=0.6.2
-micrometerVersion=1.2.0
+micrometerVersion=1.3.7
 mockitoVersion=3.3.3
 jacocoVersion=0.8.5
 nettyVersion=4.1.82.Final
@@ -76,6 +76,7 @@ gcpCloudNioVersion=0.124.5
 kotlinVersion=1.7.20
 snakeYamlVersion=1.33
 jdomVersion=2.0.6.1
+woodstoxVersion=6.4.0
 
 # Version and base tags can be overridden at build time
 pravegaVersion=0.14.0-SNAPSHOT


### PR DESCRIPTION
Signed-off-by: davideduma [david24eduma@gmail.com](mailto:david24eduma@gmail.com)

Tags:
@JhoanAlvear
@davideduma

Change log description
MavenDeployment deployment is deprecated.
Update come from: https://docs.gradle.org/current/userguide/publishing_maven.html

image

Purpose of the change
ISSUE: https://github.com/pravega/pravega/issues/6981

What the code does
Reemplace el código antiguo para actualizar el script. Sugerir documentos gradle.
https://docs.gradle.org/current/userguide/publishing_maven.html

How to verify it
Description about how to verify on the link below : https://github.com/pravega/pravega/issues/6981
