### PR TITLE
Issue 7016: Reclaiming memory of channel object in FlowHandler

### DIFF
--- a/client/src/main/java/io/pravega/client/connection/impl/FlowHandler.java
+++ b/client/src/main/java/io/pravega/client/connection/impl/FlowHandler.java
@@ -223,6 +223,7 @@ public class FlowHandler extends FailingReplyProcessor implements AutoCloseable 
                 }
             });
             channel.close();
+            channel = null;
         }
     }
     


### PR DESCRIPTION
Change log description
In one of the issues raised against pravega it was seen that some 2400+ virtual connections were getting created and destroyed in a duration of 10 seconds.
And even after having too many readers there were failures observed in system. And could see OOM issues. we went through the call flow in Flowhandler and traced that assigning the channel object to null after closing will help reclaim all the unwanted memory and will also drastically reducing the memory. 

Purpose of the change
closes https://github.com/pravega/pravega/issues/7016

How to verify it
test should run fine