### PR TITLE
Add toByte and fromByte methods to SegmentIterator

### DIFF
--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -20,8 +20,10 @@ import io.pravega.client.batch.SegmentIterator;
 import io.pravega.client.batch.SegmentRange;
 import io.pravega.client.batch.StreamSegmentsIterator;
 import io.pravega.client.batch.impl.BatchClientFactoryImpl;
+import io.pravega.client.batch.impl.SegmentIteratorImpl;
 import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
 import io.pravega.client.segment.impl.NoSuchSegmentException;
+import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
@@ -30,6 +32,7 @@ import io.pravega.client.control.impl.ControllerImpl;
 import io.pravega.client.control.impl.ControllerImplConfig;
 import lombok.val;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 /**
@@ -103,4 +106,23 @@ public interface BatchClientFactory extends AutoCloseable {
      * @return A list of segment range in between a start and end stream cut.
      */
     List<SegmentRange> getSegmentRangeBetweenStreamCuts(final StreamCut startStreamCut, final StreamCut endStreamCut);
+
+    /**
+     * Provides a serialized ByteBuffer of the requested segment starting from the
+     * beginning of the segment and ending at the current end of the segment.
+     *
+     * @param segment        The segment to serialize the position.
+     * @param startingOffset A starting offset of the segment.
+     * @param endingOffset   A ending offset of the segment.
+     * @return A serialized ByteBuffer of the requested segment position
+     */
+    ByteBuffer serializedSegmentIteratorPosition(Segment segment, long startingOffset, long endingOffset);
+
+    /**
+     * Provides a SegmentIteratorImpl.SegmentIteratorPosition from the requested ByteBuffer.
+     *
+     * @param serializedPosition ByteBuffer to deserialize the position of the segment.
+     * @return A SegmentIteratorImpl.SegmentIteratorPosition of the requested ByteBuffer.
+     */
+    SegmentIteratorImpl.SegmentIteratorPosition deSerializedSegmentIteratorPosition(ByteBuffer serializedPosition);
 }

--- a/client/src/main/java/io/pravega/client/batch/SegmentIterator.java
+++ b/client/src/main/java/io/pravega/client/batch/SegmentIterator.java
@@ -16,6 +16,9 @@
 package io.pravega.client.batch;
 
 import com.google.common.annotations.Beta;
+import io.pravega.common.util.ByteArraySegment;
+
+import java.nio.ByteBuffer;
 import java.util.Iterator;
 
 /**
@@ -50,5 +53,20 @@ public interface SegmentIterator<T> extends Iterator<T>, AutoCloseable {
      */
     @Override
     void close();
+
+    /**
+     * Deserializes the position from its serialized from obtained from calling {@link #toBytes()}.
+     *
+     * @param serializedPosition A serialized position.
+     * @return The SegmentIterator object.
+     */
+    public  SegmentIterator fromBytes(ByteBuffer serializedPosition) ;
+
+    /**
+     * Serializes the position to a compact byte array.
+     *
+     * @return compact byte array
+     */
+    public ByteBuffer toBytes() ;
 
 }

--- a/client/src/main/java/io/pravega/client/batch/SegmentIterator.java
+++ b/client/src/main/java/io/pravega/client/batch/SegmentIterator.java
@@ -16,9 +16,6 @@
 package io.pravega.client.batch;
 
 import com.google.common.annotations.Beta;
-import io.pravega.common.util.ByteArraySegment;
-
-import java.nio.ByteBuffer;
 import java.util.Iterator;
 
 /**
@@ -53,20 +50,5 @@ public interface SegmentIterator<T> extends Iterator<T>, AutoCloseable {
      */
     @Override
     void close();
-
-    /**
-     * Deserializes the position from its serialized from obtained from calling {@link #toBytes()}.
-     *
-     * @param serializedPosition A serialized position.
-     * @return The SegmentIterator object.
-     */
-    public  SegmentIterator fromBytes(ByteBuffer serializedPosition) ;
-
-    /**
-     * Serializes the position to a compact byte array.
-     *
-     * @return compact byte array
-     */
-    public ByteBuffer toBytes() ;
 
 }

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
@@ -42,6 +42,8 @@ import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.StreamSegmentSuccessors;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.shared.security.auth.AccessOperation;
+
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Optional;
 import java.util.SortedSet;
