### PR TITLE
Issue 5555: Consumption based retention with multiple controllers and controller and segment store failover

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -88,7 +88,6 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
     private static final String READER_GROUP_3 = "testCBR1ReaderGroup1" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String READER_GROUP_4 = "timeBasedRetentionReaderGroup" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String SIZE_30_EVENT = "data of size 30";
-    private static Random RANDOM = RandomFactory.create();
     private static final long CLOCK_ADVANCE_INTERVAL = 5 * 1000000000L;
 
     private static final int READ_TIMEOUT = 1000;
@@ -413,9 +412,10 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
 
     @Test
     public void multipleControllerFailoverAndRestartCBRTest() throws Exception {
-        String scope = "testCBR2Scope" + RANDOM.nextInt(Integer.MAX_VALUE);
-        String stream = "multiControllerStream" + RANDOM.nextInt(Integer.MAX_VALUE);
-        String readerGroupName = "testmultiControllerReaderGroup" + RANDOM.nextInt(Integer.MAX_VALUE);
+        Random random = RandomFactory.create();
+        String scope = "testCBR2Scope" + random.nextInt(Integer.MAX_VALUE);
+        String stream = "multiControllerStream" + random.nextInt(Integer.MAX_VALUE);
+        String readerGroupName = "testmultiControllerReaderGroup" + random.nextInt(Integer.MAX_VALUE);
         // scale to three controller instances.
         scaleAndUpdateControllerURI(3);
         // scale to two segment store instances.

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -61,6 +61,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -87,6 +88,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
     private static final String READER_GROUP_3 = "testCBR1ReaderGroup1" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String READER_GROUP_4 = "timeBasedRetentionReaderGroup" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String SIZE_30_EVENT = "data of size 30";
+    private static Random RANDOM = RandomFactory.create();
     private static final long CLOCK_ADVANCE_INTERVAL = 5 * 1000000000L;
 
     private static final int READ_TIMEOUT = 1000;
@@ -411,9 +413,9 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
 
     @Test
     public void multipleControllerFailoverAndRestartCBRTest() throws Exception {
-        String scope = "testCBR2Scope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
-        String stream = "multiControllerStream" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
-        String readerGroupName = "testmultiControllerReaderGroup" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
+        String scope = "testCBR2Scope" + RANDOM.nextInt(Integer.MAX_VALUE);
+        String stream = "multiControllerStream" + RANDOM.nextInt(Integer.MAX_VALUE);
+        String readerGroupName = "testmultiControllerReaderGroup" + RANDOM.nextInt(Integer.MAX_VALUE);
         // scale to three controller instances.
         scaleAndUpdateControllerURI(3);
         // scale to two segment store instances.

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -65,7 +65,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -496,7 +496,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
         @Cleanup
         EventStreamWriter<String> writer = clientFactory.createEventWriter(stream, new JavaSerializer<>(),
                 EventWriterConfig.builder().build());
-        // Write six event.
+        // Write six events.
         writingEventsToStream(6, writer, scope, stream);
         @Cleanup
         ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(scope, clientConfig);
@@ -511,7 +511,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
         @Cleanup
         EventStreamReader<String> reader = clientFactory.createReader(readerGroupNmae + "-" + 1,
                 readerGroupNmae, new JavaSerializer<>(), readerConfig, clock::get, clock::get);
-        // Read two event with reader.
+        // Read two events with reader.
         readingEventsFromStream(2, reader);
 
         log.info("{} generating 1st stream-cuts for {}/{}", readerGroupNmae, scope, stream);

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -459,10 +459,8 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
                         new StreamImpl(SCOPE_2, STREAM_3), 0L).join().values().stream().anyMatch(off -> off == 30),
                 5000, 2 * 60 * 1000L);
 
