### PR TITLE
LTS - Set default value of storage.readindex.block.size to 1 GB.

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
@@ -40,7 +40,7 @@ public class ChunkedSegmentStorageConfig {
     public static final Property<Integer> MAX_INDEXED_SEGMENTS = Property.named("readindex.segments.max", 1024);
     public static final Property<Integer> MAX_INDEXED_CHUNKS_PER_SEGMENTS = Property.named("readindex.chunksPerSegment.max", 1024);
     public static final Property<Integer> MAX_INDEXED_CHUNKS = Property.named("readindex.chunks.max", 16 * 1024);
-    public static final Property<Long> READ_INDEX_BLOCK_SIZE = Property.named("readindex.block.size", 1024 * 1024L);
+    public static final Property<Long> READ_INDEX_BLOCK_SIZE = Property.named("readindex.block.size", 1024 * 1024 * 1024L);
 
     public static final Property<Boolean> APPENDS_ENABLED = Property.named("appends.enable", true);
     public static final Property<Boolean> INLINE_DEFRAG_ENABLED = Property.named("defrag.inline.enable", true);
@@ -97,7 +97,7 @@ public class ChunkedSegmentStorageConfig {
             .garbageCollectionSleep(Duration.ofMillis(10))
             .garbageCollectionMaxAttempts(3)
             .garbageCollectionTransactionBatchSize(5000)
-            .indexBlockSize(1024 * 1024)
+            .indexBlockSize(1024 * 1024 * 1024)
             .maxEntriesInCache(5000)
             .maxEntriesInTxnBuffer(1024)
             .journalSnapshotInfoUpdateFrequency(Duration.ofMinutes(5))


### PR DESCRIPTION
**Change log description**  
Need to increase the default value of storage.readindex.block.size to 1 GB from 1 MB. 

**Purpose of the change**  
Fixes #7002 

**What the code does**  
The code sets the default value of storage.readindex.block.size which is 1 MB to 1 GB. The purpose of the change is that the previous default value was too small and did lead to too many index entries which is unnecessary, wasteful and also led to OOM in certain conditions.

**How to verify it**  
All the tests should pass.
