### PR TITLE
Issue 7017: Build time warnings present in build.gradle 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -298,7 +298,7 @@ project ('shared:metrics') {
         // https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-prometheus/<micrometerVersion>
         compile project(':common')
         compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion
-        runtime group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jerseyVersion
+        runtimeOnly group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jerseyVersion
         compile group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         testCompile project(':test:testcommon')
         testCompile group: 'javax.xml.bind', name: 'jaxb-api', version: jaxbVersion
@@ -973,7 +973,7 @@ project('standalone') {
     }
 
     dependencies {
-        runtime group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
+        runtimeOnly group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
 
         compile project(':common')
         compile project(':client')
@@ -1045,7 +1045,7 @@ project('test:system') {
 
     dependencies {
         // https://mvnrepository.com/artifact/com.mesosphere/marathon-client
-        runtime group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
+        runtimeOnly group: 'ch.qos.logback', name: 'logback-classic', version: qosLogbackVersion
         compile group: 'com.mesosphere', name: 'marathon-client', version: marathonClientVersion, withoutLogger
         if (System.getProperty("customClient") != null) {
             implementation fileTree(System.getProperty("customClient")) { include '*.jar' }
@@ -1061,8 +1061,8 @@ project('test:system') {
         compile group: 'com.spotify', name: 'docker-client', version: dockerClientVersion
         compile group: 'io.kubernetes', name: 'client-java', version: k8ClientVersion
         compile group: 'org.apache.curator', name: 'curator-framework', version: apacheCuratorVersion
-        runtime group: 'org.apache.curator', name: 'curator-framework', version: apacheCuratorVersion
-        runtime group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jerseyVersion
+        runtimeOnly group: 'org.apache.curator', name: 'curator-framework', version: apacheCuratorVersion
+        runtimeOnly group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jerseyVersion
     }
     //disable the default test task.
     test {
@@ -1070,9 +1070,9 @@ project('test:system') {
     }
 
     jar { //create a fat jar
-        archiveName = "test-collection.jar"
+        archiveFileName = "test-collection.jar"
         from {
-            (configurations.runtime).collect {
+            (configurations.runtimeClasspath).collect {
                 it.isDirectory() ? it : zipTree(it)
             }
         }
@@ -1081,7 +1081,7 @@ project('test:system') {
     }
 
     task testJarForDocker(type: Jar) {
-        archiveName = "test-docker-collection.jar"
+        archiveFileName = "test-docker-collection.jar"
         from {
             (configurations.runtime).collect {
                 it.isDirectory() ? it : zipTree(it)
@@ -1444,8 +1444,8 @@ task sourceCopy(type: Copy) {
 task sourceTar(type: Tar) {
     dependsOn 'sourceCopy'
     from  'source'
-    destinationDir = file('sourceArtifacts')
-    extension = 'tgz'
+    destinationDirectory = file('sourceArtifacts')
+    archiveExtension = 'tgz'
     compression = Compression.GZIP
 }
 
@@ -1472,7 +1472,7 @@ task javadocs(type: Javadoc) {
 apply plugin: 'distribution'
 distributions {
     main {
-        baseName = "pravega"
+        distributionBaseName = "pravega"
         contents {
             duplicatesStrategy = "exclude"
             from ("dist/conf") {
@@ -1495,7 +1495,7 @@ distributions {
         }
     }
     client {
-        baseName = "pravega-client"
+        distributionBaseName = "pravega-client"
         contents {
             from { project(":shared:authplugin").configurations.runtime }
             from { project(":shared:authplugin").configurations.runtime.allArtifacts.files }
@@ -1506,7 +1506,7 @@ distributions {
         }
     }
     javadoc {
-        baseName = "pravega-javadoc"
+        distributionBaseName = "pravega-javadoc"
         contents {
             from (javadocs)
             from 'LICENSE'


### PR DESCRIPTION
**Change log description**
Handling Build time warnings which were caused due to the usage of deprecated properties and configurations in build.gradle.

**Purpose of the change**
Fixes #7017  

**What the code does**
There were 13 warnings from build.gradle and were handled by
Changing Runtime configuration to RuntimeOnly.
Changing AbstractArchiveTask.archiveName property to archieveFileName.
Changing AbstractArchiveTask.destinationDir property to destinationDirectory.
Changing AbstractArchiveTask.extension property to archieveExtension.
Changing Distribution.baseName property to distributionBaseName.
Changing runtime configuration to runtimeClasspath.

**How to verify it**
There should be no build time warnings from build.gradle