-        // Read next event.
-        readingEventsFromStream(1, reader);
-
-        log.info("{} generating 1st stream-cuts for {}/{}", READER_GROUP_1, SCOPE_2, STREAM_3);
+        log.info("{} generating 2nd stream-cuts for {}/{}", READER_GROUP_1, SCOPE_2, STREAM_3);
+        // Reader has already read next event during previous generateStreamCuts method call
         streamCuts = generateStreamCuts(readerGroup, reader, clock);
 
         log.info("{} updating its retention stream-cut to {}", READER_GROUP_1, streamCuts);

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -446,7 +446,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
         readingEventsFromStream(1, reader);
 
         CompletableFuture<Checkpoint> checkpoint = initiateCheckPoint("Checkpoint", readerGroup, reader, clock);
-        EventRead<String> read = reader.readNextEvent(60000);
+        EventRead<String> read = reader.readNextEvent(READ_TIMEOUT);
         log.info("Reading next event after checkpoint {}", read.getEvent());
         Checkpoint cpResult = checkpoint.join();
         assertTrue(checkpoint.isDone());
@@ -464,7 +464,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
                 5000, 2 * 60 * 1000L);
 
         checkpoint = initiateCheckPoint("Checkpoint2", readerGroup, reader, clock);
-        read = reader.readNextEvent(60000);
+        read = reader.readNextEvent(READ_TIMEOUT);
         log.info("Reading next event after checkpoint {}", read.getEvent());
         cpResult = checkpoint.join();
         assertTrue(checkpoint.isDone());
@@ -580,7 +580,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
             CompletableFuture<Checkpoint> checkpoint = readerGroup.initiateCheckpoint(checkPointName, executor);
             clock.addAndGet(CLOCK_ADVANCE_INTERVAL);
             assertFalse(checkpoint.isDone());
-            EventRead<String> read = reader.readNextEvent(60000);
+            EventRead<String> read = reader.readNextEvent(READ_TIMEOUT);
             assertTrue(read.isCheckpoint());
             assertEquals(checkPointName, read.getCheckpointName());
             assertNull(read.getEvent());

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -465,9 +465,9 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
 
         // Validating the failover scenario - Start
         log.info("Controller and segment store failover scenario started");
-        // Write six events.
+        // Write three events.
         writingEventsToStream(3, writer, scope, stream);
-        // Read two events with reader.
+        // Read one event with reader.
         readingEventsFromStream(1, reader);
 
         checkpoint = initiateCheckPoint("Checkpoint3", readerGroup, reader, clock);

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -505,14 +505,14 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
         clientFactory.close();
         connectionFactory.close();
         Futures.getAndHandleExceptions(controllerService.scaleService(0), ExecutionException::new);
-        log.info("Ankur Successfully stopped 1 instance of controller service");
+        log.info("Successfully stopped 1 instance of controller service");
         Futures.getAndHandleExceptions(segmentStoreService.scaleService(0), ExecutionException::new);
-        log.info("Ankur Successfully stopped 1 instance of segment store service");
+        log.info("Successfully stopped 1 instance of segment store service");
 
         Futures.getAndHandleExceptions(segmentStoreService.scaleService(1), ExecutionException::new);
-        log.info("Ankur Successfully started 1 instance of segment store service");
+        log.info("Successfully started 1 instance of segment store service");
         scaleAndUpdateControllerURI(1);
-        log.info("Ankur Successfully started 1 instance of controller service");
+        log.info("Successfully started 1 instance of controller service");
 
         // Retention set has two stream cut at 0/150...0/240
         // READER_GROUP_1 updated stream cut at 0/120

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -521,7 +521,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
 
         //Controller Failover
         scaleAndUpdateControllerURI(1);
-        log.info("Successfully scaled down segment store to 1 instance");
+        log.info("Successfully scaled down controller to 1 instance");
         //SegmentStore Failover
         Futures.getAndHandleExceptions(segmentStoreService.scaleService(1), ExecutionException::new);
         log.info("Successfully scaled down segment store to 1 instance");

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -153,7 +153,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
     }
 
     @After
