### PR TITLE
Issue 7023 remove canceled task from queue

### DIFF
--- a/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
@@ -177,7 +177,7 @@ public class ThreadPoolScheduledExecutorService extends AbstractExecutorService 
             this.scheduledTimeNanos = unit.toNanos(delay) + System.nanoTime();
             this.task = task;
             this.future = new CompletableFuture<R>();
-            if(task instanceof ScheduleLoop){
+            if (task instanceof ScheduleLoop) {
                 ScheduleLoop loop = (ScheduleLoop) task;
                 loop.currentTask.set(this);
             }

--- a/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
@@ -177,6 +177,11 @@ public class ThreadPoolScheduledExecutorService extends AbstractExecutorService 
             this.scheduledTimeNanos = unit.toNanos(delay) + System.nanoTime();
             this.task = task;
             this.future = new CompletableFuture<R>();
+            if(task instanceof ScheduleLoop){
+                 // keep the reference of the first scheduled task
+                ScheduleLoop loop = (ScheduleLoop) task;
+                loop.currentTask.set(this);
+            }
         }
         
         private ScheduledRunnable(Callable<R> task, long scheduledTimeNanos) {
@@ -279,7 +284,7 @@ public class ThreadPoolScheduledExecutorService extends AbstractExecutorService 
         final AtomicBoolean canceled = new AtomicBoolean(false);
         final CompletableFuture<Void> shutdownFuture = new CompletableFuture<>();
         final AtomicReference<ScheduledFuture<Void>> scheduledFuture = new AtomicReference<ScheduledFuture<Void>>();
-
+        final AtomicReference<ScheduledRunnable<?>> currentTask = new AtomicReference<>();
         @Override
         public Void call() {
             if (!canceled.get()) {
@@ -319,6 +324,10 @@ public class ThreadPoolScheduledExecutorService extends AbstractExecutorService 
         public boolean cancel(boolean mayInterruptIfRunning) {
             if (canceled.getAndSet(true)) {
                 return false;
+            }
+            ScheduledRunnable<?> task = this.currentTask.get();
+            if (task != null) {
+                ThreadPoolScheduledExecutorService.this.cancel(task);
             }
             ScheduledFuture<Void> future = scheduledFuture.get();
             if (future != null) {

--- a/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
+++ b/common/src/main/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorService.java
@@ -178,7 +178,6 @@ public class ThreadPoolScheduledExecutorService extends AbstractExecutorService 
             this.task = task;
             this.future = new CompletableFuture<R>();
             if(task instanceof ScheduleLoop){
-                 // keep the reference of the first scheduled task
                 ScheduleLoop loop = (ScheduleLoop) task;
                 loop.currentTask.set(this);
             }

--- a/common/src/test/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorServiceTest.java
+++ b/common/src/test/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorServiceTest.java
@@ -253,8 +253,6 @@ public class ThreadPoolScheduledExecutorServiceTest {
     public void testCancelRecurringWithInitialDelay() throws Exception {
         ThreadPoolScheduledExecutorService pool = createPool(1);
         AtomicInteger count = new AtomicInteger(0);
-        AtomicReference<Exception> error = new AtomicReference<>();
-        // schedule a loop task with big initial delay
         ScheduledFuture<?> future = pool.scheduleAtFixedRate(() -> {
             count.incrementAndGet();
         }, 10, 2, SECONDS);

--- a/common/src/test/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorServiceTest.java
+++ b/common/src/test/java/io/pravega/common/concurrent/ThreadPoolScheduledExecutorServiceTest.java
@@ -248,6 +248,27 @@ public class ThreadPoolScheduledExecutorServiceTest {
         assertTrue(pool.shutdownNow().isEmpty());
         assertTrue(pool.awaitTermination(1, SECONDS));
     }
+
+    @Test(timeout = 10000)
+    public void testCancelRecurringWithInitialDelay() throws Exception {
+        ThreadPoolScheduledExecutorService pool = createPool(1);
+        AtomicInteger count = new AtomicInteger(0);
+        AtomicReference<Exception> error = new AtomicReference<>();
+        // schedule a loop task with big initial delay
+        ScheduledFuture<?> future = pool.scheduleAtFixedRate(() -> {
+            count.incrementAndGet();
+        }, 10, 2, SECONDS);
+        assertFalse(future.isCancelled());
+        assertFalse(future.isDone());
+        assertTrue(future.cancel(false));
+        AssertExtensions.assertThrows(CancellationException.class, () -> future.get());
+        assertTrue(future.isCancelled());
+        assertTrue(future.isDone());
+        assertEquals(0, count.get());
+        assertTrue(pool.getQueue().isEmpty());
+        assertTrue(pool.shutdownNow().isEmpty());
+        assertTrue(pool.awaitTermination(1, SECONDS));
+    }
     
     @Test(timeout = 10000)
     public void testShutdownWithRecurring() throws Exception {


### PR DESCRIPTION
**Change log description**  
keep the current scheduled task reference in ScheduleLoop, so that it can be canceled and removed from the delayed queue in cancellation before the first task being fired. In some cases, a lot of FixedRateTasks are created in shot time (2000+ within 10s), if the first tasks are accumulated in the delayed queue, it could cause memory pressue and lead to OOM before they are released after the initial delay (e.g. 20s)

**Purpose of the change**  
Fixes https://github.com/pravega/pravega/issues/7023

**What the code does**  
Keep a reference of the first task scheduled and remove it if cancel is called on the ScheduleLoop

**How to verify it**  
Restart pravega pods until it triggers alot of client connection drops, and do heap dump to see if many keepAliveTask remain the heap with canceled flag to true. WIth this fix, there should be none or few these kind of tasks.
