### PR TITLE
Issue 7042: Fix DataCorruptionException due to race condition in Cache

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -52,6 +52,7 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
@@ -74,6 +75,7 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
     @GuardedBy("lock")
     private final SortedIndex<ReadIndexEntry> indexEntries;
     private final ReadIndexConfig config;
+    @GuardedBy("lock")
     private final CacheStorage cacheStorage;
     private final FutureReadResultEntryCollection futureReads;
     @GuardedBy("lock")
@@ -585,7 +587,9 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
         }
 
         // Add append data to the Data Store.
-        appendLength = this.cacheStorage.append(entry.getCacheAddress(), (int) entry.getLength(), data);
+        synchronized (this.lock) {
+            appendLength = this.cacheStorage.append(entry.getCacheAddress(), (int) entry.getLength(), data);
+        }
         entry.increaseLength(appendLength);
         entry.setGeneration(this.summary.touchOne(entry.getGeneration()));
         return appendLength;
@@ -617,7 +621,10 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
      * @return A {@link CacheIndexEntry} representing the index entry added.
      */
     private CacheIndexEntry appendSingleEntryToCacheAndIndex(BufferView data, long segmentOffset) {
-        int dataAddress = this.cacheStorage.insert(data);
+        int dataAddress;
+        synchronized (this.lock) {
+            dataAddress = this.cacheStorage.insert(data);
+        }
         CacheIndexEntry newEntry;
         try {
             newEntry = new CacheIndexEntry(segmentOffset, data.getLength(), dataAddress);
@@ -628,8 +635,10 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
             }
         } catch (Throwable ex) {
             if (!Exceptions.mustRethrow(ex)) {
-                // Clean up the data we inserted if we were unable to add it to the index.
-                this.cacheStorage.delete(dataAddress);
+                synchronized (this.lock) {
+                    // Clean up the data we inserted if we were unable to add it to the index.
+                    this.cacheStorage.delete(dataAddress);
+                }
             }
             throw ex;
         }
@@ -668,14 +677,18 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
                     CacheIndexEntry newEntry;
                     int dataAddress = CacheStorage.NO_ADDRESS; // Null address pointer.
                     try {
-                        dataAddress = this.cacheStorage.insert(dataToInsert);
+                        synchronized (this.lock) {
+                            dataAddress = this.cacheStorage.insert(dataToInsert);
+                        }
                         newEntry = new CacheIndexEntry(segmentOffset, dataToInsert.getLength(), dataAddress);
                         ReadIndexEntry overriddenEntry = addToIndex(newEntry);
                         assert overriddenEntry == null : "Insert overrode existing entry; " + segmentOffset + ":" + dataToInsert.getLength();
                         lastInsertedEntry = newEntry;
                     } catch (Throwable ex) {
-                        // Clean up the data we might have inserted if we were unable to add it to the index.
-                        this.cacheStorage.delete(dataAddress);
+                        synchronized (this.lock) {
+                            // Clean up the data we might have inserted if we were unable to add it to the index.
+                            this.cacheStorage.delete(dataAddress);
+                        }
                         throw ex;
                     }
                 }
@@ -1330,7 +1343,9 @@ class StreamSegmentReadIndex implements CacheManager.Client, AutoCloseable {
 
     private void deleteData(ReadIndexEntry entry) {
         if (entry.isDataEntry()) {
-            this.cacheStorage.delete(entry.getCacheAddress());
+            synchronized (this.lock) {
+                this.cacheStorage.delete(entry.getCacheAddress());
+            }
         }
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/reading/StreamSegmentReadIndex.java
@@ -52,7 +52,6 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 


### PR DESCRIPTION
**Change log description**  
The changes are to put a synchronization block in the `StreamSegmentReadIndex` for `cacheStorage`. This needs to be done for every update, write, append operations.

**Purpose of the change**  
Fixes #7042 
Fixes #6785

**What the code does**  
Inside of `StreamSegmentReadIndex` it is attempting to do some sophisticated synchronization which is critical to get right to prevent this sort of error. In particular the `cacheStorage` member is accessed both inside and outside of a lock. In order to do this, it is using some double checked operations so as to not always hold a lock when accessing the data-structure. In particular when `addToCacheAndIndex` is invoked there could be a concurrent `insertEntriesToCacheAndIndex` and the append which is calling it. There will be some race between the two. The subsequent apply which invokes `appendSingleEntryToCacheAndIndex` to do the actual insert and update of the index entries.
In order to prevent this, the lock should be added to every update operations to this data structure.

**How to verify it**  
All existing test cases should pass
`DataCorruptionException` should not occur
