### PR TITLE
Issue 7099: Ability to save latest epoch info during execution of flush to storage command.

### DIFF
--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -248,6 +248,8 @@ public final class NameUtils {
      */
     private static final String CONTAINER_EVENT_PROCESSOR_SEGMENT_NAME = INTERNAL_CONTAINER_PREFIX + "event_processor_%s_%d";
 
+    private static final String CONTAINER_EPOCH_INFO = INTERNAL_CONTAINER_PREFIX + "container_%d_epoch";
+
     //endregion
 
     /**
@@ -518,6 +520,15 @@ public final class NameUtils {
      */
     public static String getSystemJournalSnapshotFileName(int containerId, long epoch, long currentSnapshotIndex) {
         return String.format(SYSJOURNAL_SNAPSHOT_NAME_FORMAT, epoch, containerId, currentSnapshotIndex);
+    }
+
+    /**
+     * Gets file name of ContainerEpochInfo for the given container instance.
+     * @param containerId The Id of the Container.
+     * @return File name of ContainerEpochInfo for given container instance
+     */
+    public static String getContainerEpochFileName(int containerId) {
+        return String.format(CONTAINER_EPOCH_INFO, containerId);
     }
 
     /**


### PR DESCRIPTION
**Change log description**  
Enhancing flush to storage command to also save epoch information in a separate file. Each line will have container id and epoch value i.e {containerId}:{epoch}.

**Purpose of the change**  
Fixes #7099 

**What the code does**  
Added changes in flush to storage to also save epoch info.

**How to verify it**  
Execute `flush-to-storage` command and validate presence of epoch info file stored at  `tier2/_system/containers/container_[containerId]_epoch`
