### PR TITLE
Issue 7043: Fix LST recovery with stoage flush

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/dataRecovery/RecoverFromStorageCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/dataRecovery/RecoverFromStorageCommand.java
@@ -485,20 +485,6 @@ public class RecoverFromStorageCommand extends DataRecoveryCommand {
         tableExtension.put(NameUtils.getMetadataSegmentName(container.getId()), Collections.singletonList(unversionedEntry), TIMEOUT).join();
     }
 
-    /**
-     *  Resets the Storage segment
-     */
-    private MetadataStore.SegmentInfo resetStorageSegment(MetadataStore.SegmentInfo segmentInfo) {
-        StreamSegmentInformation segmentInformation = StreamSegmentInformation.builder()
-                .name(segmentInfo.getProperties().getName())
-                .attributes(segmentInfo.getProperties().getAttributes())
-                .build();
-        return MetadataStore.SegmentInfo.builder()
-                .properties(segmentInformation)
-                .segmentId(segmentInfo.getSegmentId())
-                .build();
-    }
-
     private MetadataStore.SegmentInfo resetSegmentID(MetadataStore.SegmentInfo segmentInfo) {
         MetadataStore.SegmentInfo resetSegmentInfo = MetadataStore.SegmentInfo.builder()
                 .segmentId(NO_STREAM_SEGMENT_ID)

--- a/cli/admin/src/main/java/io/pravega/cli/admin/dataRecovery/RecoverFromStorageCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/dataRecovery/RecoverFromStorageCommand.java
@@ -23,6 +23,7 @@ import io.pravega.common.concurrent.Services;
 import io.pravega.common.util.BufferView;
 import io.pravega.common.util.ByteArraySegment;
 import io.pravega.common.util.ImmutableDate;
+import io.pravega.common.util.btree.BTreeIndex;
 import io.pravega.segmentstore.contracts.AttributeId;
 import io.pravega.segmentstore.contracts.StreamSegmentInformation;
 import io.pravega.segmentstore.contracts.tables.TableAttributes;
@@ -43,6 +44,7 @@ import io.pravega.segmentstore.server.containers.DebugStreamSegmentContainer;
 import io.pravega.segmentstore.server.containers.MetadataStore;
 import io.pravega.segmentstore.server.logs.DurableLogConfig;
 import io.pravega.segmentstore.server.logs.DurableLogFactory;
+import io.pravega.segmentstore.server.logs.operations.Operation;
 import io.pravega.segmentstore.server.reading.ContainerReadIndexFactory;
 import io.pravega.segmentstore.server.reading.ReadIndexConfig;
 import io.pravega.segmentstore.server.tables.ContainerTableExtension;
@@ -104,6 +106,7 @@ public class RecoverFromStorageCommand extends DataRecoveryCommand {
     private static final String RG_SCALE_GROUP = "scaleGroup";
     private static final String SYSJOURNAL_BACKUP_EXTENSION = ".backup";
     private static final String EVENT_PROCESSEOR_SEGMENT = "event_processor_GC";
+    private static final String COMMIT_STREAM_READERS = "commitStreamReaders";
     private static final String EPOCH_SPLITTER = ".E-";
     private static final String OFFSET_SPLITTER = "O-";
     private static final String CHUNK_FIELD_SEPARATOR = "-";
@@ -317,7 +320,7 @@ public class RecoverFromStorageCommand extends DataRecoveryCommand {
         List<File> filteredFiles =  Arrays.stream(allFiles)
                 .filter(File::isFile)
                 .filter(f -> !f.getName().contains(ATTRIBUTE_SUFFIX))
-                .filter(f -> f.getName().split(EPOCH_SPLITTER)[0].contains("_" + String.valueOf(containerId)))
+                .filter(f -> f.getName().split(EPOCH_SPLITTER)[0].endsWith("_" + String.valueOf(containerId)))
                 .collect(Collectors.toList());
         return filteredFiles.toArray(new File[filteredFiles.size()]);
     }
@@ -435,10 +438,6 @@ public class RecoverFromStorageCommand extends DataRecoveryCommand {
 
             if (operation instanceof TableSegmentUtils.PutOperation) {
                 MetadataStore.SegmentInfo segmentInfo = SERIALIZER.deserialize(new ByteArraySegment(unversionedEntry.getValue().getCopy()).getReader());
-                if ( segmentInfo.getProperties().getName().contains(NameUtils.getStorageMetadataSegmentName(container.getId()))) {
-                    // Reset storage_metadata segment to have 0 storageLength to avoid storage Length error in {@link SegmentAggregator@initialize} method.
-                    segmentInfo = resetStorageSegment(segmentInfo);
-                }
                 // Reset Segment ID to "NO_STREAM_SEGMENT_ID" to avoid segment id conflicts with some segments that get created when container starts up immediately after recovery.
                 ByteArraySegment segment = SERIALIZER.serialize(resetSegmentID(segmentInfo));
                 unversionedEntry = TableEntry.unversioned(unversionedEntry.getKey().getKey(), segment );
@@ -447,6 +446,43 @@ public class RecoverFromStorageCommand extends DataRecoveryCommand {
                 tableExtension.remove(tableSegment, Collections.singletonList(unversionedEntry.getKey()), TIMEOUT);
             }
         }
+        //reset the core attribs in storage_segment so as to allow the attributes
+        //index to get generated with flush-to-storage being invoked.
+        resetStorageSegment(container);
+    }
+
+    /**
+     * Reset the storage_metadata segment,especially, some of the core attributes
+     * from the recovered segment. Resetting these will allow the operations
+     * parsed from storage_metadata chunks to be processed.
+     * @param container Container being recoverd.
+     * @throws Exception
+     */
+    private void resetStorageSegment(DebugStreamSegmentContainer container) throws Exception {
+        ContainerTableExtension tableExtension = container.getExtension(ContainerTableExtension.class);
+        List<TableEntry> entries = tableExtension.get(NameUtils.getMetadataSegmentName(container.getId()),
+                Collections.singletonList(BufferView.wrap(NameUtils.getStorageMetadataSegmentName(container.getId()).getBytes(StandardCharsets.UTF_8))), TIMEOUT).get();
+        TableEntry entry = entries.get(0);
+        TableEntry unversionedEntry = TableEntry.unversioned(entry.getKey().getKey(), entry.getValue());
+        MetadataStore.SegmentInfo segmentInfo = SERIALIZER.deserialize(new ByteArraySegment(unversionedEntry.getValue().getCopy()).getReader());
+
+        Map<AttributeId, Long> attribs = new HashMap<>(segmentInfo.getProperties().getAttributes());
+        attribs.put(TableAttributes.ATTRIBUTE_SEGMENT_PERSIST_SEQ_NO, Operation.NO_SEQUENCE_NUMBER);
+        attribs.put(TableAttributes.INDEX_OFFSET, 0L);
+        attribs.put(TableAttributes.ATTRIBUTE_SEGMENT_ROOT_POINTER, BTreeIndex.IndexInfo.EMPTY.getRootPointer());
+        StreamSegmentInformation segmentInformation = StreamSegmentInformation.builder()
+                .name(segmentInfo.getProperties().getName())
+                .attributes(segmentInfo.getProperties().getAttributes())
+                .attributes(attribs)
+                .build();
+        MetadataStore.SegmentInfo newSegmentInfo =  MetadataStore.SegmentInfo.builder()
+                .properties(segmentInformation)
+                .segmentId(segmentInfo.getSegmentId())
+                .build();
+
+        ByteArraySegment segment = SERIALIZER.serialize(resetSegmentID(newSegmentInfo));
+        unversionedEntry = TableEntry.unversioned(unversionedEntry.getKey().getKey(), segment );
+        tableExtension.put(NameUtils.getMetadataSegmentName(container.getId()), Collections.singletonList(unversionedEntry), TIMEOUT).join();
     }
 
     /**
@@ -507,7 +543,9 @@ public class RecoverFromStorageCommand extends DataRecoveryCommand {
         // 2. Recovering EVENT_PROCESSOR_SEGMENT leads to length mismatch issues between container and storage
         //    metadata as EVENT_PROCESSOR_SEGMENTS are created by default when container starts and then as part
         //    of recovery, when container comes up we update the lenghts in the metadata.
-        if (segmentName.contains(RG_SCALE_GROUP) || segmentName.contains(EVENT_PROCESSEOR_SEGMENT)) {
+        // 3. Same as scaleGroup for COMMIT_STREAM_READERS
+        if (segmentName.contains(RG_SCALE_GROUP) || segmentName.contains(EVENT_PROCESSEOR_SEGMENT)
+            || segmentName.contains(COMMIT_STREAM_READERS)) {
             return false;
         }
         return true;


### PR DESCRIPTION
**Change log description**  
See Issue #7043 

**Purpose of the change**  
Fixes #7043 

**What the code does**  
Calling flush to storage prior to invoking the recover-from-storage command makes sure that everything is flushed for all segments including core attributes like `last_indexed_offset`, `last_persisted_seq_num` recorded for internal table segments like `storage_metadata` Table segment.  The `storage_metadata` Table segment is the main segment parsed during the Recovery process. During parsing this segment all parsed Operations that happen to be before the offsets recorded in persisted core attributes mentioned above tend to be skipped as they are treated as operations that are already processed. This results in 
parsed operations not being indexed for `storage_metadata` Table segment and as such no attributes-index segment being generated during the recovery process, leading to failures.
The code in this PR resets these attributes, as they will be populated during the recovery process itself as we parse the raw operations from the Table segment chunks passed to the recovery process.

**How to verify it**  
See #7043.