@@ -174,4 +176,15 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
         return segmentRanges;
     }
 
+    @Override
+    public ByteBuffer serializedSegmentIteratorPosition(Segment segment, long startingOffset, long endingOffset) {
+        log.debug("Start serialize the segment position segment name: {}, startingOffSet: {}, endingOffset: {}", segment.getScopedName(), startingOffset, endingOffset);
+        SegmentIteratorImpl.SegmentIteratorPosition iteratorPosition = new SegmentIteratorImpl.SegmentIteratorPosition(segment, startingOffset, endingOffset);
+        return iteratorPosition.toBytes();
+    }
+
+    @Override
+    public SegmentIteratorImpl.SegmentIteratorPosition deSerializedSegmentIteratorPosition(ByteBuffer serializedPosition) {
+        return SegmentIteratorImpl.SegmentIteratorPosition.fromBytes(serializedPosition);
+    }
 }

--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
@@ -153,7 +153,7 @@ public class SegmentIteratorImpl<T> implements SegmentIterator<T> {
         }
 
         @SneakyThrows(IOException.class)
-        public SegmentIteratorPosition fromBytes(ByteBuffer serializedPosition) {
+        public static SegmentIteratorPosition fromBytes(ByteBuffer serializedPosition) {
             return SERIALIZER.deserialize(new ByteArraySegment(serializedPosition));
         }
 

--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
@@ -22,35 +22,48 @@ import io.pravega.client.segment.impl.NoSuchSegmentException;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.segment.impl.SegmentInputStreamFactory;
 import io.pravega.client.segment.impl.SegmentTruncatedException;
-import io.pravega.client.stream.Serializer;
-import io.pravega.client.stream.TruncatedDataException;
+import io.pravega.client.stream.*;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeoutException;
-
+import io.pravega.common.ObjectBuilder;
+import io.pravega.common.io.serialization.RevisionDataInput;
+import io.pravega.common.io.serialization.RevisionDataOutput;
+import io.pravega.common.io.serialization.VersionedSerializer;
+import io.pravega.common.util.ByteArraySegment;
 import io.pravega.common.util.Retry;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 @Beta
 @Slf4j
 public class SegmentIteratorImpl<T> implements SegmentIterator<T> {
-
+    @Getter
     private final Segment segment;
     private final Serializer<T> deserializer;
     @Getter
     private final long startingOffset;
+    @Getter
     private final long endingOffset;
     private final EventSegmentReader input;
+    @Getter
+    private static SegmentInputStreamFactory factory;
     private final Retry.RetryWithBackoff backoffSchedule = Retry.withExpBackoff(1, 10, 9, 30000);
 
+    private static final SegmentIteratorImpl.SegmentIteratorSerializer SERIALIZER = new SegmentIteratorImpl.SegmentIteratorSerializer();
+
+    @Builder(builderClassName = "SegmentIteratorBuilder")
     public SegmentIteratorImpl(SegmentInputStreamFactory factory, Segment segment,
             Serializer<T> deserializer, long startingOffset, long endingOffset) {
         this.segment = segment;
         this.deserializer = deserializer;
         this.startingOffset = startingOffset;
         this.endingOffset = endingOffset;
+        this.factory=factory;
         input = factory.createEventReaderForSegment(segment, startingOffset, endingOffset);
     }
 
@@ -95,4 +108,47 @@ public class SegmentIteratorImpl<T> implements SegmentIterator<T> {
         input.close();
     }
 
+    static class SegmentIteratorBuilder<T> implements ObjectBuilder<SegmentIteratorImpl> {
+    }
+
+    private static class SegmentIteratorSerializer extends VersionedSerializer.WithBuilder<SegmentIteratorImpl, SegmentIteratorBuilder<Object>> {
+        @Override
+        protected byte getWriteVersion() {
+            return 0;
+        }
+
+        @Override
+        protected void declareVersions() {
+            version(0).revision(0, this::write00, this::read00);
+        }
+
+        @Override
+        protected SegmentIteratorBuilder<Object> newBuilder() {
+            return builder();
+        }
+
+        private void read00(RevisionDataInput revisionDataInput, SegmentIteratorImpl.SegmentIteratorBuilder builder) throws IOException {
+            builder.segment(Segment.fromScopedName(revisionDataInput.readUTF()));
+            builder.startingOffset(revisionDataInput.readCompactLong());
+            builder.endingOffset(revisionDataInput.readCompactLong());
+            builder.factory(factory);
+        }
+
+        private void write00(SegmentIteratorImpl segmentIterator, RevisionDataOutput revisionDataOutput) throws IOException {
+            revisionDataOutput.writeUTF(segmentIterator.segment.getScopedName());
+            revisionDataOutput.writeCompactLong(segmentIterator.getStartingOffset());
+            revisionDataOutput.writeCompactLong(segmentIterator.endingOffset);
+        }
+    }
+    @Override
+    @SneakyThrows(IOException.class)
+    public ByteBuffer toBytes() {
+        ByteArraySegment serialized = SERIALIZER.serialize(this);
+        return ByteBuffer.wrap(serialized.array(), serialized.arrayOffset(), serialized.getLength());
+    }
+    @Override
+    @SneakyThrows(IOException.class)
+    public  SegmentIterator fromBytes(ByteBuffer serializedPosition) {
+        return SERIALIZER.deserialize(new ByteArraySegment(serializedPosition));
+    }
 }

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
@@ -35,8 +35,6 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
-import lombok.Cleanup;
-import org.junit.Test;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
 import static org.junit.Assert.assertEquals;

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
@@ -15,6 +15,7 @@
  */
 package io.pravega.client.batch.impl;
 
+import io.pravega.client.batch.SegmentIterator;
 import io.pravega.client.security.auth.DelegationTokenProviderFactory;
 import io.pravega.client.segment.impl.EndOfSegmentException;
 import io.pravega.client.segment.impl.EventSegmentReader;
@@ -29,7 +30,10 @@ import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.PendingEvent;
 import io.pravega.client.stream.mock.MockSegmentStreamFactory;
 import io.pravega.test.common.AssertExtensions;
+import lombok.Cleanup;
+import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import lombok.Cleanup;
@@ -146,6 +150,30 @@ public class SegmentIteratorTest {
         verify(input, times(2)).read();
         when(input.read()).thenThrow(SegmentTruncatedException.class);
         assertThrows(TruncatedDataException.class, () -> iter.next());
+    }
+
+    @Test(timeout = 5000)
+    public void testSegmentIteratorBytes() {
+        MockSegmentStreamFactory factory = new MockSegmentStreamFactory();
+        Segment segment = new Segment("Scope", "Stream", 1);
+        EventWriterConfig config = EventWriterConfig.builder().build();
+        SegmentOutputStream outputStream = factory.createOutputStreamForSegment(segment, c -> { }, config, DelegationTokenProviderFactory.createWithEmptyToken());
+        sendData("A", outputStream);
+        sendData("B", outputStream);
+
+        @Cleanup
+        SegmentMetadataClient metadataClient = factory.createSegmentMetadataClient(segment, DelegationTokenProviderFactory.createWithEmptyToken());
+        long length = metadataClient.getSegmentInfo().join().getWriteOffset();
+        @Cleanup
+        SegmentIteratorImpl<String> iterator = new SegmentIteratorImpl<>(factory, segment, stringSerializer, 0, length);
+        ByteBuffer byteBuffer = iterator.toBytes();
+        SegmentIteratorImpl segmentIterator =  (SegmentIteratorImpl)iterator.fromBytes(byteBuffer);
+
+        assertEquals(iterator.getSegment().getScopedName(),segmentIterator.getSegment().getScopedName());
+        assertEquals(iterator.getStartingOffset(),segmentIterator.getStartingOffset());
+        assertEquals(iterator.getEndingOffset(),segmentIterator.getEndingOffset());
+        assertEquals(factory,SegmentIteratorImpl.getFactory());
+        assertEquals(iterator.getOffset(),segmentIterator.getOffset());
     }
 
     private void sendData(String data, SegmentOutputStream outputStream) {


### PR DESCRIPTION
**Change log description**  
Adding toBytes and fromBytes method in SegmentIteratorImpl for serialization and deserialization.

**Purpose of the change**  
SegmentIterator should have a fromBytes and a toBytes method for serialize and deserialize the position in segment.

**What the code does**  
it will serialize and deserialize the position in segment.

**How to verify it**  
(Optional: steps to verify that the changes are effective)
