### PR TITLE
Issue 7062: SLTS - Fix ChunkedSegmentStorage.close by calling chunkStorage.close

### DIFF
--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -809,10 +809,15 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
         close("garbageCollector", this.garbageCollector);
         // taskQueue is per instance so safe to close this here.
         close("taskQueue", this.taskQueue);
+
+        // Do not forget to close ChunkStorage.
+        close("chunkStorage", this.chunkStorage);
+
         this.reporter.cancel(true);
         if (null != this.storageChecker) {
             this.storageChecker.cancel(true);
         }
+
         this.closed.set(true);
     }
 

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageMockTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageMockTests.java
@@ -545,4 +545,20 @@ public class ChunkedSegmentStorageMockTests extends ThreadPooledTestSuite {
                 () -> chunkedSegmentStorage.listSegments().get(),
                 ex -> clazz.equals(ex.getClass()));
     }
+
+    @Test
+    public void testClose() {
+        @Cleanup
+        BaseMetadataStore spyMetadataStore = spy(new InMemoryMetadataStore(ChunkedSegmentStorageConfig.DEFAULT_CONFIG, executorService()));
+        @Cleanup
+        BaseChunkStorage spyChunkStorage = spy(new NoOpChunkStorage(executorService()));
+
+        ChunkedSegmentStorage chunkedSegmentStorage = new ChunkedSegmentStorage(CONTAINER_ID, spyChunkStorage, spyMetadataStore, executorService(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG);
+        chunkedSegmentStorage.initialize(1);
+
+        chunkedSegmentStorage.close();
+
+        // Verify that chunkStorage is closed
+        verify(spyChunkStorage).close();
+    }
 }


### PR DESCRIPTION
**Change log description**  
Fix ChunkedSegmentStorage.close by correctly calling chunkStorage.close
Previously this line was mistakenly deleted in old PR #6108 .

**Purpose of the change**  
Fixes https://github.com/pravega/pravega/issues/7062

**What the code does**  
ChunkedSegmentStorage.close does not close chunkStorage anymore.
This change (https://github.com/pravega/pravega/commit/d680043da7299efa360887294dae4d8782e5244f#r110569766) mistakenly deleted the line closing chunkStorage.

This specifically causes leaks in ExtenededS3ChunkStorage. The client is supposed to be destroyed but becuase of this bug the zombie client will keep pinging the ECS server.

**How to verify it**  
Test should pass.
