### PR TITLE
Issue-7081: Update Global Retention Policy only for Validation

### DIFF
--- a/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
@@ -740,6 +740,9 @@ public class ControllerImpl implements Controller {
             case STREAM_NOT_FOUND:
                 log.warn(requestId, "Stream does not exist: {}", streamName);
                 throw new IllegalArgumentException("Stream does not exist: " + streamConfig);
+            case INVALID_RETENTION_POLICY:
+                 log.warn(requestId, "Missing retention policy for the stream: {}", streamName);
+                 throw new IllegalArgumentException("Missing retention policy, retention policy must be specified as requireRetentionPolicy is enabled: " + streamConfig);
             case STREAM_SEALED:
                 log.warn(requestId, "Stream is sealed: {}", streamName);
                 throw new UnsupportedOperationException("Stream is sealed: " + streamConfig);

--- a/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
@@ -638,6 +638,10 @@ public class ControllerImpl implements Controller {
             case INVALID_STREAM_NAME:
                 log.warn(requestId, "Illegal stream name: {}", streamName);
                 throw new IllegalArgumentException("Illegal stream name: " + streamConfig);
+
+            case INVALID_RETENTION_POLICY:
+                log.warn(requestId, "Invalid retention policy for the stream: {}", streamName);
+                throw new IllegalArgumentException("Invalid retention policy as require retention policy is enabled: " + streamConfig);
             case SCOPE_NOT_FOUND:
                 log.warn(requestId, "Scope not found: {}", scope);
                 throw new IllegalArgumentException("Scope does not exist: " + streamConfig);

--- a/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
+++ b/client/src/main/java/io/pravega/client/control/impl/ControllerImpl.java
@@ -640,8 +640,8 @@ public class ControllerImpl implements Controller {
                 throw new IllegalArgumentException("Illegal stream name: " + streamConfig);
 
             case INVALID_RETENTION_POLICY:
-                log.warn(requestId, "Invalid retention policy for the stream: {}", streamName);
-                throw new IllegalArgumentException("Invalid retention policy as require retention policy is enabled: " + streamConfig);
+                log.warn(requestId, "Missing retention policy for the stream: {}", streamName);
+                throw new IllegalArgumentException("Missing retention policy, retention policy must be specified as requireRetentionPolicy is enabled: " + streamConfig);
             case SCOPE_NOT_FOUND:
                 log.warn(requestId, "Scope not found: {}", scope);
                 throw new IllegalArgumentException("Scope does not exist: " + streamConfig);

--- a/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
@@ -276,6 +276,11 @@ public class ControllerImplTest {
                                                     .setStatus(CreateStreamStatus.Status.INVALID_STREAM_NAME)
                                                     .build());
                     responseObserver.onCompleted();
+                } else if (request.getStreamInfo().getStream().equals("requiredRetentionStream")) {
+                    responseObserver.onNext(CreateStreamStatus.newBuilder()
+                                                              .setStatus(CreateStreamStatus.Status.INVALID_RETENTION_POLICY)
+                                                              .build());
+                    responseObserver.onCompleted();
                 } else if (request.getStreamInfo().getStream().equals("streamparallel")) {
 
                     // Simulating delay in sending response.
@@ -1626,6 +1631,11 @@ public class ControllerImplTest {
                                                                    .build());
         AssertExtensions.assertFutureThrows("Should throw Exception",
                 createStreamStatus, throwable -> true);
+
+        createStreamStatus = controllerClient.createStream("scope1", "requiredRetentionStream", StreamConfiguration.builder()
+                                                                                                                   .scalingPolicy(ScalingPolicy.fixed(2))
+                                                                                                                   .build());
+        AssertExtensions.assertFutureThrows("Should throw Exception", createStreamStatus, throwable -> true);
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ControllerImplTest.java
@@ -366,6 +366,11 @@ public class ControllerImplTest {
                     responseObserver.onCompleted();
                 } else if (request.getStreamInfo().getStream().equals("deadline")) {
                     // dont send any response
+                } else if (request.getStreamInfo().getStream().equals("retentionRequired")) {
+                    responseObserver.onNext(UpdateStreamStatus.newBuilder()
+                                                              .setStatus(UpdateStreamStatus.Status.INVALID_RETENTION_POLICY)
+                                                              .build());
+                    responseObserver.onCompleted();
                 } else {
                     responseObserver.onError(Status.INTERNAL.withDescription("Server error").asRuntimeException());
                 }
@@ -1673,6 +1678,12 @@ public class ControllerImplTest {
         updateStreamStatus = controllerClient.updateStream("scope1", "stream6", StreamConfiguration.builder()
                                                                   .scalingPolicy(ScalingPolicy.fixed(1))
                                                                   .build());
+        AssertExtensions.assertFutureThrows("Should throw Exception",
+                updateStreamStatus, throwable -> true);
+
+        updateStreamStatus = controllerClient.updateStream("scope1", "retentionRequired", StreamConfiguration.builder()
+                                                                                                   .scalingPolicy(ScalingPolicy.fixed(2))
+                                                                                                   .build());
         AssertExtensions.assertFutureThrows("Should throw Exception",
                 updateStreamStatus, throwable -> true);
     }

--- a/controller/src/conf/controller.config.properties
+++ b/controller/src/conf/controller.config.properties
@@ -68,12 +68,7 @@ controller.retention.frequency.minutes=${RETENTION_FREQUENCY_MINUTES}
 controller.retention.bucket.count=${BUCKET_COUNT}
 controller.retention.thread.count=${RETENTION_THREAD_POOL_SIZE}
 
-controller.retention.type=${RETENTION_TYPE}
-# If retention type is Time then min value and max value are in minutes
-# If retention type is Size then min value and max value are in bytes
-controller.retention.min.value=${RETENTION_MIN_VALUE}
-controller.retention.max.value=${RETENTION_MAX_VALUE}
-controller.retention.global.policy.enabled=${GLOBAL_RETENTION_POLICY}
+controller.require.retention.policy=${REQUIRE_RETENTION_POLICY}
 
 controller.transaction.lease.count.min=${MIN_LEASE_VALUE}
 controller.transaction.lease.count.max=${MAX_LEASE_VALUE}

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -398,8 +398,12 @@ public class ControllerService {
     }
 
     @VisibleForTesting
-    protected void validateStreamConfig(StreamConfiguration streamConfig) {
-        boolean isInvalidStreamConfig =  Config.REQUIRE_RETENTION_POLICY
+    protected boolean getRequiredRetentionPolicyValue() {
+        return Config.REQUIRE_RETENTION_POLICY;
+    }
+
+    private void validateStreamConfig(StreamConfiguration streamConfig) {
+        boolean isInvalidStreamConfig =  getRequiredRetentionPolicyValue()
                 && !ScalingPolicy.fixed(1).equals(streamConfig.getScalingPolicy())
                 && streamConfig.getRetentionPolicy() == null;
         Preconditions.checkArgument(!isInvalidStreamConfig, "Missing retention policy for the stream");

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -390,7 +390,7 @@ public class ControllerService {
         try {
             validateStreamConfig(streamConfig);
         } catch (IllegalArgumentException e) {
-            log.error(requestId, "Create stream: {} failed due to invalid retention policy {}", stream, streamConfig);
+            log.error(requestId, "Create stream: {} failed due to missing retention policy {}", stream, streamConfig);
             return CompletableFuture.completedFuture(
                     CreateStreamStatus.newBuilder().setStatus(CreateStreamStatus.Status.INVALID_RETENTION_POLICY).build());
         }
@@ -400,9 +400,9 @@ public class ControllerService {
     @VisibleForTesting
     protected void validateStreamConfig(StreamConfiguration streamConfig) {
         boolean isInvalidStreamConfig =  Config.REQUIRE_RETENTION_POLICY
-                && !streamConfig.getScalingPolicy().equals(ScalingPolicy.fixed(1))
+                && !ScalingPolicy.fixed(1).equals(streamConfig.getScalingPolicy())
                 && streamConfig.getRetentionPolicy() == null;
-        Preconditions.checkArgument(!isInvalidStreamConfig, "Invalid retention policy for the stream");
+        Preconditions.checkArgument(!isInvalidStreamConfig, "Missing retention policy for the stream");
     }
 
     private CompletableFuture<CreateStreamStatus> callCreateStream(final String scope, final String stream,

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -399,9 +399,9 @@ public class ControllerService {
 
     @VisibleForTesting
     protected void validateStreamConfig(StreamConfiguration streamConfig) {
-        boolean isInvalidStreamConfig =  (Config.REQUIRE_RETENTION_POLICY
+        boolean isInvalidStreamConfig =  Config.REQUIRE_RETENTION_POLICY
                 && !streamConfig.getScalingPolicy().equals(ScalingPolicy.fixed(1))
-                && streamConfig.getRetentionPolicy() == null);
+                && streamConfig.getRetentionPolicy() == null;
         Preconditions.checkArgument(!isInvalidStreamConfig, "Invalid retention policy for the stream");
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -88,7 +88,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 /**
@@ -400,9 +399,9 @@ public class ControllerService {
 
     @VisibleForTesting
     protected void validateStreamConfig(StreamConfiguration streamConfig) {
-        boolean isInvalidStreamConfig =  (Config.REQUIRE_RETENTION_POLICY &&
-                !streamConfig.getScalingPolicy().equals(ScalingPolicy.fixed(1)) &&
-                streamConfig.getRetentionPolicy()==null);
+        boolean isInvalidStreamConfig =  (Config.REQUIRE_RETENTION_POLICY
+                && !streamConfig.getScalingPolicy().equals(ScalingPolicy.fixed(1))
+                && streamConfig.getRetentionPolicy() == null);
         Preconditions.checkArgument(!isInvalidStreamConfig, "Invalid retention policy for the stream");
     }
 

--- a/controller/src/main/java/io/pravega/controller/server/ControllerService.java
+++ b/controller/src/main/java/io/pravega/controller/server/ControllerService.java
@@ -452,6 +452,14 @@ public class ControllerService {
     public CompletableFuture<UpdateStreamStatus> updateStream(String scope, String stream, final StreamConfiguration streamConfig,
                                                               long requestId) {
         Preconditions.checkNotNull(streamConfig, "streamConfig");
+        try {
+            validateStreamConfig(streamConfig);
+        } catch (IllegalArgumentException e) {
+            log.error(requestId, "Update stream: {} failed due to missing retention policy {}", stream, streamConfig);
+            return CompletableFuture.completedFuture(
+                    UpdateStreamStatus.newBuilder().setStatus(UpdateStreamStatus.Status.INVALID_RETENTION_POLICY).build());
+        }
+
         Timer timer = new Timer();
         return streamMetadataTasks.updateStream(scope, stream, streamConfig, requestId)
                 .thenApplyAsync(status -> {

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -241,6 +241,8 @@ public class LocalController implements Controller {
                 throw new IllegalArgumentException(String.format("Failed to update Stream %s as Scope %s does not exist.", scope, streamName));
             case STREAM_NOT_FOUND:
                 throw new IllegalArgumentException(String.format("Failed to update Stream: %s as Stream does not exist under Scope: %s", streamName, scope));
+            case INVALID_RETENTION_POLICY:
+                throw new IllegalArgumentException(String.format("Invalid retention policy for stream: %s as require retention policy is enabled: %s", streamName, streamConfig));
             case STREAM_SEALED:
                 throw new UnsupportedOperationException(String.format("Failed to update Stream: %s as Stream is sealed", streamName));
             case SUCCESS:

--- a/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
+++ b/controller/src/main/java/io/pravega/controller/server/eventProcessor/LocalController.java
@@ -216,6 +216,8 @@ public class LocalController implements Controller {
                 throw new ControllerFailureException(String.format("Failed to create stream: %s/%s with config: %s", scope, streamName, streamConfig));
             case INVALID_STREAM_NAME:
                 throw new IllegalArgumentException(String.format("Failed to create stream. Illegal Stream name: %s", streamName));
+            case INVALID_RETENTION_POLICY:
+                throw new IllegalArgumentException(String.format("Invalid retention policy for stream: %s as require retention policy is enabled: %s", streamName, streamConfig));
             case SCOPE_NOT_FOUND:
                 throw new IllegalArgumentException(String.format("Failed to create stream: %s as Scope %s does not exist.", streamName, scope));
             case STREAM_EXISTS:

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -732,6 +732,10 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
                     streamStatus.getStatus() == UpdateStreamStatus.Status.SCOPE_NOT_FOUND) {
                 log.warn(requestId, "Stream: {}/{} not found", scopeName, streamName);
                 return Response.status(Status.NOT_FOUND).build();
+            } else if (streamStatus.getStatus() == UpdateStreamStatus.Status.INVALID_RETENTION_POLICY) {
+                log.warn(requestId, "Invalid retention policy for the stream {} as require retention is enabled: {}",
+                        streamName, streamConfiguration);
+                return Response.status(Status.BAD_REQUEST).build();
             } else {
                 log.warn(requestId, "updateStream failed for {}/{}", scopeName, streamName);
                 return Response.status(Status.INTERNAL_SERVER_ERROR).build();

--- a/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/resources/StreamMetadataResourceImpl.java
@@ -217,6 +217,10 @@ public class StreamMetadataResourceImpl implements ApiV1.ScopesApi {
                     } else if (streamStatus.getStatus() == CreateStreamStatus.Status.INVALID_STREAM_NAME) {
                         log.warn(requestId, "Invalid stream name: {}", streamName);
                         resp = Response.status(Status.BAD_REQUEST).build();
+                    } else if (streamStatus.getStatus() == CreateStreamStatus.Status.INVALID_RETENTION_POLICY) {
+                        log.warn(requestId, "Invalid retention policy for the stream {} as require retention is enabled: {}",
+                                streamName, streamConfiguration);
+                        resp = Response.status(Status.BAD_REQUEST).build();
                     } else {
                         log.warn(requestId, "createStream failed for : {}/{}", scopeName, streamName);
                         resp = Response.status(Status.INTERNAL_SERVER_ERROR).build();

--- a/controller/src/main/java/io/pravega/controller/server/rest/v1/ApiV1.java
+++ b/controller/src/main/java/io/pravega/controller/server/rest/v1/ApiV1.java
@@ -105,6 +105,9 @@ public final class ApiV1 {
                         code = 409, message = "Stream already exists", response = StreamProperty.class),
 
                 @ApiResponse(
+                        code = 400, message = "Invalid stream name or retention policy", response = StreamProperty.class),
+
+                @ApiResponse(
                         code = 500, message = "Server error", response = StreamProperty.class) })
         void createStream(@ApiParam(value = "Scope name", required = true) @PathParam("scopeName") String scopeName,
                 @ApiParam(value = "The stream configuration", required = true) CreateStreamRequest createStreamRequest,

--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -175,17 +175,8 @@ public final class Config {
     public static final Property<Integer> PROPERTY_RETENTION_BUCKET_COUNT = Property.named(
             "retention.bucket.count", 1, "retention.bucketCount");
 
-    public static final Property<RetentionType> PROPERTY_RETENTION_TYPE = Property.named(
-            "retention.type", RetentionType.TIME, "retention.type");
-
-    public static final Property<Integer> PROPERTY_RETENTION_MIN_VALUE = Property.named(
-            "retention.min.value", Integer.MAX_VALUE, "retention.minVal");
-
-    public static final Property<Integer> PROPERTY_RETENTION_MAX_VALUE = Property.named(
-            "retention.max.value", Integer.MAX_VALUE, "retention.maxVal");
-
-    public static final Property<Boolean> PROPERTY_GLOBAL_RETENTION_POLICY = Property.named(
-            "retention.global.policy.enabled", false, "retention.globalPolicy");
+    public static final Property<Boolean> PROPERTY_REQUIRE_RETENTION_POLICY = Property.named(
+            "require.retention.policy", false, "require.retentionPolicy");
 
     public static final Property<Integer> PROPERTY_RETENTION_THREAD_COUNT = Property.named(
             "retention.thread.count", 1, "retention.threadCount");
@@ -292,12 +283,7 @@ public final class Config {
     public static final int MINIMUM_RETENTION_FREQUENCY_IN_MINUTES;
     public static final int RETENTION_BUCKET_COUNT;
 
-    public static final RetentionType RETENTION_TYPE;
-
-    public static final boolean GLOBAL_RETENTION_POLICY;
-    public static final int RETENTION_MIN_VALUE;
-
-    public static final int RETENTION_MAX_VALUE;
+    public static final boolean REQUIRE_RETENTION_POLICY;
     public static final int RETENTION_THREAD_POOL_SIZE;
 
     // Watermarking Configuration
@@ -381,10 +367,7 @@ public final class Config {
         COMPLETED_TRANSACTION_TTL_IN_HOURS = p.getInt(PROPERTY_TXN_TTL_HOURS);
         MINIMUM_RETENTION_FREQUENCY_IN_MINUTES = p.getInt(PROPERTY_RETENTION_FREQUENCY_MINUTES);
         RETENTION_BUCKET_COUNT = p.getInt(PROPERTY_RETENTION_BUCKET_COUNT);
-        RETENTION_TYPE = p.getEnum(PROPERTY_RETENTION_TYPE, RetentionType.class);
-        RETENTION_MIN_VALUE = p.getInt(PROPERTY_RETENTION_MIN_VALUE);
-        RETENTION_MAX_VALUE = p.getInt(PROPERTY_RETENTION_MAX_VALUE);
-        GLOBAL_RETENTION_POLICY = p.getBoolean(PROPERTY_GLOBAL_RETENTION_POLICY);
+        REQUIRE_RETENTION_POLICY = p.getBoolean(PROPERTY_REQUIRE_RETENTION_POLICY);
         RETENTION_THREAD_POOL_SIZE = p.getInt(PROPERTY_RETENTION_THREAD_COUNT);
         MINIMUM_WATERMARKING_FREQUENCY_IN_SECONDS = p.getInt(PROPERTY_WATERMARKING_FREQUENCY_SECONDS);
         WATERMARKING_BUCKET_COUNT = p.getInt(PROPERTY_WATERMARKING_BUCKET_COUNT);

--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -16,7 +16,6 @@
 package io.pravega.controller.util;
 
 import com.google.common.base.Strings;
-import io.pravega.client.stream.RetentionPolicy.RetentionType;
 import io.pravega.common.security.TLSProtocolVersion;
 import io.pravega.common.util.Property;
 import io.pravega.common.util.TypedProperties;

--- a/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
@@ -34,6 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
@@ -193,6 +194,15 @@ public class FailingSecureStreamMetaDataTests extends StreamMetaDataTests {
         // Test to delete a reader group
         Response response = addAuthHeaders(client.target(resourceURI).request()).buildDelete().invoke();
         assertEquals("Delete reader group response code", expectedResult, response.getStatus());
+        response.close();
+    }
+
+    @Override
+    public void testRequireRetention() {
+        final String streamResourceURI = getURI() + "v1/scopes/" + scope1 + "/streams";
+        // Test to create a stream
+        Response response = addAuthHeaders(client.target(streamResourceURI).request()).buildPost(Entity.json(createStreamRequest)).invoke();
+        assertEquals("Create Stream Status", expectedResult, response.getStatus());
         response.close();
     }
 }

--- a/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
@@ -195,13 +195,4 @@ public class FailingSecureStreamMetaDataTests extends StreamMetaDataTests {
         assertEquals("Delete reader group response code", expectedResult, response.getStatus());
         response.close();
     }
-
-    @Override
-    public void testRequireRetention() {
-        final String streamResourceURI = getURI() + "v1/scopes/" + scope1 + "/streams";
-        // Test to create a stream
-        Response response = addAuthHeaders(client.target(streamResourceURI).request()).buildPost(Entity.json(createStreamRequest)).invoke();
-        assertEquals("Create Stream Status", expectedResult, response.getStatus());
-        response.close();
-    }
 }

--- a/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/FailingSecureStreamMetaDataTests.java
@@ -16,12 +16,12 @@
 package io.pravega.controller.rest.v1;
 
 import io.grpc.ServerBuilder;
-import io.pravega.controller.server.security.auth.GrpcAuthHelper;
-import io.pravega.test.common.SecurityConfigDefaults;
 import io.pravega.controller.server.rest.generated.model.CreateScopeRequest;
 import io.pravega.controller.server.rest.generated.model.StreamState;
 import io.pravega.controller.server.rpc.grpc.impl.GRPCServerConfigImpl;
+import io.pravega.controller.server.security.auth.GrpcAuthHelper;
 import io.pravega.shared.rest.security.AuthHandlerManager;
+import io.pravega.test.common.SecurityConfigDefaults;
 import io.pravega.test.common.TestUtils;
 import java.util.Arrays;
 import java.util.Date;
@@ -34,7 +34,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -192,6 +192,8 @@ public class StreamMetaDataTests {
             completedFuture(CreateStreamStatus.newBuilder().setStatus(CreateStreamStatus.Status.FAILURE).build());
     private final CompletableFuture<CreateStreamStatus> createStreamStatus4 = CompletableFuture.
             completedFuture(CreateStreamStatus.newBuilder().setStatus(CreateStreamStatus.Status.SCOPE_NOT_FOUND).build());
+    private final CompletableFuture<CreateStreamStatus> createStreamStatus5 = CompletableFuture.
+            completedFuture(CreateStreamStatus.newBuilder().setStatus(CreateStreamStatus.Status.INVALID_RETENTION_POLICY).build());
     private CompletableFuture<UpdateStreamStatus> updateStreamStatus = CompletableFuture.
             completedFuture(UpdateStreamStatus.newBuilder().setStatus(UpdateStreamStatus.Status.SUCCESS).build());
     private CompletableFuture<UpdateStreamStatus> updateStreamStatus2 = CompletableFuture.
@@ -386,6 +388,19 @@ public class StreamMetaDataTests {
         when(mockControllerService.createStream(any(), any(), any(), anyLong(), anyLong())).thenReturn(createStreamStatus4);
         response = addAuthHeaders(client.target(streamResourceURI).request()).buildPost(Entity.json(createStreamRequest3)).invoke();
         assertEquals("Create Stream Status for non-existent scope", 404, response.getStatus());
+        response.close();
+    }
+
+    /**
+     * Test for require retention policy.
+     */
+    @Test(timeout = 30000)
+    public void testRequireRetention() {
+        String streamResourceURI = getURI() + "v1/scopes/" + scope1 + "/streams";
+        // Test to create a stream
+        when(mockControllerService.createStream(any(), any(), any(), anyLong(), anyLong())).thenReturn(createStreamStatus5);
+        Response response = addAuthHeaders(client.target(streamResourceURI).request()).buildPost(Entity.json(createStreamRequest)).invoke();
+        assertEquals("Create Stream Status", 400, response.getStatus());
         response.close();
     }
 

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -394,7 +394,7 @@ public class StreamMetaDataTests {
     /**
      * Test for require retention policy.
      */
-    @Test(timeout = 30000)
+    @Test(timeout = 10000)
     public void testRequireRetention() {
         String streamResourceURI = getURI() + "v1/scopes/" + scope1 + "/streams";
         // Test to create a stream

--- a/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/StreamMetaDataTests.java
@@ -202,6 +202,8 @@ public class StreamMetaDataTests {
             completedFuture(UpdateStreamStatus.newBuilder().setStatus(UpdateStreamStatus.Status.FAILURE).build());
     private CompletableFuture<UpdateStreamStatus> updateStreamStatus4 = CompletableFuture.
             completedFuture(UpdateStreamStatus.newBuilder().setStatus(UpdateStreamStatus.Status.SCOPE_NOT_FOUND).build());
+    private CompletableFuture<UpdateStreamStatus> updateStreamStatus5 = CompletableFuture.
+            completedFuture(UpdateStreamStatus.newBuilder().setStatus(UpdateStreamStatus.Status.INVALID_RETENTION_POLICY).build());
 
     @Before
     public void setup() throws Exception {
@@ -389,17 +391,10 @@ public class StreamMetaDataTests {
         response = addAuthHeaders(client.target(streamResourceURI).request()).buildPost(Entity.json(createStreamRequest3)).invoke();
         assertEquals("Create Stream Status for non-existent scope", 404, response.getStatus());
         response.close();
-    }
 
-    /**
-     * Test for require retention policy.
-     */
-    @Test(timeout = 10000)
-    public void testRequireRetention() {
-        String streamResourceURI = getURI() + "v1/scopes/" + scope1 + "/streams";
-        // Test to create a stream
+        // Test create stream with required retention enabled
         when(mockControllerService.createStream(any(), any(), any(), anyLong(), anyLong())).thenReturn(createStreamStatus5);
-        Response response = addAuthHeaders(client.target(streamResourceURI).request()).buildPost(Entity.json(createStreamRequest)).invoke();
+        response = addAuthHeaders(client.target(streamResourceURI).request()).buildPost(Entity.json(createStreamRequest)).invoke();
         assertEquals("Create Stream Status", 400, response.getStatus());
         response.close();
     }
@@ -447,6 +442,12 @@ public class StreamMetaDataTests {
         when(mockControllerService.updateStream(any(), any(), any(), anyLong())).thenReturn(updateStreamStatus4);
         response = addAuthHeaders(client.target(resourceURI).request()).buildPut(Entity.json(updateStreamRequest)).invoke();
         assertEquals("Update Stream Status", 404, response.getStatus());
+        response.close();
+
+        // Test to update an existing stream with required retention enabled
+        when(mockControllerService.updateStream(any(), any(), any(), anyLong())).thenReturn(updateStreamStatus5);
+        response = addAuthHeaders(client.target(resourceURI).request()).buildPut(Entity.json(updateStreamRequest)).invoke();
+        assertEquals("Update Stream Status", 400, response.getStatus());
         response.close();
     }
 

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -273,6 +273,13 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
         assertThrows("Expected ControllerFailureException",
                 () -> this.testController.updateStream("scope", "stream", StreamConfiguration.builder().build()).join(),
                 ex -> ex instanceof ControllerFailureException);
+
+        when(this.mockControllerService.updateStream(any(), any(), any(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.UpdateStreamStatus.newBuilder()
+                                                                               .setStatus(Controller.UpdateStreamStatus.Status.INVALID_RETENTION_POLICY).build()));
+        assertThrows("Expected IllegalArgumentException",
+                () -> this.testController.updateStream("scope", "stream", StreamConfiguration.builder().build()).join(),
+                ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test(timeout = 10000)

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/LocalControllerTest.java
@@ -230,6 +230,13 @@ public class LocalControllerTest extends ThreadPooledTestSuite {
         assertThrows("Expected ControllerFailureException",
                 () -> this.testController.createInternalStream("scope", "stream", StreamConfiguration.builder().build()).join(),
                 ex -> ex instanceof ControllerFailureException);
+
+        when(this.mockControllerService.createStream(any(), any(), any(), anyLong(), anyLong())).thenReturn(
+                CompletableFuture.completedFuture(Controller.CreateStreamStatus.newBuilder()
+                                                                               .setStatus(Controller.CreateStreamStatus.Status.INVALID_RETENTION_POLICY).build()));
+        assertThrows("Expected IllegalArgumentException",
+                () -> this.testController.createStream("scope", "stream", StreamConfiguration.builder().build()).join(),
+                ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test(timeout = 10000)

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -27,7 +27,6 @@ import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.RetentionPolicy;
-import io.pravega.client.stream.RetentionPolicy.RetentionType;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -1102,57 +1102,6 @@ public abstract class StreamMetadataTasksTest {
         doCallRealMethod().when(streamStorePartialMock).listSubscribers(any(), any(), any(), any());
     }
 
-    @Test(timeout = 20000)
-    public void testGlobalRetention() throws Exception {
-        final ScalingPolicy policy = ScalingPolicy.fixed(2);
-        final StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(policy)
-                .build();
-        assertNull(configuration.getRetentionPolicy());
-        TaskMetadataStore taskMetadataStore = spy(TaskStoreFactory.createZKStore(zkClient, executor));
-        @Cleanup
-        StreamMetadataTasks metadataTask = new StreamMetadataTasks(streamStorePartialMock, bucketStore, taskMetadataStore,
-                SegmentHelperMock.getSegmentHelperMock(), executor, "host",
-                new GrpcAuthHelper(authEnabled, "key", 300));
-
-        metadataTask.setGlobalRetentionValues(true, 1L, 2L, RetentionType.TIME);
-        metadataTask.createStreamRetryOnLockFailure(SCOPE, "testStream1", configuration, System.currentTimeMillis(), 10, 0L).get();
-        StreamConfiguration streamConfig = streamStorePartialMock.getConfiguration(SCOPE, "testStream1", null, executor).get();
-
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionType(), RetentionType.TIME);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionParam(), Duration.ofMinutes(1L).toMillis());
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionMax(), Duration.ofMinutes(2L).toMillis());
-
-        metadataTask.setGlobalRetentionValues(true, 1L, 0L, RetentionType.TIME);
-        metadataTask.createStreamRetryOnLockFailure(SCOPE, "testStream2", configuration, System.currentTimeMillis(), 10, 0L).get();
-        streamConfig = streamStorePartialMock.getConfiguration(SCOPE, "testStream2", null, executor).get();
-
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionType(), RetentionPolicy.RetentionType.TIME);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionParam(), Duration.ofMinutes(1L).toMillis());
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionMax(), Long.MAX_VALUE);
-
-        metadataTask.setGlobalRetentionValues(true, 1000L, 2000L, RetentionType.SIZE);
-        metadataTask.createStreamRetryOnLockFailure(SCOPE, "testStream3", configuration, System.currentTimeMillis(), 10, 0L).get();
-        streamConfig = streamStorePartialMock.getConfiguration(SCOPE, "testStream3", null, executor).get();
-
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionType(), RetentionPolicy.RetentionType.SIZE);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionParam(), 1000);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionMax(), 2000);
-
-        metadataTask.setGlobalRetentionValues(true, 1000L, 0L, RetentionType.SIZE);
-        metadataTask.createStreamRetryOnLockFailure(SCOPE, "testStream4", configuration, System.currentTimeMillis(), 10, 0L).get();
-        streamConfig = streamStorePartialMock.getConfiguration(SCOPE, "testStream4", null, executor).get();
-
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionType(), RetentionPolicy.RetentionType.SIZE);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionParam(), 1000);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionMax(), Long.MAX_VALUE);
-
-        metadataTask.setGlobalRetentionValues(false, 0L, 0L, RetentionType.TIME);
-        metadataTask.createStreamRetryOnLockFailure(SCOPE, "testStream5", configuration, System.currentTimeMillis(), 10, 0L).get();
-        streamConfig = streamStorePartialMock.getConfiguration(SCOPE, "testStream5", null, executor).get();
-
-        assertNull(streamConfig.getRetentionPolicy());
-    }
-
     @Test(timeout = 30000)
     public void sizeBasedRetentionStreamTest() throws Exception {
         final ScalingPolicy policy = ScalingPolicy.fixed(2);

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -225,6 +225,7 @@ message UpdateStreamStatus {
         STREAM_NOT_FOUND = 2;
         SCOPE_NOT_FOUND = 3;
         STREAM_SEALED = 4;
+        INVALID_RETENTION_POLICY = 5;
     }
     Status status = 1;
 }

--- a/shared/controller-api/src/main/proto/Controller.proto
+++ b/shared/controller-api/src/main/proto/Controller.proto
@@ -213,6 +213,7 @@ message CreateStreamStatus {
         STREAM_EXISTS = 2;
         SCOPE_NOT_FOUND = 3;
         INVALID_STREAM_NAME = 4;
+        INVALID_RETENTION_POLICY = 5;
     }
     Status status = 1;
 }


### PR DESCRIPTION
**Change log description**  
This PR aims to update the variable `globalRetentionPolicy` to `requireRetentionPolicy` and restrict it's usage from explicitly updating the `Streamonfiguration` object by setting the retention policy to validate instead.

**Purpose of the change**  
Fixes #7081 

**What the code does**  
The code introduces a validation before creating/updating a user stream based on the global value `requireRetentionPolicy`. If the value is true and the user stream creation/updation request falls onto the server with retention policy as none then the server should respond with `IllegalArgumentException`. The same should be apllicable for rest and grpc

**How to verify it**  
There should be sufficient test-coverage 
