### PR TITLE
Issue 5557: cbr with stream scaling

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -528,6 +528,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
                 5000,  2 * 60 * 1000L);
         log.info("Test Executed successfully");
     }
+
     @Test
     public void streamScalingCBRTest() throws Exception {
         Random random = RandomFactory.create();
@@ -600,7 +601,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
         // Read two events with reader.
         readingEventsFromStream(2, reader);
         //Stream scaling down
-        status =controller.scaleStream(stream, Arrays.asList(NameUtils.computeSegmentId(1, 1), NameUtils.computeSegmentId(2, 1)),
+        status = controller.scaleStream(stream, Arrays.asList(NameUtils.computeSegmentId(1, 1), NameUtils.computeSegmentId(2, 1)),
                 Collections.singletonMap(0.0, 1.0), executor).getFuture().get();
         assertTrue(status);
 

--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -411,6 +411,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
                 new StreamImpl(SCOPE_1, STREAM_2), 0L).join().values().stream().anyMatch(off -> off == 390));
     }
 
+    @Test
     public void streamScalingCBRTest() throws Exception {
         String scope = "streamScalingCBRScope" + random.nextInt(Integer.MAX_VALUE);
         String streamName = "streamScalingCBRStream" + random.nextInt(Integer.MAX_VALUE);


### PR DESCRIPTION
**Change log description**  
Consumption Based Retention with Stream Scaling system test

**Purpose of the change**  
closes #5557 

**What the code does**  
The test "streamScalingCBRTest" verifies the consumption based retention with stream scaling. Stream S is created with initially 1 segment and with size retention policy defined as min= 90 and max =180. One subscriber with MANUAL_RELEASE_AT_USER_STREAMCUT is created. Stream S is filled with 2 events of same size (30) and the subscriber reads the 2 events. After that stream scale api is called to scale up the stream with two segments. And then 7 more events are filled to the stream. Subscriber reads 3 more events from the stream and generates a stream cut at this point (150) . Retention set has one stream cut at 270. Since truncating at the SLB leaves the stream with 120 bytes which satisfies the min and max criteria. So truncation should happen at this stream cut. After truncation, In the assertion we are verifying the entryset of the map containing segment and its offset, from the generated stream cut should be equal to entryset of the map containing segment and its offset at the head of the stream. 
After that subscriber reads 3 more events from the stream. Now the stream scale api is called to scale down the stream to 1 segment. Stream is again filled with 3 more events. Subscriber generates the second stream cut at 240. Retention set has two stream cut at 270 and 360. Truncation should happen at SLB. After truncation, In the assertion we are verifying the entryset of the map containing segment and its offset, from the generated stream cut should be equal to entryset of the map containing segment and its offset at the head of the stream. 

**How to verify it**  
(Optional: steps to verify that the changes are effective)
