### PR TITLE
Issue 1886: Introduces readRange method in RevisionStreamClient

### DIFF
--- a/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
+++ b/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
@@ -65,7 +65,7 @@ public interface RevisionedStreamClient<T> extends AutoCloseable {
      * @throws TruncatedDataException If the data at start no longer exists because it has been
      *             truncated. IE: It is below {@link #fetchOldestRevision()}
      */
-    public Iterator<Entry<Revision, T>> readRange(Revision startRevision, Revision endRevision) throws TruncatedDataException;
+    Iterator<Entry<Revision, T>> readRange(Revision startRevision, Revision endRevision) throws TruncatedDataException;
 
     /**
      * If the supplied revision is the latest revision in the stream write the provided value and return the new revision.

--- a/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
+++ b/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
@@ -66,6 +66,7 @@ public interface RevisionedStreamClient<T> extends AutoCloseable {
      *             truncated. IE: It is below {@link #fetchOldestRevision()}
      */
     public Iterator<Entry<Revision, T>> readRange(Revision startRevision, Revision endRevision) throws TruncatedDataException;
+
     /**
      * If the supplied revision is the latest revision in the stream write the provided value and return the new revision.
      * If the supplied revision is not the latest, nothing will occur and null will be returned.

--- a/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
+++ b/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
@@ -55,6 +55,18 @@ public interface RevisionedStreamClient<T> extends AutoCloseable {
     Iterator<Entry<Revision, T>> readFrom(Revision start) throws TruncatedDataException;
 
     /**
+     * Read all data from a given start revision to a given end revision. The returned iterator will
+     * stop once it reaches the given end of the data that was in the stream at the time this method was
+     * called.
+     *
+     * @param startRevision The location the iterator should start at.
+     * @param endRevision The location the iterator should end at.
+     * @return An iterator over Revision, value pairs.
+     * @throws TruncatedDataException If the data at start no longer exists because it has been
+     *             truncated. IE: It is below {@link #fetchOldestRevision()}
+     */
+    public Iterator<Entry<Revision, T>> readRange(Revision startRevision, Revision endRevision);
+    /**
      * If the supplied revision is the latest revision in the stream write the provided value and return the new revision.
      * If the supplied revision is not the latest, nothing will occur and null will be returned.
      * 

--- a/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
+++ b/client/src/main/java/io/pravega/client/state/RevisionedStreamClient.java
@@ -65,7 +65,7 @@ public interface RevisionedStreamClient<T> extends AutoCloseable {
      * @throws TruncatedDataException If the data at start no longer exists because it has been
      *             truncated. IE: It is below {@link #fetchOldestRevision()}
      */
-    public Iterator<Entry<Revision, T>> readRange(Revision startRevision, Revision endRevision);
+    public Iterator<Entry<Revision, T>> readRange(Revision startRevision, Revision endRevision) throws TruncatedDataException;
     /**
      * If the supplied revision is the latest revision in the stream write the provided value and return the new revision.
      * If the supplied revision is not the latest, nothing will occur and null will be returned.

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -16,6 +16,7 @@
 package io.pravega.client.state.impl;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import io.pravega.client.security.auth.DelegationTokenProvider;
 import io.pravega.client.segment.impl.ConditionalOutputStream;
 import io.pravega.client.segment.impl.EndOfSegmentException;
@@ -152,6 +153,8 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
 
     @Override
     public Iterator<Entry<Revision, T>> readRange(Revision startRevision, Revision endRevision) {
+        Preconditions.checkNotNull(startRevision);
+        Preconditions.checkNotNull(endRevision);
         log.trace("Read segment {} from revision {} to revision {}", segment, startRevision, endRevision);
         synchronized (lock) {
             long startOffset = startRevision.asImpl().getOffsetInSegment();
@@ -161,7 +164,7 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
                 throw new TruncatedDataException(format("Data at the supplied revision {%s} has been truncated. The current segment info is {%s}", startRevision, segmentInfo));
             }
             if (startOffset == endOffset) {
-                log.debug("No new updates to be read from revision {}", endRevision);
+                log.debug("No new updates to be read from revision {}", startOffset);
             }
             if (startOffset > endOffset) {
                 throw new IllegalStateException("startOffset: " + startOffset + " is grater than endOffset: " +  endOffset);

--- a/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
+++ b/client/src/main/java/io/pravega/client/state/impl/RevisionedStreamClientImpl.java
@@ -157,12 +157,8 @@ public class RevisionedStreamClientImpl<T> implements RevisionedStreamClient<T> 
             long startOffset = startRevision.asImpl().getOffsetInSegment();
             SegmentInfo segmentInfo = Futures.getThrowingException(meta.getSegmentInfo());
             long endOffset = endRevision.asImpl().getOffsetInSegment();
-            long writeOffset = segmentInfo.getWriteOffset();
             if (startOffset < segmentInfo.getStartingOffset()) {
                 throw new TruncatedDataException(format("Data at the supplied revision {%s} has been truncated. The current segment info is {%s}", startRevision, segmentInfo));
-            }
-            if (endOffset > writeOffset) {
-                throw new IllegalStateException("endOffset: " + endOffset + " is grater than currentWriteOffset: " +  writeOffset);
             }
             if (startOffset == endOffset) {
                 log.debug("No new updates to be read from revision {}", endRevision);

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -160,8 +160,10 @@ public class RevisionedStreamClientTest {
         assertEquals("a", iterA.next().getValue());
         assertEquals("b", iterA.next().getValue());
         assertThrows(NoSuchElementException.class, () -> iterA.next().getValue());
+        // Will return an empty Entry for the same revision
         Iterator<Entry<Revision, String>> iterB = client.readRange(r0, r0);
         assertFalse(iterB.hasNext());
+        // Checking the condition when endRevision is passed at the place of the startRevision
         assertThrows(IllegalStateException.class, () -> client.readRange(rb, r0));
     }
 

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -161,7 +161,7 @@ public class RevisionedStreamClientTest {
         assertEquals("a", iterA.next().getValue());
         assertEquals("b", iterA.next().getValue());
         assertThrows(NoSuchElementException.class, () -> iterA.next().getValue());
-        // This will return an empty Entry for the same revision
+        // will return an empty Entry for the same revision
         Iterator<Entry<Revision, String>> iterB = client.readRange(r0, r0);
         assertFalse(iterB.hasNext());
         // Checking the condition when endRevision is passed at the place of the startRevision

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -152,6 +152,7 @@ public class RevisionedStreamClientTest {
 
         Revision r0 = client.fetchOldestRevision();
         client.writeUnconditionally("a");
+        Revision ra = client.fetchLatestRevision();
         client.writeUnconditionally("b");
         Revision rb = client.fetchLatestRevision();
         client.writeUnconditionally("c");
@@ -165,6 +166,11 @@ public class RevisionedStreamClientTest {
         assertFalse(iterB.hasNext());
         // Checking the condition when endRevision is passed at the place of the startRevision
         assertThrows(IllegalStateException.class, () -> client.readRange(rb, r0));
+        // Validating the case when stream already truncated and start revision didn't exist.   
+        Revision rc = client.fetchLatestRevision();
+        client.truncateToRevision(rb);
+        assertEquals(rb, client.fetchOldestRevision());
+        assertThrows(TruncatedDataException.class, () -> client.readRange(ra , rc));
     }
 
 

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -160,7 +160,7 @@ public class RevisionedStreamClientTest {
         assertEquals("a", iterA.next().getValue());
         assertEquals("b", iterA.next().getValue());
         assertThrows(NoSuchElementException.class, () -> iterA.next().getValue());
-        // Will return an empty Entry for the same revision
+        // This will return an empty Entry for the same revision
         Iterator<Entry<Revision, String>> iterB = client.readRange(r0, r0);
         assertFalse(iterB.hasNext());
         // Checking the condition when endRevision is passed at the place of the startRevision

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -131,6 +131,7 @@ public class RevisionedStreamClientTest {
         assertEquals("d", iter.next().getValue());
         assertFalse(iter.hasNext());
     }
+
     @Test
     public void testReadRange() throws Exception {
         String scope = "scope";

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -161,7 +161,7 @@ public class RevisionedStreamClientTest {
         assertEquals("a", iterA.next().getValue());
         assertEquals("b", iterA.next().getValue());
         assertThrows(NoSuchElementException.class, () -> iterA.next().getValue());
-        // will return an empty Entry for the same revision
+        // This will return an empty Entry for the same revision
         Iterator<Entry<Revision, String>> iterB = client.readRange(r0, r0);
         assertFalse(iterB.hasNext());
         // Checking the condition when endRevision is passed at the place of the startRevision

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -58,6 +58,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import lombok.Cleanup;
@@ -130,6 +131,39 @@ public class RevisionedStreamClientTest {
         assertEquals("d", iter.next().getValue());
         assertFalse(iter.hasNext());
     }
+    @Test
+    public void testReadrange() throws Exception {
+        String scope = "scope";
+        String stream = "stream";
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);
+        @Cleanup
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        @Cleanup
+        MockController controller = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
+        createScopeAndStream(scope, stream, controller);
+        MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
+        @Cleanup
+        SynchronizerClientFactory clientFactory = new ClientFactoryImpl(scope, controller, connectionFactory, streamFactory, streamFactory, streamFactory, streamFactory);
+
+        SynchronizerConfig config = SynchronizerConfig.builder().build();
+        @Cleanup
+        RevisionedStreamClient<String> client = clientFactory.createRevisionedStreamClient(stream, new JavaSerializer<>(), config);
+
+        Revision r0 = client.fetchOldestRevision();
+        client.writeUnconditionally("a");
+        client.writeUnconditionally("b");
+        Revision rb = client.fetchLatestRevision();
+        client.writeUnconditionally("c");
+        Iterator<Entry<Revision, String>> iterA = client.readRange(r0, rb);
+        assertTrue(iterA.hasNext());
+        assertEquals("a", iterA.next().getValue());
+        assertEquals("b", iterA.next().getValue());
+        assertThrows(NoSuchElementException.class, () -> iterA.next().getValue());
+        Iterator<Entry<Revision, String>> iterB = client.readRange(r0, r0);
+        assertFalse(iterB.hasNext());
+        assertThrows(IllegalStateException.class, () -> client.readRange(rb, r0));
+    }
+
 
     @Test
     public void testConditionalWrite() {

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -166,11 +166,11 @@ public class RevisionedStreamClientTest {
         assertFalse(iterB.hasNext());
         // Checking the condition when endRevision is passed at the place of the startRevision
         assertThrows(IllegalStateException.class, () -> client.readRange(rb, r0));
-        // Validating the case when stream already truncated and start revision didn't exist.   
+        // Validating the case when stream already truncated and start revision didn't exist.
         Revision rc = client.fetchLatestRevision();
         client.truncateToRevision(rb);
         assertEquals(rb, client.fetchOldestRevision());
-        assertThrows(TruncatedDataException.class, () -> client.readRange(ra , rc));
+        assertThrows(TruncatedDataException.class, () -> client.readRange(ra, rc));
     }
 
 

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -132,7 +132,7 @@ public class RevisionedStreamClientTest {
         assertFalse(iter.hasNext());
     }
     @Test
-    public void testReadrange() throws Exception {
+    public void testReadRange() throws Exception {
         String scope = "scope";
         String stream = "stream";
         PravegaNodeUri endpoint = new PravegaNodeUri("localhost", SERVICE_PORT);

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -161,7 +161,7 @@ public class RevisionedStreamClientTest {
         assertEquals("a", iterA.next().getValue());
         assertEquals("b", iterA.next().getValue());
         assertThrows(NoSuchElementException.class, () -> iterA.next().getValue());
-        // This will return an empty Entry for the same revision
+        // Will return an empty Entry for the same revision
         Iterator<Entry<Revision, String>> iterB = client.readRange(r0, r0);
         assertFalse(iterB.hasNext());
         // Checking the condition when endRevision is passed at the place of the startRevision

--- a/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/RevisionedStreamClientTest.java
@@ -132,7 +132,7 @@ public class RevisionedStreamClientTest {
         assertFalse(iter.hasNext());
     }
 
-    @Test
+    @Test(timeout = 30000L)
     public void testReadRange() throws Exception {
         String scope = "scope";
         String stream = "stream";

--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -48,6 +48,7 @@ import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -151,23 +152,27 @@ public class SynchronizerTest {
         @Override
         public Iterator<Entry<Revision, UpdateOrInit<RevisionedImpl>>> readRange(Revision startRevision, Revision endRevision) {
             return new Iterator<Entry<Revision, UpdateOrInit<RevisionedImpl>>>() {
-                private int pos = startRevision.asImpl().getEventAtOffset();
+                private int startPos = startRevision.asImpl().getEventAtOffset();
+                private int endPos = endRevision.asImpl().getEventAtOffset();
                 @Override
                 public Entry<Revision, UpdateOrInit<RevisionedImpl>> next() {
+                    if(!hasNext()) {
+                        throw new NoSuchElementException();
+                    }
                     UpdateOrInit<RevisionedImpl> value;
-                    RevisionImpl revision = new RevisionImpl(segment, pos, pos);
-                    if (pos == 0) {
+                    RevisionImpl revision = new RevisionImpl(segment, startPos, startPos);
+                    if (startPos == 0) {
                         value = new UpdateOrInit<>(init);
                     } else {
-                        value = new UpdateOrInit<>(Collections.singletonList(updates[pos - 1]));
+                        value = new UpdateOrInit<>(Collections.singletonList(updates[startPos - 1]));
                     }
-                    pos++;
+                    startPos++;
                     return new AbstractMap.SimpleImmutableEntry<>(revision, value);
                 }
 
                 @Override
                 public boolean hasNext() {
-                    return pos <= visableLength;
+                    return startPos <= endPos;
                 }
             };
         }

--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -149,6 +149,31 @@ public class SynchronizerTest {
         }
 
         @Override
+        public Iterator<Entry<Revision, UpdateOrInit<RevisionedImpl>>> readRange(Revision startRevision, Revision endRevision) {
+            return new Iterator<Entry<Revision, UpdateOrInit<RevisionedImpl>>>() {
+                private int pos = startRevision.asImpl().getEventAtOffset();
+                @Override
+                public Entry<Revision, UpdateOrInit<RevisionedImpl>> next() {
+                    UpdateOrInit<RevisionedImpl> value;
+                    RevisionImpl revision = new RevisionImpl(segment, pos, pos);
+                    if (pos == 0) {
+                        value = new UpdateOrInit<>(init);
+                    } else {
+                        value = new UpdateOrInit<>(Collections.singletonList(updates[pos - 1]));
+                    }
+                    pos++;
+                    return new AbstractMap.SimpleImmutableEntry<>(revision, value);
+                }
+
+                @Override
+                public boolean hasNext() {
+                    return pos <= visableLength;
+                }
+            };
+        }
+
+
+        @Override
         public Revision writeConditionally(Revision latestRevision, UpdateOrInit<RevisionedImpl> value) {
             throw new NotImplementedException("writeConditionally");
         }

--- a/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
+++ b/client/src/test/java/io/pravega/client/state/impl/SynchronizerTest.java
@@ -156,7 +156,7 @@ public class SynchronizerTest {
                 private int endPos = endRevision.asImpl().getEventAtOffset();
                 @Override
                 public Entry<Revision, UpdateOrInit<RevisionedImpl>> next() {
-                    if(!hasNext()) {
+                    if (!hasNext()) {
                         throw new NoSuchElementException();
                     }
                     UpdateOrInit<RevisionedImpl> value;

--- a/controller/src/test/java/io/pravega/controller/server/bucket/WatermarkWorkflowTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/WatermarkWorkflowTest.java
@@ -730,6 +730,15 @@ public class WatermarkWorkflowTest {
 
         @Override
         @Synchronized
+        public Iterator<Map.Entry<Revision, Watermark>> readRange(Revision start, Revision end) throws TruncatedDataException {
+            checkValid();
+            int startIndex = start.equals(MockRevision.EMPTY) ? 0 : ((MockRevision) start).id + 1;
+            int endIndex = end.equals(MockRevision.EMPTY) ? 0 : ((MockRevision) start).id;
+            return watermarks.subList(startIndex, endIndex).iterator();
+        }
+
+        @Override
+        @Synchronized
         public Revision writeConditionally(Revision latestRevision, Watermark value) {
             checkValid();
             Revision last = watermarks.isEmpty() ? MockRevision.EMPTY : watermarks.get(watermarks.size() - 1).getKey();


### PR DESCRIPTION
**Change log description**  
This PR introduces a new method that allows reading data between two specific revisions - a start revision and an end revision.

**Purpose of the change**  
Fixes #1886

**What the code does**  
Reads all data from  a given start revision to the end revision and also adds unit test for the newly added method.


**How to verify it**  
All test should pass

**Note :-**  This PR is related to this draft PR https://github.com/pravega/pravega/pull/6942. for more context please have a look to this.
