### PR TITLE
Issue 7113: LTS - Save snapshot info to LTS and boot from it in case of migration/recovery.

### DIFF
--- a/client/src/test/java/io/pravega/client/stream/impl/LargeEventWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/LargeEventWriterTest.java
@@ -66,6 +66,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import lombok.Cleanup;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -427,6 +428,7 @@ public class LargeEventWriterTest {
     }
     
     @Test(timeout = 5000)
+    @Ignore("DISABLED FLAKY TEST")
     public void testEventStreamWriter() throws ConnectionFailedException, SegmentSealedException {
         String scope = "scope";
         String streamName = "stream";

--- a/client/src/test/java/io/pravega/client/stream/impl/LargeEventWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/LargeEventWriterTest.java
@@ -66,7 +66,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import lombok.Cleanup;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -84,7 +83,7 @@ public class LargeEventWriterTest {
 
     private final UUID writerId = UUID.randomUUID();
 
-    @Test(timeout = 5000)
+    @Test(timeout = 15000)
     public void testBufferSplitting()
             throws NoSuchSegmentException, AuthenticationException, SegmentSealedException, ConnectionFailedException {
         Segment segment = Segment.fromScopedName("foo/bar/1");
@@ -133,7 +132,7 @@ public class LargeEventWriterTest {
         assertEquals(6 + WireCommands.TYPE_PLUS_LENGTH_SIZE * 3, written.get(3).readableBytes());
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 15000)
     public void testRetries()
             throws ConnectionFailedException, NoSuchSegmentException, AuthenticationException {
         Segment segment = Segment.fromScopedName("foo/bar/1");
@@ -177,7 +176,7 @@ public class LargeEventWriterTest {
 
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 15000)
     public void testThrownErrors() throws ConnectionFailedException {
         Segment segment = Segment.fromScopedName("foo/bar/1");
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
@@ -224,7 +223,7 @@ public class LargeEventWriterTest {
         });
     }
     
-    @Test(timeout = 5000)
+    @Test(timeout = 15000)
     public void testRetriedErrors() throws ConnectionFailedException, NoSuchSegmentException, AuthenticationException, SegmentSealedException {
         Segment segment = Segment.fromScopedName("foo/bar/1");
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
@@ -326,7 +325,7 @@ public class LargeEventWriterTest {
         assertTrue(succeeded.getAndSet(false));
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 15000)
     public void testUnexpectedErrors() throws ConnectionFailedException, NoSuchSegmentException, AuthenticationException, SegmentSealedException {
         Segment segment = Segment.fromScopedName("foo/bar/1");
         MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
@@ -427,8 +426,7 @@ public class LargeEventWriterTest {
         assertTrue(succeeded.getAndSet(false));
     }
     
-    @Test(timeout = 5000)
-    @Ignore("DISABLED FLAKY TEST")
+    @Test(timeout = 15000)
     public void testEventStreamWriter() throws ConnectionFailedException, SegmentSealedException {
         String scope = "scope";
         String streamName = "stream";
@@ -486,7 +484,7 @@ public class LargeEventWriterTest {
         order.verifyNoMoreInteractions();
     }
     
-    @Test(timeout = 5000)
+    @Test(timeout = 15000)
     public void testSegmentSealed() throws ConnectionFailedException, SegmentSealedException {
         String scope = "scope";
         String streamName = "stream";

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/FileSystemIntegrationTest.java
@@ -61,6 +61,7 @@ public class FileSystemIntegrationTest extends BookKeeperIntegrationTestBase {
                                 .garbageCollectionDelay(Duration.ofMillis(10))
                                 .garbageCollectionSleep(Duration.ofMillis(10))
                                 .selfCheckEnabled(true)
+                                .selfCheckForSnapshotEnabled(true)
                                 .build(),
                                 setup.getConfig(FileSystemStorageConfig::builder),
                                 setup.getStorageExecutor()))

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -234,11 +234,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         if (null != chunkedSegmentStorage) {
             val snapshotInfoStore = getStorageSnapshotInfoStore();
             // Bootstrap
-            StorageEventProcessor eventProcessor = new StorageEventProcessor(this.metadata.getContainerId(),
-                    this.containerEventProcessor,
-                    batch -> chunkedSegmentStorage.getGarbageCollector().processBatch(batch),
-                    chunkedSegmentStorage.getConfig().getGarbageCollectionMaxConcurrency());
-            return chunkedSegmentStorage.bootstrap(snapshotInfoStore, eventProcessor);
+            return chunkedSegmentStorage.bootstrap(snapshotInfoStore);
         }
         return CompletableFuture.completedFuture(null);
     }
@@ -316,7 +312,11 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         delayedStart.thenComposeAsync(v -> {
                     val chunkedSegmentStorage = ChunkedSegmentStorage.getReference(this.storage);
                     if (null != chunkedSegmentStorage) {
-                        return chunkedSegmentStorage.finishBootstrap();
+                        StorageEventProcessor eventProcessor = new StorageEventProcessor(this.metadata.getContainerId(),
+                                this.containerEventProcessor,
+                                batch -> chunkedSegmentStorage.getGarbageCollector().processBatch(batch),
+                                chunkedSegmentStorage.getConfig().getGarbageCollectionMaxConcurrency());
+                        return chunkedSegmentStorage.finishBootstrap(eventProcessor);
                     }
                     return CompletableFuture.completedFuture(null);
                 }, this.executor)

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorage.java
@@ -213,21 +213,22 @@ public class ChunkedSegmentStorage implements Storage, StatsReporter {
      * Initializes the ChunkedSegmentStorage and bootstrap the metadata about storage metadata segments by reading and processing the journal.
      *
      * @param snapshotInfoStore Store that saves {@link SnapshotInfo}.
-     * @param taskQueue  Task queue to use for garbage collection.
      */
-    public CompletableFuture<Void> bootstrap(SnapshotInfoStore snapshotInfoStore, AbstractTaskQueueManager<GarbageCollector.TaskInfo> taskQueue) {
+    public CompletableFuture<Void> bootstrap(SnapshotInfoStore snapshotInfoStore) {
 
         this.logPrefix = String.format("ChunkedSegmentStorage[%d]", containerId);
-        this.taskQueue = taskQueue;
         // Now bootstrap
         return this.systemJournal.bootstrap(epoch, snapshotInfoStore);
     }
 
     /**
      * Concludes and finalizes the boostrap.
+     *
+     * @param taskQueue  Task queue to use for garbage collection.
      * @return
      */
-    public CompletableFuture<Void> finishBootstrap() {
+    public CompletableFuture<Void> finishBootstrap(AbstractTaskQueueManager<GarbageCollector.TaskInfo> taskQueue) {
+        this.taskQueue = taskQueue;
         return garbageCollector.initialize(taskQueue);
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
@@ -66,6 +66,7 @@ public class ChunkedSegmentStorageConfig {
     public static final Property<Integer> SELF_CHECK_LATE_WARNING_THRESHOLD = Property.named("self.check.late", 100);
     public static final Property<Boolean> SELF_CHECK_DATA_INTEGRITY = Property.named("self.check.integrity.data", false);
     public static final Property<Boolean> SELF_CHECK_METADATA_INTEGRITY = Property.named("self.check.integrity.metadata", false);
+    public static final Property<Boolean> SELF_CHECK_SNAPSHOT_INTEGRITY = Property.named("self.check.integrity.snapshot", false);
 
     public static final Property<Long> MAX_SAFE_SIZE = Property.named("safe.size.bytes.max", Long.MAX_VALUE);
     public static final Property<Boolean> ENABLE_SAFE_SIZE_CHECK = Property.named("safe.size.check.enable", true);
@@ -301,6 +302,12 @@ public class ChunkedSegmentStorageConfig {
     final private boolean selfCheckForMetadataEnabled;
 
     /**
+     * When enabled, SLTS will perform extra validation for snapshot.
+     */
+    @Getter
+    final private boolean selfCheckForSnapshotEnabled;
+
+    /**
      * Maximum storage size in bytes below which operations are considered safe.
      * Above this value any non-critical writes are not allowed.
      */
@@ -349,6 +356,7 @@ public class ChunkedSegmentStorageConfig {
         this.selfCheckEnabled = properties.getBoolean(SELF_CHECK_ENABLED);
         this.selfCheckForDataEnabled = properties.getBoolean(SELF_CHECK_DATA_INTEGRITY);
         this.selfCheckForMetadataEnabled = properties.getBoolean(SELF_CHECK_METADATA_INTEGRITY);
+        this.selfCheckForSnapshotEnabled = properties.getBoolean(SELF_CHECK_SNAPSHOT_INTEGRITY);
         this.indexBlockSize = properties.getPositiveLong(READ_INDEX_BLOCK_SIZE);
         this.maxEntriesInTxnBuffer = properties.getPositiveInt(MAX_METADATA_ENTRIES_IN_BUFFER);
         this.maxEntriesInCache = properties.getPositiveInt(MAX_METADATA_ENTRIES_IN_CACHE);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SnapshotInfo.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SnapshotInfo.java
@@ -15,8 +15,14 @@
  */
 package io.pravega.segmentstore.storage.chunklayer;
 
+import io.pravega.common.ObjectBuilder;
+import io.pravega.common.io.serialization.RevisionDataInput;
+import io.pravega.common.io.serialization.RevisionDataOutput;
+import io.pravega.common.io.serialization.VersionedSerializer;
 import lombok.Builder;
 import lombok.Data;
+
+import java.io.IOException;
 
 /**
  * Basic info about snapshot.
@@ -33,4 +39,40 @@ public class SnapshotInfo {
      * Id of the snapshot.
      */
     final private long snapshotId;
+
+    /**
+     * Builder that implements {@link ObjectBuilder}.
+     */
+    public static class SnapshotInfoBuilder implements ObjectBuilder<SnapshotInfo> {
+    }
+
+    /**
+     * Serializer that implements {@link VersionedSerializer}.
+     */
+    public static class Serializer extends VersionedSerializer.WithBuilder<SnapshotInfo, SnapshotInfoBuilder> {
+        @Override
+        protected SnapshotInfo.SnapshotInfoBuilder newBuilder() {
+            return SnapshotInfo.builder();
+        }
+
+        @Override
+        protected byte getWriteVersion() {
+            return 0;
+        }
+
+        @Override
+        protected void declareVersions() {
+            version(0).revision(0, this::write00, this::read00);
+        }
+
+        private void write00(SnapshotInfo object, RevisionDataOutput output) throws IOException {
+            output.writeCompactLong(object.epoch);
+            output.writeCompactLong(object.snapshotId);
+        }
+
+        private void read00(RevisionDataInput input, SnapshotInfo.SnapshotInfoBuilder b) throws IOException {
+            b.epoch(input.readCompactLong());
+            b.snapshotId(input.readCompactLong());
+        }
+    }
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -617,14 +617,14 @@ public class SystemJournal {
                                     if (null != e) {
                                         val ex = Exceptions.unwrap(e);
                                         if (ex instanceof StorageNotPrimaryException) {
-                                            log.warn("SystemJournal[{}] Error while snapshot info to file {}. info = {}", containerId, snapshotInfoFileName, info, e);
+                                            log.warn("SystemJournal[{}] Error while saving snapshot info to file {}. info = {}", containerId, snapshotInfoFileName, info, e);
                                             throw new CompletionException(e);
                                         }
                                         if (attempts.incrementAndGet() > config.getMaxJournalWriteAttempts()) {
-                                            log.warn("SystemJournal[{}] Error while  snapshot info to LTS. File = {}. info = {}", containerId, snapshotInfoFileName, info, e);
+                                            log.warn("SystemJournal[{}] Error while saving snapshot info to LTS. File = {}. info = {}", containerId, snapshotInfoFileName, info, e);
                                             throw new CompletionException(e);
                                         }
-                                        log.warn("SystemJournal[{}] Error while  snapshot info to LTS. File = {}. info = {}", containerId, snapshotInfoFileName, info, e);
+                                        log.warn("SystemJournal[{}] Error while saving snapshot info to LTS. File = {}. info = {}", containerId, snapshotInfoFileName, info, e);
                                     } else {
                                         // No exception we are done
                                         log.info("SystemJournal[{}] Snapshot info saved successfully. info = {}", containerId, info);

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -585,7 +585,7 @@ public class SystemJournal {
                                         return readSnapshotInfoFromFile()
                                                 .thenComposeAsync( existingSnapshot -> {
                                                     if (existingSnapshot.getEpoch() > epoch) {
-                                                        return CompletableFuture.failedFuture(new StorageNotPrimaryException(""));
+                                                        return CompletableFuture.failedFuture(new StorageNotPrimaryException(String.format("SystemJournal[{}] Unexpected snapshot. Expected = {} actual = {}", info, existingSnapshot)));
                                                     } else {
                                                         return chunkStorage.delete(ChunkHandle.writeHandle(snapshotInfoFileName));
                                                     }
@@ -712,7 +712,7 @@ public class SystemJournal {
                     if (ex instanceof ChunkNotFoundException) {
                         log.info(String.format("Chunk containing SnapshotInfo does not exist. This is ok if this is new installation. Chunk name = %s", snapshotInfoFileName));
                     } else {
-                        log.warn(String.format("Chunk containing could not be read. chunk name = %s", snapshotInfoFileName), ex);
+                        log.warn(String.format("Chunk containing SnapshotInfo could not be read. Chunk name = %s", snapshotInfoFileName), ex);
                     }
                     return null;
                 })

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -25,6 +25,7 @@ import io.pravega.common.io.serialization.RevisionDataInput;
 import io.pravega.common.io.serialization.RevisionDataOutput;
 import io.pravega.common.io.serialization.VersionedSerializer;
 import io.pravega.common.util.ByteArraySegment;
+import io.pravega.segmentstore.storage.StorageNotPrimaryException;
 import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
 import io.pravega.segmentstore.storage.metadata.ChunkMetadataStore;
 import io.pravega.segmentstore.storage.metadata.MetadataTransaction;
@@ -97,6 +98,11 @@ public class SystemJournal {
      * Serializer for {@link SystemJournal.SystemSnapshotRecord}.
      */
     private static final SystemSnapshotRecord.Serializer SYSTEM_SNAPSHOT_SERIALIZER = new SystemSnapshotRecord.Serializer();
+
+    /**
+     * Serializer for {@link SnapshotInfo}.
+     */
+    private static final SnapshotInfo.Serializer SNAPSHOT_INFO_SERIALIZER = new SnapshotInfo.Serializer();
 
     @Getter
     private final ChunkStorage chunkStorage;
@@ -540,7 +546,8 @@ public class SystemJournal {
                             .epoch(epoch)
                             .build();
                     return snapshotInfoStore.writeSnapshotInfo(info)
-                            .thenAcceptAsync(v1 -> {
+                            .thenComposeAsync(v1 -> writeSnapshotInfoToFile(info), executor)
+                            .thenAcceptAsync(v2 -> {
                                 val oldSnapshotInfo = lastSavedSnapshotInfo.get();
                                 log.info("SystemJournal[{}] Snapshot info saved.{}", containerId, info);
                                 lastSavedSnapshotInfo.set(info);
@@ -552,10 +559,84 @@ public class SystemJournal {
                                 pendingGarbageChunks.clear();
                             }, executor)
                             .exceptionally(e -> {
-                                log.error("Unable to persist snapshot info.{}", currentSnapshotIndex, e);
+                                log.error("SystemJournal[{}] Unable to persist snapshot info.{}", containerId, currentSnapshotIndex, e);
                                 return null;
                             });
                 }, executor);
+    }
+
+    /**
+     * Writes SnapshotInfo to a well known file.
+     */
+    private CompletableFuture<Void> writeSnapshotInfoToFile(SnapshotInfo info) {
+        val snapshotInfoFileName = NameUtils.getSystemJournalSnapshotInfoFileName(containerId);
+        try {
+            val isDone = new AtomicBoolean(false);
+            val attempts = new AtomicInteger();
+            val bytes = SNAPSHOT_INFO_SERIALIZER.serialize(info);
+
+            return Futures.loop(
+                    () -> !isDone.get(),
+                    () -> {
+                        return chunkStorage.exists(snapshotInfoFileName)
+                                .thenComposeAsync( exists -> {
+                                    if (exists) {
+                                        // Read back and make sure higher epoch has not already written it
+                                        return readSnapshotInfoFromFile()
+                                                .thenComposeAsync( existingSnapshot -> {
+                                                    if (existingSnapshot.getEpoch() > epoch) {
+                                                        return CompletableFuture.failedFuture(new StorageNotPrimaryException(""));
+                                                    } else {
+                                                        return chunkStorage.delete(ChunkHandle.writeHandle(snapshotInfoFileName));
+                                                    }
+                                                }, executor);
+                                    } else {
+                                        return CompletableFuture.completedFuture(null);
+                                    }
+                                }, executor)
+                                .thenComposeAsync(v -> chunkStorage.createWithContent(snapshotInfoFileName,
+                                                bytes.getLength(),
+                                                new ByteArrayInputStream(bytes.array(), bytes.arrayOffset(), bytes.getLength())),
+                                        executor)
+                                .thenAcceptAsync(v -> {
+                                    log.debug("SystemJournal[{}] Snapshot info saved to LTS. File {}. info = {}", containerId, snapshotInfoFileName, info);
+                                }, executor)
+                                .thenComposeAsync(v -> readSnapshotInfoFromFile(), executor)
+                                .thenApplyAsync( readBackInfo -> {
+                                    if (readBackInfo.getEpoch() > epoch) {
+                                        return CompletableFuture.failedFuture(
+                                                new StorageNotPrimaryException(String.format("SystemJournal[{}] Unexpected snapshot. Expected = {} actual = {}", info, readBackInfo)));
+                                    }
+                                    if (!info.equals(readBackInfo)) {
+                                        return CompletableFuture.failedFuture(
+                                                new IllegalStateException(String.format("SystemJournal[{}] Unexpected snapshot. Expected = {} actual = {}", info, readBackInfo)));
+                                    }
+                                    return CompletableFuture.completedFuture(null);
+                                }, executor)
+                                .handleAsync((v, e) -> {
+                                    if (null != e) {
+                                        val ex = Exceptions.unwrap(e);
+                                        if (ex instanceof StorageNotPrimaryException) {
+                                            log.warn("SystemJournal[{}] Error while snapshot info to file {}. info = {}", containerId, snapshotInfoFileName, info, e);
+                                            throw new CompletionException(e);
+                                        }
+                                        if (attempts.incrementAndGet() > config.getMaxJournalWriteAttempts()) {
+                                            log.warn("SystemJournal[{}] Error while  snapshot info to LTS. File = {}. info = {}", containerId, snapshotInfoFileName, info, e);
+                                            throw new CompletionException(e);
+                                        }
+                                        log.warn("SystemJournal[{}] Error while  snapshot info to LTS. File = {}. info = {}", containerId, snapshotInfoFileName, info, e);
+                                    } else {
+                                        // No exception we are done
+                                        log.info("SystemJournal[{}] Snapshot info saved successfully. info = {}", containerId, info);
+                                        isDone.set(true);
+                                    }
+                                    return null;
+                                }, executor);
+                    }, executor);
+
+        } catch (IOException e) {
+            return CompletableFuture.failedFuture(new ChunkStorageException(snapshotInfoFileName, "Unable to serialize", e));
+        }
     }
 
     /**
@@ -563,25 +644,89 @@ public class SystemJournal {
      */
     private CompletableFuture<SystemSnapshotRecord> findLatestSnapshot() {
         // Step 1: Read snapshot info.
-        return snapshotInfoStore.readSnapshotInfo()
-                .thenComposeAsync(snapshotInfo -> {
-                    if (null != snapshotInfo) {
-                        val snapshotFileName = NameUtils.getSystemJournalSnapshotFileName(containerId, snapshotInfo.getEpoch(), snapshotInfo.getSnapshotId());
-                        log.debug("SystemJournal[{}] Snapshot info read. {} pointing to {}", containerId, snapshotInfo, snapshotFileName);
+        return readSnapshotInfo()
+            .thenComposeAsync(snapshotInfo -> {
+                if (null != snapshotInfo) {
+                    val snapshotFileName = NameUtils.getSystemJournalSnapshotFileName(containerId, snapshotInfo.getEpoch(), snapshotInfo.getSnapshotId());
+                    log.debug("SystemJournal[{}] Snapshot info read. {} pointing to {}", containerId, snapshotInfo, snapshotFileName);
 
-                        // Step 2: Validate and Read contents.
-                        return getContents(snapshotFileName, false)
-                                // Step 3: Deserialize and return.
-                                .thenApplyAsync(contents -> readSnapshotRecord(snapshotInfo, contents), executor)
-                                .exceptionally(e -> {
-                                    throw new CompletionException(new IllegalStateException(
-                                            String.format("Chunk pointed by SnapshotInfo could not be read. chunk name = %s", snapshotFileName),
-                                            Exceptions.unwrap(e)));
-                                });
+                    // Step 2: Validate and Read contents.
+                    return getContents(snapshotFileName, false)
+                            // Step 3: Deserialize and return.
+                            .thenApplyAsync(contents -> readSnapshotRecord(snapshotInfo, contents), executor)
+                            .exceptionally(e -> {
+                                throw new CompletionException(new IllegalStateException(
+                                        String.format("Chunk pointed by SnapshotInfo could not be read. chunk name = %s", snapshotFileName),
+                                        Exceptions.unwrap(e)));
+                            });
+                } else {
+                    log.info("SystemJournal[{}] No Snapshot info available. This is ok if this is new installation", containerId);
+                    return CompletableFuture.completedFuture(null);
+                }
+            }, executor);
+    }
+
+    /**
+     * Read snapshot info.
+     */
+    private CompletableFuture<SnapshotInfo> readSnapshotInfo() {
+        log.info("SystemJournal[{}] reading snapshot info from store.", containerId);
+        return snapshotInfoStore.readSnapshotInfo()
+            .thenComposeAsync(snapshotInfoFromStore -> {
+                if (config.isSelfCheckForSnapshotEnabled() || null == snapshotInfoFromStore) {
+                    log.info("SystemJournal[{}] Read Snapshot info from store. Info = {}", containerId, snapshotInfoFromStore);
+                    return readSnapshotInfoFromFile()
+                            .thenComposeAsync( snapshotInfoFromFile -> {
+                                if ( null == snapshotInfoFromFile ) {
+                                    log.info("SystemJournal[{}] No Snapshot info available from storage. This is ok if this is new installation", containerId);
+                                    return CompletableFuture.completedFuture(snapshotInfoFromStore);
+                                } else {
+                                    if (snapshotInfoFromStore != null) {
+                                        if (!snapshotInfoFromStore.equals(snapshotInfoFromFile)) {
+                                            log.warn("SystemJournal[{}] Snapshot info from store should match one from file. File = {}, Store = {}", containerId, snapshotInfoFromFile, snapshotInfoFromStore);
+                                        } else {
+                                            log.debug("SystemJournal[{}] readSnapshotInfo. File = {}, Store = {}", containerId, snapshotInfoFromFile, snapshotInfoFromStore);
+                                        }
+                                    } else {
+                                        log.info("SystemJournal[{}] Using Snapshot info available from LTS instead of store. This is ok if this first boot after migration",
+                                                containerId);
+                                    }
+                                    return CompletableFuture.completedFuture(snapshotInfoFromFile);
+                                }
+
+                            }, executor);
+                } else {
+                    return CompletableFuture.completedFuture(snapshotInfoFromStore);
+                }
+            }, executor);
+    }
+
+    /**
+     * Read snapshot info from file.
+     */
+    private CompletableFuture<SnapshotInfo> readSnapshotInfoFromFile() {
+        val snapshotInfoFileName = NameUtils.getSystemJournalSnapshotInfoFileName(containerId);
+        return getContents(snapshotInfoFileName, false)
+                .exceptionally(e -> {
+                    val ex = Exceptions.unwrap(e);
+                    if (ex instanceof ChunkNotFoundException) {
+                        log.info(String.format("Chunk containing SnapshotInfo does not exist. This is ok if this is new installation. Chunk name = %s", snapshotInfoFileName));
                     } else {
-                        log.info("SystemJournal[{}] No Snapshot info available. This is ok if this is new installation", containerId);
-                        return CompletableFuture.completedFuture(null);
+                        log.warn(String.format("Chunk containing could not be read. chunk name = %s", snapshotInfoFileName), ex);
                     }
+                    return null;
+                })
+                .thenApplyAsync(contents -> {
+                    if (contents != null) {
+                        log.debug("SystemJournal[{}] reading snapshot info from LTS file {}", containerId, snapshotInfoFileName);
+                        try {
+                            val snapshotInfo = SNAPSHOT_INFO_SERIALIZER.deserialize(contents);
+                            return snapshotInfo;
+                        } catch (Exception e) {
+                            log.error("SystemJournal[{}] Error while reading snapshot info {}", containerId, e);
+                        }
+                    }
+                    return null;
                 }, executor);
     }
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -617,7 +617,7 @@ public class SystemJournal {
                                     if (null != e) {
                                         val ex = Exceptions.unwrap(e);
                                         if (ex instanceof StorageNotPrimaryException) {
-                                            log.warn("SystemJournal[{}] Error while saving snapshot info to file {}. info = {}", containerId, snapshotInfoFileName, info, e);
+                                            log.warn("SystemJournal[{}] Error while saving snapshot info to LTS {}. info = {}", containerId, snapshotInfoFileName, info, e);
                                             throw new CompletionException(e);
                                         }
                                         if (attempts.incrementAndGet() > config.getMaxJournalWriteAttempts()) {

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/FlakyChunkStorage.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/FlakyChunkStorage.java
@@ -80,12 +80,7 @@ public class FlakyChunkStorage extends BaseChunkStorage {
         // Apply any interceptors with identifier 'doWrite.before' or 'doWrite.after'
         interceptor.intercept(chunkName, "doWrite.before");
         // Make sure you are calling methods on super class.
-        ChunkHandle handle = innerChunkStorage.doCreate(chunkName);
-        int bytesWritten = innerChunkStorage.doWrite(handle, 0, length, data);
-        if (bytesWritten < length) {
-            innerChunkStorage.doDelete(ChunkHandle.writeHandle(chunkName));
-            throw new ChunkStorageException(chunkName, "doCreateWithContent - invalid length returned");
-        }
+        val handle = innerChunkStorage.doCreateWithContent(chunkName, length, data);
         interceptor.intercept(chunkName, "doWrite.after");
         return handle;
     }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalOperationsTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalOperationsTests.java
@@ -208,6 +208,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
                 .maxJournalUpdatesPerSnapshot(2)
                 .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
+                .selfCheckForSnapshotEnabled(true)
                 .build());
 
         val testSegmentName = testContext.segmentNames[0];
@@ -287,6 +288,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
                 .maxJournalUpdatesPerSnapshot(3)
                 .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
+                .selfCheckForSnapshotEnabled(true)
                 .build());
 
         val testSegmentName = testContext.segmentNames[0];
@@ -385,6 +387,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
                 .maxJournalUpdatesPerSnapshot(2)
                 .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
+                .selfCheckForSnapshotEnabled(true)
                 .build());
 
         val testSegmentName = testContext.segmentNames[0];
@@ -461,6 +464,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
                 .maxJournalUpdatesPerSnapshot(2)
                 .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
+                .selfCheckForSnapshotEnabled(true)
                 .build());
         val testSegmentName = testContext.segmentNames[0];
         testScenario(testContext, getSimpleScenarioActions(testContext, testSegmentName));
@@ -549,6 +553,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
                         .maxJournalUpdatesPerSnapshot(2)
                         .garbageCollectionDelay(Duration.ZERO)
                         .selfCheckEnabled(true)
+                        .selfCheckForSnapshotEnabled(true)
                         .build());
                 val testSegmentName = testContext.segmentNames[0];
                 val truncateAt = i * maxChunkSize + j;
@@ -583,6 +588,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
                 .maxJournalUpdatesPerSnapshot(2)
                 .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
+                .selfCheckForSnapshotEnabled(true)
                 .build());
         val testSegmentName = testContext.segmentNames[0];
         val sizes = new int[chunkCount];
@@ -611,6 +617,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
                 .maxJournalUpdatesPerSnapshot(maxJournalUpdatesPerSnapshot)
                 .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
+                .selfCheckForSnapshotEnabled(true)
                 .build();
     }
 
@@ -1089,6 +1096,7 @@ public class SystemJournalOperationsTests extends ThreadPooledTestSuite {
         ChunkedSegmentStorageConfig config = ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .garbageCollectionDelay(Duration.ZERO)
                 .selfCheckEnabled(true)
+                .selfCheckForSnapshotEnabled(true)
                 .build();
         ChunkStorage chunkStorage;
         HashMap<String, ArrayList<ExpectedChunkInfo>> expectedChunks = new HashMap<>();

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalRecordsTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalRecordsTests.java
@@ -427,4 +427,26 @@ public class SystemJournalRecordsTests {
         }
     }
 
+    @Test
+    public void testSystemSnapshotInfoSerialization() throws Exception {
+        testSystemSnapshotInfoSerialization(SnapshotInfo.builder()
+                .build());
+        testSystemSnapshotInfoSerialization(SnapshotInfo.builder()
+                .snapshotId(1)
+                .build());
+        testSystemSnapshotInfoSerialization(SnapshotInfo.builder()
+                .epoch(2)
+                .build());
+        testSystemSnapshotInfoSerialization(SnapshotInfo.builder()
+                .snapshotId(3)
+                .epoch(4)
+                .build());
+    }
+
+    private void testSystemSnapshotInfoSerialization(SnapshotInfo original) throws Exception {
+        val serializer = new SnapshotInfo.Serializer();
+        val bytes = serializer.serialize(original);
+        val obj = serializer.deserialize(bytes);
+        Assert.assertEquals(original, obj);
+    }
 }

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -31,11 +31,13 @@ import io.pravega.shared.NameUtils;
 import io.pravega.test.common.AssertExtensions;
 import io.pravega.test.common.ThreadPooledTestSuite;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.Vector;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import lombok.Cleanup;
 import lombok.val;
@@ -703,6 +705,156 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
             Assert.assertTrue(Exceptions.unwrap(e) instanceof IllegalStateException
                     && ex.getMessage().contains("Chunk pointed by SnapshotInfo could not be read"));
         }
+    }
+
+    @Test
+    public void testSimpleBootstrapWithOneFailoverForAutoRecovery() throws Exception {
+        int containerId = 42;
+        val data = new InMemorySnapshotInfoStore();
+        int maxLength = 8;
+        val policy = new SegmentRollingPolicy(maxLength);
+        val config = getDefaultConfigBuilder(policy)
+                .maxJournalUpdatesPerSnapshot(1) // Force snapshot
+                .selfCheckForSnapshotEnabled(true)
+                .build();
+        @Cleanup
+        ChunkStorage chunkStorage = getChunkStorage();
+
+        testSimpleBootstrapWithOneFailoverWithFaultInjection(containerId, config, chunkStorage, data, epoch -> {
+            InMemorySnapshotInfoStore.clear();
+        });
+    }
+
+    @Test
+    public void testMissingSnapshotInfoFileWithNoAutoRecovery() throws Exception {
+        int containerId = 42;
+        val data = new InMemorySnapshotInfoStore();
+        int maxLength = 8;
+        val policy = new SegmentRollingPolicy(maxLength);
+        val config = getDefaultConfigBuilder(policy)
+                .maxJournalUpdatesPerSnapshot(1) // Force snapshot
+                .selfCheckForSnapshotEnabled(true)
+                .build();
+        @Cleanup
+        ChunkStorage chunkStorage = getChunkStorage();
+
+        testSimpleBootstrapWithOneFailoverWithFaultInjection(containerId, config, chunkStorage, data, epoch -> {
+            chunkStorage.delete(ChunkHandle.writeHandle(NameUtils.getSystemJournalSnapshotInfoFileName(containerId)));
+        });
+    }
+
+    /**
+     * Test when there are errors while writing snapshot info file. number of failures is lesser than max attempts.
+     *
+     * @throws Exception Exception if any.
+     */
+    @Test
+    public void testAutoRecoveryWithFlakyWrites() throws Exception {
+        testSimpleBootstrapWithOneFailoverForAutoRecoveryWithFlakyWrites(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxJournalWriteAttempts() / 2 );
+    }
+
+    /**
+     * Test when there are errors while writing snapshot info file. number of failures is greater than max attempts.
+     *
+     * @throws Exception Exception if any.
+     */
+    @Test
+    public void testAutoRecoveryWithFlakyWritesRetryExhausted() throws Exception {
+        testSimpleBootstrapWithOneFailoverForAutoRecoveryWithFlakyWrites(ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxJournalWriteAttempts() + 2);
+    }
+
+    public void testSimpleBootstrapWithOneFailoverForAutoRecoveryWithFlakyWrites(int failureCount) throws Exception {
+        int containerId = 42;
+        val data = new InMemorySnapshotInfoStore();
+        int maxLength = 8;
+        val policy = new SegmentRollingPolicy(maxLength);
+        val config = getDefaultConfigBuilder(policy)
+                .maxJournalUpdatesPerSnapshot(1) // Force snapshot
+                .selfCheckForSnapshotEnabled(true)
+                .build();
+
+        @Cleanup
+        ChunkStorage chunkStorage = getChunkStorage();
+        AtomicInteger callCount = new AtomicInteger();
+        FlakyChunkStorage flakyChunkStorage = new FlakyChunkStorage((BaseChunkStorage) chunkStorage, executorService());
+        flakyChunkStorage.getInterceptor().getFlakyPredicates().add(FlakinessPredicate.builder()
+                .method("doWrite.before")
+                .matchPredicate(n -> callCount.incrementAndGet() < failureCount)
+                .matchRegEx(NameUtils.getSystemJournalSnapshotInfoFileName(containerId))
+                .action(() -> {
+                    throw new IOException("Intentional");
+                })
+                .build());
+        testSimpleBootstrapWithOneFailoverWithFaultInjection(containerId, config, flakyChunkStorage, data, epoch -> {
+            InMemorySnapshotInfoStore.clear();
+        });
+    }
+
+    public void testSimpleBootstrapWithOneFailoverWithFaultInjection(int containerId,
+                                                                     ChunkedSegmentStorageConfig config,
+                                                                     ChunkStorage chunkStorage,
+                                                                     InMemorySnapshotInfoStore data,
+                                                                     Consumer<Long> faultInjection) throws Exception {
+        @Cleanup
+        ChunkMetadataStore metadataStoreBeforeCrash = getMetadataStore();
+        @Cleanup
+        ChunkMetadataStore metadataStoreAfterCrash = getMetadataStore();
+
+        String systemSegmentName = SystemJournal.getChunkStorageSystemSegments(containerId)[0];
+        long epoch = 1;
+        val snapshotInfoStore = new SnapshotInfoStore(containerId,
+                snapshotId -> data.setSnapshotId(containerId, snapshotId),
+                () -> data.getSnapshotId(containerId));
+
+        // Init
+        long offset = 0;
+
+        // Start container with epoch 1
+        @Cleanup
+        ChunkedSegmentStorage segmentStorage1 = new ChunkedSegmentStorage(containerId, chunkStorage, metadataStoreBeforeCrash, executorService(), config);
+
+        segmentStorage1.initialize(epoch);
+        segmentStorage1.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
+
+        // Bootstrap
+        segmentStorage1.bootstrap(snapshotInfoStore).join();
+        deleteGarbage(segmentStorage1);
+        checkSystemSegmentsLayout(segmentStorage1);
+
+        // Simulate some writes to system segment, this should cause some new chunks being added.
+        val h = segmentStorage1.openWrite(systemSegmentName).join();
+        val b1 = "Hello".getBytes();
+        segmentStorage1.write(h, offset, new ByteArrayInputStream(b1), b1.length, null).join();
+        offset += b1.length;
+        val b2 = " World".getBytes();
+        segmentStorage1.write(h, offset, new ByteArrayInputStream(b2), b2.length, null).join();
+        offset += b2.length;
+
+        // Step 2
+        // Start container with epoch 2
+        epoch++;
+
+        if (null != faultInjection) {
+            faultInjection.accept(epoch);
+        }
+
+        @Cleanup
+        ChunkedSegmentStorage segmentStorage2 = new ChunkedSegmentStorage(containerId, chunkStorage, metadataStoreAfterCrash, executorService(), config);
+        segmentStorage2.initialize(epoch);
+        segmentStorage2.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
+
+        // Bootstrap
+        segmentStorage2.bootstrap(snapshotInfoStore).join();
+        deleteGarbage(segmentStorage2);
+        checkSystemSegmentsLayout(segmentStorage2);
+
+        // Validate
+        val info = segmentStorage2.getStreamSegmentInfo(systemSegmentName, null).join();
+        Assert.assertEquals(b1.length + b2.length, info.getLength());
+        byte[] out = new byte[b1.length + b2.length];
+        val hr = segmentStorage2.openRead(systemSegmentName).join();
+        segmentStorage2.read(hr, 0, out, 0, b1.length + b2.length, null).join();
+        Assert.assertEquals("Hello World", new String(out));
     }
 
     /**

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -90,6 +90,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
     private ChunkedSegmentStorageConfig.ChunkedSegmentStorageConfigBuilder getDefaultConfigBuilder(SegmentRollingPolicy policy) {
         return ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
                 .selfCheckEnabled(true)
+                .selfCheckForSnapshotEnabled(true)
                 .garbageCollectionDelay(Duration.ZERO)
                 .storageMetadataRollingPolicy(policy);
     }
@@ -263,7 +264,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
 
         segmentStorage.initialize(epoch);
         segmentStorage.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
-        segmentStorage.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage);
         segmentStorage.create("test", null).get();
 
@@ -320,7 +321,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage1.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
         // Bootstrap
-        segmentStorage1.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage1.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage1);
         checkSystemSegmentsLayout(segmentStorage1);
 
@@ -343,7 +344,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage2.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
         // Bootstrap
-        segmentStorage2.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage2.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage2);
         checkSystemSegmentsLayout(segmentStorage2);
 
@@ -391,7 +392,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage1.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
         // Bootstrap
-        segmentStorage1.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage1.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage1);
         checkSystemSegmentsLayout(segmentStorage1);
 
@@ -412,7 +413,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage2.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
         // Bootstrap
-        segmentStorage2.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage2.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage2);
         checkSystemSegmentsLayout(segmentStorage2);
 
@@ -470,7 +471,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage1.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
         // Bootstrap
-        segmentStorage1.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage1.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage1);
         checkSystemSegmentsLayout(segmentStorage1);
 
@@ -494,7 +495,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage2.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
         // Bootstrap
-        segmentStorage2.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage2.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage2);
         checkSystemSegmentsLayout(segmentStorage2);
 
@@ -543,7 +544,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage1.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
         // Bootstrap
-        segmentStorage1.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage1.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage1);
         checkSystemSegmentsLayout(segmentStorage1);
 
@@ -577,7 +578,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage2.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
         // Bootstrap
-        segmentStorage2.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage2.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage2);
         checkSystemSegmentsLayout(segmentStorage2);
 
@@ -635,7 +636,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
             segmentStorageInLoop.initialize(epoch);
             segmentStorageInLoop.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
-            segmentStorageInLoop.bootstrap(snapshotInfoStore, null).join();
+            segmentStorageInLoop.bootstrap(snapshotInfoStore).join();
             deleteGarbage(segmentStorageInLoop);
             checkSystemSegmentsLayout(segmentStorageInLoop);
 
@@ -668,7 +669,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorageFinal.initialize(epoch);
         segmentStorageFinal.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
-        segmentStorageFinal.bootstrap(snapshotInfoStore, null).join();
+        segmentStorageFinal.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorageFinal);
         checkSystemSegmentsLayout(segmentStorageFinal);
 
@@ -746,7 +747,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
             segmentStorageInLoop.initialize(epoch);
             segmentStorageInLoop.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
-            segmentStorageInLoop.bootstrap(snapshotInfoStore, null).join();
+            segmentStorageInLoop.bootstrap(snapshotInfoStore).join();
             deleteGarbage(segmentStorageInLoop);
             checkSystemSegmentsLayout(segmentStorageInLoop);
 
@@ -801,7 +802,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorageFinal.initialize(epoch);
         segmentStorageFinal.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
-        segmentStorageFinal.bootstrap(snapshotInfoStore, null).join();
+        segmentStorageFinal.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorageFinal);
         checkSystemSegmentsLayout(segmentStorageFinal);
 
@@ -897,7 +898,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage1.initialize(epoch);
         segmentStorage1.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
         // Bootstrap
-        segmentStorage1.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage1.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage1);
         checkSystemSegmentsLayout(segmentStorage1);
 
@@ -919,7 +920,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage2.initialize(epoch);
         segmentStorage2.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
-        segmentStorage2.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage2.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage2);
         checkSystemSegmentsLayout(segmentStorage2);
 
@@ -979,7 +980,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage1.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
         // Bootstrap
-        segmentStorage1.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage1.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage1);
         checkSystemSegmentsLayout(segmentStorage1);
 
@@ -999,7 +1000,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
         segmentStorage2.initialize(epoch);
         segmentStorage2.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
 
-        segmentStorage2.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage2.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage2);
         checkSystemSegmentsLayout(segmentStorage2);
 
@@ -1604,7 +1605,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
 
         // Bootstrap
         segmentStorage1.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
-        segmentStorage1.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage1.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage1);
 
         checkSystemSegmentsLayout(segmentStorage1);
@@ -1649,7 +1650,7 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
 
         // Bootstrap
         segmentStorage2.getGarbageCollector().initialize(new InMemoryTaskQueueManager()).join();
-        segmentStorage2.bootstrap(snapshotInfoStore, null).join();
+        segmentStorage2.bootstrap(snapshotInfoStore).join();
         deleteGarbage(segmentStorage2);
         checkSystemSegmentsLayout(segmentStorage2);
 

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -203,6 +203,11 @@ public final class NameUtils {
     private static final String SYSJOURNAL_SNAPSHOT_NAME_FORMAT = INTERNAL_CONTAINER_PREFIX + "_sysjournal.epoch%d.container%d.snapshot%d";
 
     /**
+     * Format for Container System snapshot file name.
+     */
+    private static final String SYSJOURNAL_SNAPSHOT_INFO_NAME_FORMAT = INTERNAL_CONTAINER_PREFIX + "_sysjournal.container%d.snapshot_info";
+
+    /**
      * The Transaction unique identifier is made of two parts, each having a length of 16 bytes (64 bits in Hex).
      */
     private static final int TRANSACTION_PART_LENGTH = Long.BYTES * 8 / 4;
@@ -518,6 +523,15 @@ public final class NameUtils {
      */
     public static String getSystemJournalSnapshotFileName(int containerId, long epoch, long currentSnapshotIndex) {
         return String.format(SYSJOURNAL_SNAPSHOT_NAME_FORMAT, epoch, containerId, currentSnapshotIndex);
+    }
+
+    /**
+     * Gets file name of SystemJournal snapshot info file for given container instance.
+     * @param containerId The Id of the Container.
+     * @return File name of SystemJournal for given container instance
+     */
+    public static String getSystemJournalSnapshotInfoFileName(int containerId) {
+        return String.format(SYSJOURNAL_SNAPSHOT_INFO_NAME_FORMAT, containerId);
     }
 
     /**

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -175,6 +175,8 @@ public class NameUtilsTest {
                 "_system/containers/_sysjournal.epoch3.container2.file4");
         Assert.assertEquals(NameUtils.getSystemJournalSnapshotFileName(5, 6, 7),
                 "_system/containers/_sysjournal.epoch6.container5.snapshot7");
+        Assert.assertEquals(NameUtils.getSystemJournalSnapshotInfoFileName(42),
+                "_system/containers/_sysjournal.container42.snapshot_info");
         Assert.assertTrue(NameUtils.getSegmentChunkName("segment", 8, 9).startsWith("segment.E-8-O-9"));
         Assert.assertEquals(NameUtils.getSegmentReadIndexBlockName("segment", 10), "segment.B-10");
     }


### PR DESCRIPTION
---This is PR for feature branch---

**Change log description**  
Issue 7113: LTS - Save snapshot info to LTS and boot from it in case of migration/recovery.

**Purpose of the change**  
Fixes #7113 

**What the code does**  
- Save snapshot info to a well-known LTS location at the same time it is written to snapshot info store. 
- During bootstrap use snapshot info from this well-known location on LTS when BK and ZK are empty.
- Also, slight adjustment to boot sequence to initialize SLTS GC task queue as late as possible.

Note that this code assumes following. 
- that underlying LTS provides read after create consistency. And consistency of creation of chunk with same name after delete. In other words, it is NOT eventually consistent.
-  Write by zombie is still prevented by fencing of snapshot store.

**How to verify it**  
All tests should pass.
Manually test the scenario
