### PR TITLE
Issue 7009: Fix for Unsupported Operation exception in STF

### DIFF
--- a/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
+++ b/test/system/src/main/java/io/pravega/test/system/framework/services/kubernetes/K8SequentialExecutor.java
@@ -37,6 +37,8 @@ import io.pravega.test.system.framework.Utils;
 import io.pravega.test.system.framework.kubernetes.ClientFactory;
 import io.pravega.test.system.framework.kubernetes.K8sClient;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -145,8 +147,12 @@ public class K8SequentialExecutor implements TestExecutor {
                 ))
                 .restartPolicy("Never"));
         if (Utils.TLS_AND_AUTH_ENABLED) {
-            pod.getSpec().getVolumes().add(new V1Volume().name("tls-cert").secret(new V1SecretVolumeSource().secretName(Utils.TLS_SECRET_NAME)));
-            pod.getSpec().getContainers().get(0).addVolumeMountsItem(new V1VolumeMount().mountPath(Utils.TLS_MOUNT_PATH).name("tls-secret"));
+            List<V1Volume> volumes = new ArrayList<>(pod.getSpec().getVolumes());
+            volumes.add(new V1Volume().name("tls-cert").secret(new V1SecretVolumeSource().secretName(Utils.TLS_SECRET_NAME)));
+            pod.getSpec().setVolumes(volumes);
+            List<V1VolumeMount> volumeMounts = new ArrayList<>(pod.getSpec().getContainers().get(0).getVolumeMounts());
+            volumeMounts.add(new V1VolumeMount().mountPath(Utils.TLS_MOUNT_PATH).name("tls-cert"));
+            pod.getSpec().getContainers().get(0).setVolumeMounts(volumeMounts);
         }
         return pod;
     }


### PR DESCRIPTION
**Change log description**  
This PR adds a fix for Unsupported Operation exception seen in System Test Framework when TLS is enabled.


**Purpose of the change**  
Fixes #7009 

**What the code does**  
Instead of directly adding Volume and VolumeMount to the ImmutableList in PodSpec, we are first creating a List of Volumes `List<V1Volume> volumes` and List of VolumeMounts `List<V1VolumeMounts> volumeMounts` and then using `.setVolume(volumes)` and `.setVolumeMount(volumeMounts)` methods of podSpec.

**How to verify it**  

- QE tests didn't show any Unsupported Operation Exception after adding this piece of code.
- Currently dev side System tests (STF) doesn't have support for TLS. 
- Verified that Volume and VolumeMounts are getting created in the test pod.

```
    Mounts:
      /data from task-pv-storage (rw)
      /etc/secret-volume from tls-cert (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-v9kfq (ro)
Volumes:
  task-pv-storage:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  task-pv-claim
    ReadOnly:   false
  tls-cert:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  controller-tls
    Optional:    false
```
