### PR TITLE
Issue 7083: Move hardcoded parameters to config file

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -683,3 +683,15 @@ pravegaservice.admin.gateway.enable=false
 pravegaservice.admin.gateway.port=9999
 
 ##endregion
+
+##region connection tracker
+
+#Maximum allowed outstanding bytes from all connections. If we exceed this value, all connections should be paused.
+#default value is 512*1024*1024
+#pravegaservice.default.all.connections.max.outstanding.bytes=536870912
+
+#Maximum allowed outstanding bytes from a single connection. If we exceed this value, that connection should be paused.
+#Default value is one-fourth of default.all.connections.max.outstanding.bytes i.e 128*1024*1024
+#pravegaservice.default.single.connections.max.outstanding.bytes=134217728
+
+##endregion

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ConnectionTracker.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ConnectionTracker.java
@@ -17,6 +17,8 @@ package io.pravega.segmentstore.server.host.handler;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import io.pravega.segmentstore.server.store.ServiceConfig;
+
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -25,25 +27,17 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ConnectionTracker {
     /**
      * Threshold under which any connection may be resumed, subject to total connections not exceeding
-     * {@link #DEFAULT_ALL_CONNECTIONS_MAX_OUTSTANDING_BYTES}.
      */
     @VisibleForTesting
     static final int LOW_WATERMARK = 1024 * 1024; //1MB
-    /**
-     * Maximum allowed outstanding bytes from all connections. If we exceed this value, all connections should be paused.
-     */
-    private static final int DEFAULT_ALL_CONNECTIONS_MAX_OUTSTANDING_BYTES = 512 * 1024 * 1024;
-    /**
-     * Maximum allowed outstanding bytes from a single connection. If we exceed this value, that connection should be paused.
-     */
-    private static final int DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING = DEFAULT_ALL_CONNECTIONS_MAX_OUTSTANDING_BYTES / 4;
 
     private final int allConnectionsLimit;
     private final int singleConnectionDoubleLimit;
     private final AtomicLong totalOutstanding = new AtomicLong(0);
 
     public ConnectionTracker() {
-        this(DEFAULT_ALL_CONNECTIONS_MAX_OUTSTANDING_BYTES, DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING);
+        this(ServiceConfig.DEFAULT_ALL_CONNECTIONS_MAX_OUTSTANDING_BYTES.getDefaultValue().intValue(),
+                ServiceConfig.DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING_BYTES.getDefaultValue().intValue());
     }
 
     ConnectionTracker(int allConnectionsMaxOutstandingBytes, int singleConnectionMaxOutstandingBytes) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -22,16 +22,16 @@ import io.pravega.common.util.ConfigurationException;
 import io.pravega.common.util.Property;
 import io.pravega.common.util.TypedProperties;
 import io.pravega.segmentstore.server.CachePolicy;
-import java.net.Inet4Address;
-import java.net.UnknownHostException;
-import java.time.Duration;
-import java.util.Arrays;
-
 import io.pravega.segmentstore.storage.StorageLayoutType;
 import io.pravega.shared.rest.RESTServerConfig;
 import io.pravega.shared.rest.impl.RESTServerConfigImpl;
 import lombok.Getter;
 import lombok.SneakyThrows;
+
+import java.net.Inet4Address;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.Arrays;
 
 /**
  * General Service Configuration.
@@ -91,6 +91,13 @@ public class ServiceConfig {
     // Admin Gateway-related parameters
     public static final Property<Boolean> ENABLE_ADMIN_GATEWAY = Property.named("admin.gateway.enable", false);
     public static final Property<Integer> ADMIN_GATEWAY_PORT = Property.named("admin.gateway.port", 9999);
+
+    //Connection Tracker related parameters
+    public static final Property<Integer> DEFAULT_ALL_CONNECTIONS_MAX_OUTSTANDING_BYTES = Property.named("default.all.connections.max.outstanding.bytes",
+            512 * 1024 * 1024);
+    public static final Property<Integer> DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING_BYTES = Property.named("default.all.connections.max.outstanding.bytes",
+            128 * 1024 * 1024);
+
 
     public static final String COMPONENT_CODE = "pravegaservice";
 
@@ -347,6 +354,12 @@ public class ServiceConfig {
 
     @Getter
     private final Duration healthCheckInterval;
+
+    @Getter
+    private final int defaultAllConnectionsMaxOutstandingBytes;
+
+    @Getter
+    private final int defaultSingleConnectionsMaxOutstandingBytes;
     //endregion
 
     //region Constructor
@@ -426,6 +439,8 @@ public class ServiceConfig {
         this.healthCheckInterval = Duration.ofSeconds(properties.getInt(HEALTH_CHECK_INTERVAL_SECONDS));
         this.enableAdminGateway = properties.getBoolean(ENABLE_ADMIN_GATEWAY);
         this.adminGatewayPort = properties.getInt(ADMIN_GATEWAY_PORT);
+        this.defaultAllConnectionsMaxOutstandingBytes = properties.getInt(DEFAULT_ALL_CONNECTIONS_MAX_OUTSTANDING_BYTES);
+        this.defaultSingleConnectionsMaxOutstandingBytes = properties.getInt(DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING_BYTES);
     }
 
     /**


### PR DESCRIPTION
**Change log description**  
Moving DEFAULT_ALL_CONNECTIONS_MAX_OUTSTANDING_BYTES and DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING to config.properties which can be configured depending on the installation.

**Purpose of the change**  
Fixes #7083

**What the code does**  
Moving hardcoded values such as DEFAULT_ALL_CONNECTIONS_MAX_OUTSTANDING_BYTES and DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING to config.properties

**How to verify it**  
(Optional: steps to verify that the changes are effective)
