### PR TITLE
Issue 1909: Closing ReaderGroupManager prevents checkpoints from making progress 

### DIFF
--- a/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
+++ b/client/src/main/java/io/pravega/client/admin/ReaderGroupManager.java
@@ -24,6 +24,7 @@ import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.ReaderGroupNotFoundException;
 import io.pravega.client.stream.Serializer;
+import io.pravega.common.ObjectClosedException;
 import lombok.val;
 
 import java.net.URI;
@@ -76,8 +77,9 @@ public interface ReaderGroupManager extends AutoCloseable {
      * @return True if ReaderGroup was created.
      * @throws ConfigMismatchException If the reader group already exists with a different configuration. Use {@link ReaderGroup#resetReaderGroup} to change
      * the reader group configuration.
+     * @throws ObjectClosedException If the ReaderGroupManager is closed and if reused the instance for further calls.
      */
-    boolean createReaderGroup(String groupName, ReaderGroupConfig config) throws ConfigMismatchException;
+    boolean createReaderGroup(String groupName, ReaderGroupConfig config) throws ConfigMismatchException, ObjectClosedException;
     
     /**
      * Deletes a reader group, removing any state associated with it. There should be no reader left
@@ -85,8 +87,9 @@ public interface ReaderGroupManager extends AutoCloseable {
      * them and they will encounter exceptions.
      * 
      * @param groupName The group to be deleted.
+     * @throws ObjectClosedException If the ReaderGroupManager is closed and if reused the instance for further calls.
      */
-    void deleteReaderGroup(String groupName);
+    void deleteReaderGroup(String groupName) throws ObjectClosedException;
     
     /**
      * Returns the requested reader group.
@@ -94,8 +97,9 @@ public interface ReaderGroupManager extends AutoCloseable {
      * @param groupName The name of the group
      * @return Reader group with the given name
      * @throws ReaderGroupNotFoundException If the reader group does not exist.
+     * @throws ObjectClosedException If the ReaderGroupManager is closed and if reused the instance for further calls.
      */
-    ReaderGroup getReaderGroup(String groupName) throws ReaderGroupNotFoundException;
+    ReaderGroup getReaderGroup(String groupName) throws ReaderGroupNotFoundException, ObjectClosedException;
     
     /**
      * Close this manager class. This will close any connections created through it.

--- a/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/endtoendtest/EndToEndReaderGroupTest.java
@@ -39,6 +39,7 @@ import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.ClientFactoryImpl;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.StreamCutImpl;
+import io.pravega.common.ObjectClosedException;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.controller.server.eventProcessor.LocalController;
 import io.pravega.test.common.InlineExecutor;
@@ -604,4 +605,44 @@ public class EndToEndReaderGroupTest extends AbstractEndToEndTest {
         writer.writeEvent( "0", Integer.toString(eventId)).join();
     }
 
+    @Test(timeout = 60000, expected = ObjectClosedException.class)
+    public void testRGManagerCallWhenExecutorisNotAvailable() throws Exception {
+        StreamConfiguration config = getStreamConfig();
+        LocalController controller = (LocalController) PRAVEGA.getLocalController();
+        String streamName = "testDeleteReaderGroup";
+        controller.createScope("test").get();
+        controller.createStream("test", streamName, config).get();
+        @Cleanup
+        ConnectionFactory connectionFactory = new SocketConnectionFactoryImpl(ClientConfig.builder()
+                .controllerURI(PRAVEGA.getControllerURI())
+                .build());
+        @Cleanup
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl("test", controller, connectionFactory);
+
+        @Cleanup
+        ReaderGroupManager groupManager = new ReaderGroupManagerImpl("test", controller, clientFactory);
+        // Create a ReaderGroup
+        String groupName = "testDeleteReaderGroup-group";
+        groupManager.createReaderGroup(groupName, ReaderGroupConfig.builder().disableAutomaticCheckpoints()
+                .stream("test/" + streamName).build());
+        // Create a Reader
+        EventStreamReader<String> reader = clientFactory.createReader("reader1", groupName, serializer, ReaderConfig.builder().build());
+
+        // Write events into the stream.
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(streamName, serializer, EventWriterConfig.builder().build());
+        writer.writeEvent("0", "data1").get();
+
+        EventRead<String> eventRead = reader.readNextEvent(10000);
+        assertEquals("data1", eventRead.getEvent());
+
+        // Close the reader, this internally invokes ReaderGroup#readerOffline
+        reader.close();
+
+        // close the ReaderGroupManager
+        groupManager.close();
+        
+        // try to get the readerGroup, this should throw an exception as we have added a check to verify if the executor is available.
+        groupManager.getReaderGroup(groupName);
+    }
 }


### PR DESCRIPTION
Change log description
This purpose of this change is to verify if we are trying to use the already closed instance of ReaderGroupManager, and to catch the problem early.

Purpose of the change
Fixes 1909

What the code does
Added a check to verify if we are trying to use the closed instance of ReaderGroupManager to make any further calls and throws the exception in such scenario.

How to verify it
All tests should pass