-    public void tearDown() throws ExecutionException{
+    public void tearDown() throws ExecutionException {
         streamManager.close();
         controller.close();
         ExecutorServiceHelpers.shutdown(executor);
@@ -471,7 +471,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
 
         // Retention set has one stream cut at 0/150
         // READER_GROUP_1 updated stream cut at 0/60
-        // Subscriber lower bound is 0/30, truncation should happen at this point
+        // Subscriber lower bound is 0/60, truncation should happen at this point
         // The timeout is set to 2 minutes a little longer than the retention period which is set to 1 minutes
         // in order to confirm that the retention has taken place.
         AssertExtensions.assertEventuallyEquals("Truncation did not take place at offset 60.", true, () -> controller.getSegmentsAtTime(

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -452,8 +452,8 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
         // Subscriber lower bound is 0/120, truncation should happen at this point
         // The timeout is set to 2 minutes a little longer than the retention period which is set to 1 minutes
         // in order to confirm that the retention has taken place.
-        AssertExtensions.assertEventuallyEquals("Truncation did not take place at offset 90.", true, () -> controller.getSegmentsAtTime(
-                        new StreamImpl(SCOPE_1, STREAM_1), 0L).join().values().stream().anyMatch(off -> off == 120),
+        AssertExtensions.assertEventuallyEquals("Truncation did not take place at offset 120.", true, () -> controller.getSegmentsAtTime(
+                        new StreamImpl(SCOPE_2, STREAM_3), 0L).join().values().stream().anyMatch(off -> off == 120),
                 5000, 2 * 60 * 1000L);
     }
 

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -80,14 +80,17 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
     private static final String SCOPE = "testConsumptionBasedRetentionScope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String SCOPE_1 = "testCBR1Scope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String SCOPE_2 = "testCBR2Scope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
+    private static final String SCOPE_3 = "testCBR3Scope" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String STREAM = "testConsumptionBasedRetentionStream" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String STREAM_1 = "testCBR1Stream" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String STREAM_2 = "timeBasedRetentionStream" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String STREAM_3 = "multiControllerStream" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
+    private static final String STREAM_4 = "testControllerFailOverStream" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String READER_GROUP_1 = "testConsumptionBasedRetentionReaderGroup1" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String READER_GROUP_2 = "testConsumptionBasedRetentionReaderGroup2" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String READER_GROUP_3 = "testCBR1ReaderGroup1" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String READER_GROUP_4 = "timeBasedRetentionReaderGroup" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
+    private static final String READER_GROUP_5 = "testControllerFailOverReaderGroup" + RandomFactory.create().nextInt(Integer.MAX_VALUE);
     private static final String SIZE_30_EVENT = "data of size 30";
     private static final long CLOCK_ADVANCE_INTERVAL = 5 * 1000000000L;
 
@@ -112,6 +115,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
     private Controller controller = null;
     private ClientConfig clientConfig;
     private Service controllerService = null;
+    private Service segmentStoreService = null;
 
     /**
      * This is used to setup the various services required by the system test framework.
@@ -127,16 +131,25 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
 
     @Before
     public void setup() {
-        controllerService = Utils.createPravegaControllerService(null);
-        List<URI> controllerURIs = controllerService.getServiceDetails();
-        controllerURI = controllerURIs.get(0);
-
+        Service zkService = Utils.createZookeeperService();
+        assertTrue(zkService.isRunning());
+        List<URI> zkUris = zkService.getServiceDetails();
+        log.info("zookeeper service details: {}", zkUris);
+        controllerService = Utils.createPravegaControllerService(zkUris.get(0));
+        if (!controllerService.isRunning()) {
+            controllerService.start(true);
+        }
+        List<URI> controllerUris = controllerService.getServiceDetails();
+        // Fetch all the RPC endpoints and construct the client URIs.
+        List<String> uris = controllerUris.stream().filter(ISGRPC).map(URI::getAuthority).collect(Collectors.toList());
+        controllerURI = URI.create(TCP + String.join(",", uris));
         clientConfig = Utils.buildClientConfig(controllerURI);
-
         controller = new ControllerImpl(ControllerImplConfig.builder()
                 .clientConfig(clientConfig)
                 .maxBackoffMillis(5000).build(), executor);
         streamManager = StreamManager.create(clientConfig);
+
+        segmentStoreService = Utils.createPravegaSegmentStoreService(zkUris.get(0), controllerURI);
     }
 
     @After
@@ -405,7 +418,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
         Futures.getAndHandleExceptions(controllerService.scaleService(3), ExecutionException::new);
         List<URI> controllerUris = controllerService.getServiceDetails();
         log.info("Pravega Controller service  details: {}", controllerUris);
-        final List<String> uris = controllerUris.stream().filter(ISGRPC).map(URI::getAuthority).collect(Collectors.toList());
+          final List<String> uris = controllerUris.stream().filter(ISGRPC).map(URI::getAuthority).collect(Collectors.toList());
         assertEquals("3 controller instances should be running", 3, uris.size());
         // use the last three uris
         controllerURI = URI.create("tcp://" + String.join(",", uris));
@@ -473,6 +486,82 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
         AssertExtensions.assertEventuallyEquals("Truncation did not take place at offset 60.", true, () -> controller.getSegmentsAtTime(
                         new StreamImpl(SCOPE_2, STREAM_3), 0L).join().values().stream().anyMatch(off -> off == 60),
                 5000, 2 * 60 * 1000L);
+    }
+
+    @Test
+    public void testCBRwithControllerAndSegmentStoreFailover() throws Exception {
+
+        Futures.getAndHandleExceptions(controllerService.scaleService(3), ExecutionException::new);
+        List<URI> controllerUris = controllerService.getServiceDetails();
+        log.info("Pravega Controller service  details: {}", controllerUris);
+        List<String> uris = controllerUris.stream().filter(ISGRPC).map(URI::getAuthority).collect(Collectors.toList());
+        assertEquals("3 controller instances should be running", 3, uris.size());
+        // use the last three uris
+        controllerURI = URI.create(TCP + String.join(",", uris));
+        clientConfig = Utils.buildClientConfig(controllerURI);
+        controller = new ControllerImpl(ControllerImplConfig.builder()
+                .clientConfig(clientConfig)
+                .maxBackoffMillis(5000).build(), executor);
+        streamManager = StreamManager.create(clientConfig);
+
+        Futures.getAndHandleExceptions(segmentStoreService.scaleService(2), ExecutionException::new);
+        log.info("Successfully stopped instance of segment store service");
+
+        assertTrue("Creating scope", streamManager.createScope(SCOPE_3));
+        assertTrue("Creating stream", streamManager.createStream(SCOPE_3, STREAM_4, STREAM_CONFIGURATION));
+        @Cleanup
+        ConnectionFactory connectionFactory = new SocketConnectionFactoryImpl(ClientConfig.builder().build());
+        @Cleanup
+        ClientFactoryImpl clientFactory = new ClientFactoryImpl(SCOPE_3, controller, connectionFactory);
+        @Cleanup
+        EventStreamWriter<String> writer = clientFactory.createEventWriter(STREAM_4, new JavaSerializer<>(),
+                EventWriterConfig.builder().build());
+        // Write six event.
+        writingEventsToStream(6, writer, SCOPE_3, STREAM_4);
+        @Cleanup
+        ReaderGroupManager readerGroupManager = ReaderGroupManager.withScope(SCOPE_3, clientConfig);
+        ReaderGroupConfig readerGroupConfig = getReaderGroupConfig(SCOPE_3, STREAM_4, ReaderGroupConfig.StreamDataRetention.MANUAL_RELEASE_AT_USER_STREAMCUT);
+
+        assertTrue("Reader group is not created", readerGroupManager.createReaderGroup(READER_GROUP_5, readerGroupConfig));
+        assertEquals(1, controller.listSubscribers(SCOPE_3, STREAM_4).join().size());
+
+        @Cleanup
+        ReaderGroup readerGroup = readerGroupManager.getReaderGroup(READER_GROUP_5);
+        AtomicLong clock = new AtomicLong();
+        @Cleanup
+        EventStreamReader<String> reader = clientFactory.createReader(READER_GROUP_5 + "-" + 1,
+                READER_GROUP_5, new JavaSerializer<>(), readerConfig, clock::get, clock::get);
+        // Read two event with reader.
+        readingEventsFromStream(2, reader);
+
+        log.info("{} generating 1st stream-cuts for {}/{}", READER_GROUP_5, SCOPE_3, STREAM_4);
+        Map<Stream, StreamCut> streamCuts = generateStreamCuts(readerGroup, reader, clock);
+
+        log.info("{} updating its retention stream-cut to {}", READER_GROUP_5, streamCuts);
+        readerGroup.updateRetentionStreamCut(streamCuts);
+
+        Futures.getAndHandleExceptions(controllerService.scaleService(1), ExecutionException::new);
+        log.info("Successfully scaled down controller instance to 1");
+        Futures.getAndHandleExceptions(segmentStoreService.scaleService(1), ExecutionException::new);
+        log.info("Successfully scaled down segment store to 1 instance");
+
+        controllerUris = controllerService.getServiceDetails();
+        uris = controllerUris.stream().filter(ISGRPC).map(URI::getAuthority).collect(Collectors.toList());
+        log.info("Pravega filtered Controller uris: {}", uris);
+        assertEquals("1 controller instances should be running", 1, uris.size());
+
+
+        controllerURI = URI.create(TCP + String.join(",", uris));
+        ClientConfig clientConf = Utils.buildClientConfig(controllerURI);
+        @Cleanup
+        final Controller controller2 = new ControllerImpl(
+                ControllerImplConfig.builder()
+                        .clientConfig(clientConf)
+                        .build(), executor);
+
+        AssertExtensions.assertEventuallyEquals("Truncation did not take place at offset 60.", true, () -> controller2.getSegmentsAtTime(
+                        new StreamImpl(SCOPE_3, STREAM_4), 0L).join().values().stream().anyMatch(off -> off == 60),
+                5000,  2 * 60 * 1000L);
     }
 
 


### PR DESCRIPTION
**Change log description**  
- Testing Consumption Based Retention with Multiple Controllers
- Testing Consumption Based Retention with Controller and Segment Store Failover

**Purpose of the change**  
closes #5555
closes #5556

**What the code does**  
- The test case "multipleControllerFailoverAndRestartCBRTest" verifies the consumption based retention with multiple instances of controller. Three instances of controller are deployed. Stream S is created with fixed segment =1, min = 90 and max = 180. One reader group(subscribers) with AUTOMATIC_RELEASE_AT_LAST_CHECKPOINT is created. Stream 'S' is filled with 3 events. Subscriber 1 initiates checkpoint at 0/30(SLB) and stream is again filled with 2 more events. Retention Set has one stream cut at 0/150. Subscriber Lower Bound (SLB) is 0/30 which leaves more data in the stream than min and less data than max. So, truncation should happen at this stream cut i.e. 0/30. 
- Now Stream S is filled with 3 more events and Subscriber 1 initiates checkpoint at 0/90(SLB). 2 instances of controller and 1 instance of segment store fails. For next retention cycle ,Retention Set has two stream cut at 0/150...0/240. truncation should happen at the SLB ie, 0/90 which satisfies min and max criteria. 
- Again Subscriber 1 initiates checkpoint at 0/120(SLB). Both controller and segmentstore have been restarted. For next retention cycle ,Retention Set has two stream cut at 0/150...0/240. truncation should happen at the SLB ie, 0/120 which satisfies min and max criteria. 

**How to verify it**  
(Optional: steps to verify that the changes are effective)
