### PR TITLE
Issue 7093: Cherry-pick PR#7090 to r0.13

### DIFF
--- a/controller/src/conf/controller.config.properties
+++ b/controller/src/conf/controller.config.properties
@@ -68,13 +68,6 @@ controller.retention.frequency.minutes=${RETENTION_FREQUENCY_MINUTES}
 controller.retention.bucket.count=${BUCKET_COUNT}
 controller.retention.thread.count=${RETENTION_THREAD_POOL_SIZE}
 
-controller.retention.type=${RETENTION_TYPE}
-# If retention type is Time then min value and max value are in minutes
-# If retention type is Size then min value and max value are in bytes
-controller.retention.min.value=${RETENTION_MIN_VALUE}
-controller.retention.max.value=${RETENTION_MAX_VALUE}
-controller.retention.global.policy.enabled=${GLOBAL_RETENTION_POLICY}
-
 controller.transaction.lease.count.min=${MIN_LEASE_VALUE}
 controller.transaction.lease.count.max=${MAX_LEASE_VALUE}
 controller.transaction.ttl.hours=${COMPLETED_TXN_TTL_IN_HOURS}

--- a/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
+++ b/controller/src/main/java/io/pravega/controller/task/Stream/StreamMetadataTasks.java
@@ -25,7 +25,6 @@ import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.RetentionPolicy;
-import io.pravega.client.stream.RetentionPolicy.RetentionType;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
@@ -146,14 +145,6 @@ public class StreamMetadataTasks extends TaskBase {
     private static final long READER_GROUP_SEGMENT_ROLLOVER_SIZE_BYTES = 4 * 1024 * 1024; // 4MB
     private final AtomicLong retentionFrequencyMillis;
 
-    private final AtomicBoolean globalRetentionPolicy;
-
-    private final AtomicReference<RetentionType>  retentionType;
-
-    private final AtomicLong minRetentionValue;
-
-    private final AtomicLong maxRetentionValue;
-
     private final StreamMetadataStore streamMetadataStore;
     private final BucketStore bucketStore;
     private final SegmentHelper segmentHelper;
@@ -213,10 +204,6 @@ public class StreamMetadataTasks extends TaskBase {
         this.retentionFrequencyMillis = new AtomicLong(Duration.ofMinutes(Config.MINIMUM_RETENTION_FREQUENCY_IN_MINUTES).toMillis());
         this.retentionClock = new AtomicReference<>(System::currentTimeMillis);
         this.eventHelperFuture = new CompletableFuture<>();
-        this.minRetentionValue = new AtomicLong(Config.RETENTION_MIN_VALUE);
-        this.maxRetentionValue = new AtomicLong(Config.RETENTION_MAX_VALUE);
-        this.globalRetentionPolicy = new AtomicBoolean(Config.GLOBAL_RETENTION_POLICY);
-        this.retentionType = new AtomicReference<>(Config.RETENTION_TYPE);
         this.setReady();
     }
 
@@ -788,34 +775,11 @@ public class StreamMetadataTasks extends TaskBase {
                                                                      long createTimestamp, long requestId) {
         log.debug(requestId, "createStream with resource called.");
         OperationContext context = streamMetadataStore.createStreamContext(scope, stream, requestId);
-        if (config.getRetentionPolicy() == null && this.globalRetentionPolicy.get()) {
-            config = createRetentionPolicy(config);
-        }
-        final StreamConfiguration  streamConfig = config;
-        return execute(
-                    new Resource(scope, stream),
-                    new Serializable[]{scope, stream, streamConfig, createTimestamp, requestId},
-                    () -> createStreamBody(scope, stream, streamConfig, createTimestamp, context));
-    }
 
-    private StreamConfiguration createRetentionPolicy(StreamConfiguration config) {
-        Preconditions.checkArgument(this.minRetentionValue.get() > 0, "Min retention value must be > 0.");
-        RetentionPolicy retentionPolicy = null;
-        if (this.retentionType.get() == RetentionPolicy.RetentionType.TIME) {
-            if (this.maxRetentionValue.get() > 0) {
-                retentionPolicy = RetentionPolicy.byTime(Duration.ofMinutes(this.minRetentionValue.get()),
-                        Duration.ofMinutes(this.maxRetentionValue.get()));
-            } else {
-                retentionPolicy = RetentionPolicy.byTime(Duration.ofMinutes(this.minRetentionValue.get()));
-            }
-        } else if (this.retentionType.get() == RetentionPolicy.RetentionType.SIZE) {
-            if (this.maxRetentionValue.get() > 0) {
-                retentionPolicy = RetentionPolicy.bySizeBytes(this.minRetentionValue.get(), this.maxRetentionValue.get());
-            } else {
-                retentionPolicy = RetentionPolicy.bySizeBytes(this.minRetentionValue.get());
-            }
-        }
-        return config.toBuilder().retentionPolicy(retentionPolicy).build();
+            return execute(
+                    new Resource(scope, stream),
+                    new Serializable[]{scope, stream, config, createTimestamp, requestId},
+                    () -> createStreamBody(scope, stream, config, createTimestamp, context));
     }
 
     /**
@@ -2174,14 +2138,6 @@ public class StreamMetadataTasks extends TaskBase {
     @VisibleForTesting
     void setRetentionFrequencyMillis(long timeoutMillis) {
         retentionFrequencyMillis.set(timeoutMillis);
-    }
-
-    @VisibleForTesting
-    void setGlobalRetentionValues(boolean globalPolicy, long minValue, long maxValue, RetentionType type) {
-        globalRetentionPolicy.set(globalPolicy);
-        retentionType.set(type);
-        minRetentionValue.set(minValue);
-        maxRetentionValue.set(maxValue);
     }
 
     @VisibleForTesting

--- a/controller/src/main/java/io/pravega/controller/util/Config.java
+++ b/controller/src/main/java/io/pravega/controller/util/Config.java
@@ -16,7 +16,6 @@
 package io.pravega.controller.util;
 
 import com.google.common.base.Strings;
-import io.pravega.client.stream.RetentionPolicy.RetentionType;
 import io.pravega.common.security.TLSProtocolVersion;
 import io.pravega.common.util.Property;
 import io.pravega.common.util.TypedProperties;
@@ -175,18 +174,6 @@ public final class Config {
     public static final Property<Integer> PROPERTY_RETENTION_BUCKET_COUNT = Property.named(
             "retention.bucket.count", 1, "retention.bucketCount");
 
-    public static final Property<RetentionType> PROPERTY_RETENTION_TYPE = Property.named(
-            "retention.type", RetentionType.TIME, "retention.type");
-
-    public static final Property<Integer> PROPERTY_RETENTION_MIN_VALUE = Property.named(
-            "retention.min.value", Integer.MAX_VALUE, "retention.minVal");
-
-    public static final Property<Integer> PROPERTY_RETENTION_MAX_VALUE = Property.named(
-            "retention.max.value", Integer.MAX_VALUE, "retention.maxVal");
-
-    public static final Property<Boolean> PROPERTY_GLOBAL_RETENTION_POLICY = Property.named(
-            "retention.global.policy.enabled", false, "retention.globalPolicy");
-
     public static final Property<Integer> PROPERTY_RETENTION_THREAD_COUNT = Property.named(
             "retention.thread.count", 1, "retention.threadCount");
 
@@ -291,13 +278,6 @@ public final class Config {
     // Retention Configuration
     public static final int MINIMUM_RETENTION_FREQUENCY_IN_MINUTES;
     public static final int RETENTION_BUCKET_COUNT;
-
-    public static final RetentionType RETENTION_TYPE;
-
-    public static final boolean GLOBAL_RETENTION_POLICY;
-    public static final int RETENTION_MIN_VALUE;
-
-    public static final int RETENTION_MAX_VALUE;
     public static final int RETENTION_THREAD_POOL_SIZE;
 
     // Watermarking Configuration
@@ -381,10 +361,6 @@ public final class Config {
         COMPLETED_TRANSACTION_TTL_IN_HOURS = p.getInt(PROPERTY_TXN_TTL_HOURS);
         MINIMUM_RETENTION_FREQUENCY_IN_MINUTES = p.getInt(PROPERTY_RETENTION_FREQUENCY_MINUTES);
         RETENTION_BUCKET_COUNT = p.getInt(PROPERTY_RETENTION_BUCKET_COUNT);
-        RETENTION_TYPE = p.getEnum(PROPERTY_RETENTION_TYPE, RetentionType.class);
-        RETENTION_MIN_VALUE = p.getInt(PROPERTY_RETENTION_MIN_VALUE);
-        RETENTION_MAX_VALUE = p.getInt(PROPERTY_RETENTION_MAX_VALUE);
-        GLOBAL_RETENTION_POLICY = p.getBoolean(PROPERTY_GLOBAL_RETENTION_POLICY);
         RETENTION_THREAD_POOL_SIZE = p.getInt(PROPERTY_RETENTION_THREAD_COUNT);
         MINIMUM_WATERMARKING_FREQUENCY_IN_SECONDS = p.getInt(PROPERTY_WATERMARKING_FREQUENCY_SECONDS);
         WATERMARKING_BUCKET_COUNT = p.getInt(PROPERTY_WATERMARKING_BUCKET_COUNT);

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -27,7 +27,6 @@ import io.pravega.client.stream.EventStreamWriter;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.RetentionPolicy;
-import io.pravega.client.stream.RetentionPolicy.RetentionType;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
@@ -1100,57 +1099,6 @@ public abstract class StreamMetadataTasksTest {
         assertTrue(truncProp.isUpdating());
         assertTrue(truncProp.getStreamCut().get(0L) == 1L && truncProp.getStreamCut().get(1L) == 1L);
         doCallRealMethod().when(streamStorePartialMock).listSubscribers(any(), any(), any(), any());
-    }
-
-    @Test(timeout = 20000)
-    public void testGlobalRetention() throws Exception {
-        final ScalingPolicy policy = ScalingPolicy.fixed(2);
-        final StreamConfiguration configuration = StreamConfiguration.builder().scalingPolicy(policy)
-                .build();
-        assertNull(configuration.getRetentionPolicy());
-        TaskMetadataStore taskMetadataStore = spy(TaskStoreFactory.createZKStore(zkClient, executor));
-        @Cleanup
-        StreamMetadataTasks metadataTask = new StreamMetadataTasks(streamStorePartialMock, bucketStore, taskMetadataStore,
-                SegmentHelperMock.getSegmentHelperMock(), executor, "host",
-                new GrpcAuthHelper(authEnabled, "key", 300));
-
-        metadataTask.setGlobalRetentionValues(true, 1L, 2L, RetentionType.TIME);
-        metadataTask.createStreamRetryOnLockFailure(SCOPE, "testStream1", configuration, System.currentTimeMillis(), 10, 0L).get();
-        StreamConfiguration streamConfig = streamStorePartialMock.getConfiguration(SCOPE, "testStream1", null, executor).get();
-
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionType(), RetentionType.TIME);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionParam(), Duration.ofMinutes(1L).toMillis());
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionMax(), Duration.ofMinutes(2L).toMillis());
-
-        metadataTask.setGlobalRetentionValues(true, 1L, 0L, RetentionType.TIME);
-        metadataTask.createStreamRetryOnLockFailure(SCOPE, "testStream2", configuration, System.currentTimeMillis(), 10, 0L).get();
-        streamConfig = streamStorePartialMock.getConfiguration(SCOPE, "testStream2", null, executor).get();
-
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionType(), RetentionPolicy.RetentionType.TIME);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionParam(), Duration.ofMinutes(1L).toMillis());
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionMax(), Long.MAX_VALUE);
-
-        metadataTask.setGlobalRetentionValues(true, 1000L, 2000L, RetentionType.SIZE);
-        metadataTask.createStreamRetryOnLockFailure(SCOPE, "testStream3", configuration, System.currentTimeMillis(), 10, 0L).get();
-        streamConfig = streamStorePartialMock.getConfiguration(SCOPE, "testStream3", null, executor).get();
-
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionType(), RetentionPolicy.RetentionType.SIZE);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionParam(), 1000);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionMax(), 2000);
-
-        metadataTask.setGlobalRetentionValues(true, 1000L, 0L, RetentionType.SIZE);
-        metadataTask.createStreamRetryOnLockFailure(SCOPE, "testStream4", configuration, System.currentTimeMillis(), 10, 0L).get();
-        streamConfig = streamStorePartialMock.getConfiguration(SCOPE, "testStream4", null, executor).get();
-
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionType(), RetentionPolicy.RetentionType.SIZE);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionParam(), 1000);
-        assertEquals(streamConfig.getRetentionPolicy().getRetentionMax(), Long.MAX_VALUE);
-
-        metadataTask.setGlobalRetentionValues(false, 0L, 0L, RetentionType.TIME);
-        metadataTask.createStreamRetryOnLockFailure(SCOPE, "testStream5", configuration, System.currentTimeMillis(), 10, 0L).get();
-        streamConfig = streamStorePartialMock.getConfiguration(SCOPE, "testStream5", null, executor).get();
-
-        assertNull(streamConfig.getRetentionPolicy());
     }
 
     @Test(timeout = 30000)


### PR DESCRIPTION
**Change log description**  
Reverts the changes from #7013 as the global retention should not be applied to few streams which are associated with statesynchronizer or revisionclient

**Purpose of the change**  
Fixes #7093 

**What the code does**  
#7089 

**How to verify it**  
#7089 
