### PR TITLE
Issue 7077 : Incorrect log message in ControllerEventProcessors

### DIFF
--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessors.java
@@ -537,7 +537,7 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
 
         log.debug("Creating abort event processors");
         Retry.indefinitelyWithExpBackoff(DELAY, MULTIPLIER, MAX_DELAY,
-                e -> log.warn("Error creating commit event processor group", e))
+                e -> log.warn("Error creating abort event processor group", e))
                 .run(() -> {
                     abortEventProcessors = system.createEventProcessorGroup(abortConfig, checkpointStore, rebalanceExecutor);
                     return null;
@@ -591,9 +591,9 @@ public class ControllerEventProcessors extends AbstractIdleService implements Fa
                         .minRebalanceIntervalMillis(rebalanceIntervalMillis)
                         .build();
 
-        log.debug("Creating kvt request event processors");
+        log.debug("Creating kvt event processors");
         Retry.indefinitelyWithExpBackoff(DELAY, MULTIPLIER, MAX_DELAY,
-                e -> log.warn("Error creating request event processor group", e))
+                e -> log.warn("Error creating kvt event processor group", e))
                 .run(() -> {
                     kvtRequestEventProcessors = system.createEventProcessorGroup(kvtRequestConfig, checkpointStore, rebalanceExecutor);
                     return null;

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ControllerEventProcessorsTest.java
@@ -188,7 +188,15 @@ public class ControllerEventProcessorsTest extends ThreadPooledTestSuite {
 
         EventProcessorGroup mockEventProcessorGroup = mock(EventProcessorGroup.class);
         doNothing().when(mockEventProcessorGroup).awaitRunning();
-        doReturn(mockEventProcessorGroup).when(system).createEventProcessorGroup(any(EventProcessorConfig.class), any(CheckpointStore.class), any(ScheduledExecutorService.class));
+        when(system.createEventProcessorGroup(any(EventProcessorConfig.class), any(CheckpointStore.class), any(ScheduledExecutorService.class)))
+                .thenThrow(new RuntimeException("Error occurred") )
+                .thenReturn(mockEventProcessorGroup)
+                .thenThrow(new RuntimeException("Error occurred") )
+                .thenReturn(mockEventProcessorGroup)
+                .thenThrow(new RuntimeException("Error occurred") )
+                .thenReturn(mockEventProcessorGroup)
+                .thenThrow(new RuntimeException("Error occurred") )
+                .thenReturn(mockEventProcessorGroup);
 
         processors.startAsync();
         processors.awaitRunning();


### PR DESCRIPTION
**Change log description**  
The log messages are incorrect for a few of the process which can be misleading sometimes.
During the creation of abort event processors the warn message prints Error creating commit event processor group which should be Error creating abort event processor group and same for kvt event processor.

**Purpose of the change**  
(Fixes #7077)

**What the code does**  
Code will print the exact error message.

**How to verify it**  
Check the logs once controller fail to create reader group.  

