### PR TITLE
Issue 7099: Add new admin cli command to save container epoch info

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/AdminCommand.java
@@ -32,6 +32,7 @@ import io.pravega.cli.admin.bookkeeper.BookKeeperLogReconcileCommand;
 import io.pravega.cli.admin.bookkeeper.BookkeeperDeleteLedgersCommand;
 import io.pravega.cli.admin.bookkeeper.ContainerContinuousRecoveryCommand;
 import io.pravega.cli.admin.bookkeeper.ContainerRecoverCommand;
+import io.pravega.cli.admin.bookkeeper.GetContainerEpochsCommand;
 import io.pravega.cli.admin.cluster.GetClusterNodesCommand;
 import io.pravega.cli.admin.cluster.GetSegmentStoreByContainerCommand;
 import io.pravega.cli.admin.cluster.ListContainersCommand;
@@ -387,6 +388,7 @@ public abstract class AdminCommand {
                         .put(ControllerDescribeStreamCommand::descriptor, ControllerDescribeStreamCommand::new)
                         .put(GetClusterNodesCommand::descriptor, GetClusterNodesCommand::new)
                         .put(ListContainersCommand::descriptor, ListContainersCommand::new)
+                        .put(GetContainerEpochsCommand::descriptor, GetContainerEpochsCommand::new)
                         .put(GetSegmentStoreByContainerCommand::descriptor, GetSegmentStoreByContainerCommand::new)
                         .put(PasswordFileCreatorCommand::descriptor, PasswordFileCreatorCommand::new)
                         .put(StorageListSegmentsCommand::descriptor, StorageListSegmentsCommand::new)

--- a/cli/admin/src/main/java/io/pravega/cli/admin/bookkeeper/GetContainerEpochsCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/bookkeeper/GetContainerEpochsCommand.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.cli.admin.bookkeeper;
+
+import io.pravega.cli.admin.AdminCommand;
+import io.pravega.cli.admin.CommandArgs;
+import io.pravega.common.io.FileHelpers;
+import io.pravega.segmentstore.storage.DurableDataLogException;
+import io.pravega.segmentstore.storage.impl.bookkeeper.DebugBookKeeperLogWrapper;
+import lombok.Cleanup;
+import lombok.val;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static io.pravega.cli.admin.utils.FileHelper.createFileAndDirectory;
+
+public class GetContainerEpochsCommand extends BookKeeperCommand {
+
+    /**
+     * Creates a new instance of the GetContainerEpochsCommand.
+     *
+     * @param args The arguments for the command.
+     */
+    public static final String COLON_SEPARATOR = ":";
+    private static final String NEW_LINE_SEPARATOR = "\n";
+    public GetContainerEpochsCommand(CommandArgs args) {
+        super(args);
+    }
+
+    @Override
+    public void execute() throws DurableDataLogException, IOException {
+        ensureArgCount(1);
+
+        final String fileName = getArg(0);
+        @Cleanup
+        val context = createContext();
+        FileHelpers.deleteFileOrDirectory(new File(fileName));
+        @Cleanup
+        FileWriter writer = new FileWriter(createFileAndDirectory(fileName));
+        for (int containerId = 0; containerId < getServiceConfig().getContainerCount(); containerId++) {
+            @Cleanup
+            DebugBookKeeperLogWrapper log = context.logFactory.createDebugLogWrapper(containerId);
+            val m = log.fetchMetadata();
+            if (m != null) {
+                writer.write(containerId + COLON_SEPARATOR + m.getEpoch() + NEW_LINE_SEPARATOR);
+            }
+        }
+        writer.flush();
+        writer.close();
+    }
+
+    public static AdminCommand.CommandDescriptor descriptor() {
+        return new AdminCommand.CommandDescriptor(COMPONENT, "get-container-epochs",
+                "Gets and saves container epochs to the given filename");
+    }
+}

--- a/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/bookkeeper/BookkeeperCommandsTest.java
@@ -43,9 +43,13 @@ import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.net.NetworkInterface;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,6 +59,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * Test basic functionality of Bookkeeper commands.
@@ -273,6 +278,15 @@ public class BookkeeperCommandsTest extends BookKeeperClusterTestCase {
         Assert.assertTrue(TestUtils.executeCommand("bk list-ledgers", STATE.get()).contains("List of ledgers in the system"));
         createLedgerInBookkeeperTestCluster(0);
         Assert.assertTrue(TestUtils.executeCommand("bk list-ledgers", STATE.get()).contains("bookieLogID: 0"));
+    }
+
+    @Test
+    public void testGetContainerEpochsCommand() throws Exception {
+        createLedgerInBookkeeperTestCluster(0);
+        TestUtils.executeCommand("bk get-container-epochs test", STATE.get());
+        File testDataFile = new File("test");
+        Assert.assertTrue(Files.lines(Path.of(testDataFile.toURI()), StandardCharsets.UTF_8)
+                .collect(Collectors.toList()).toString().contains("0:"));
     }
 
     private void createLedgerInBookkeeperTestCluster(int logId) throws Exception {


### PR DESCRIPTION
**Change log description**  
Add a new admin cli command to save container epoch info to the given file. It is required when running recovery from lts to intialize the the containers with latest epoch information.

**Purpose of the change**  
Fixes #7099 

**What the code does**  
Adds a new admin cli command, which is used to save epoch info of containers to the given file.

**How to verify it**  
Open admin cli command prompt
- Run admin cli command `bk get-container-epochs <filename>`
- verify the contents of the file, each line containing `containerId:latestEpoch` 

