### PR TITLE
Issue 4933: Add API support for shadow (child) index segment

### DIFF
--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
@@ -44,7 +44,7 @@ public class SegmentType {
     /**
      * Index segment, for associating with Stream Segment, with no special roles.
      */
-    public static final SegmentType INDEX_SEGMENT = SegmentType.builder().index().build();
+    public static final SegmentType INDEX_SEGMENT = SegmentType.builder().build();
 
     //endregion
 
@@ -70,9 +70,6 @@ public class SegmentType {
     static final long ROLE_CRITICAL = 0b0100_0000L;
     @VisibleForTesting
     static final long ROLE_TRANSIENT = 0b1000_0000L;
-    // TODO: check if this is needed
-    @VisibleForTesting
-    static final long ROLE_INDEX = 0b1000_0001L;
     private final long flags;
 
     //endregion
@@ -163,16 +160,6 @@ public class SegmentType {
         return (this.flags & ROLE_CRITICAL) == ROLE_CRITICAL;
     }
 
-    /**
-     * Whether this {@link SegmentType} refers to a Segment (regardless of Format) that is required for the functioning
-     * of the stream segment, as it is associated with it.
-     *
-     * @return True if an index Segment, false otherwise.
-     */
-    // TODO: check on this, do we need role?
-    public boolean isIndex() {
-        return (this.flags & ROLE_INDEX) == ROLE_INDEX;
-    }
 
     @Override
     public String toString() {
@@ -198,10 +185,6 @@ public class SegmentType {
 
         if (isInternal()) {
             result.append(", Internal");
-        }
-
-        if (isIndex()) {
-            result.append(", Index");
         }
 
         return result.toString();
@@ -304,11 +287,6 @@ public class SegmentType {
 
         public Builder internal() {
             this.flags |= ROLE_INTERNAL;
-            return this;
-        }
-
-        public Builder index() {
-            this.flags |= ROLE_INDEX;
             return this;
         }
 

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
@@ -41,6 +41,10 @@ public class SegmentType {
      * General Transient Segment with no special roles.
      */
     public static final SegmentType TRANSIENT_SEGMENT = SegmentType.builder().transientSegment().build();
+    /**
+     * Index segment, for associating with Stream Segment, with no special roles.
+     */
+    public static final SegmentType INDEX_SEGMENT = SegmentType.builder().index().build();
 
     //endregion
 
@@ -66,6 +70,9 @@ public class SegmentType {
     static final long ROLE_CRITICAL = 0b0100_0000L;
     @VisibleForTesting
     static final long ROLE_TRANSIENT = 0b1000_0000L;
+    // TODO: check if this is needed
+    @VisibleForTesting
+    static final long ROLE_INDEX = 0b1000_0001L;
     private final long flags;
 
     //endregion
@@ -156,6 +163,17 @@ public class SegmentType {
         return (this.flags & ROLE_CRITICAL) == ROLE_CRITICAL;
     }
 
+    /**
+     * Whether this {@link SegmentType} refers to a Segment (regardless of Format) that is required for the functioning
+     * of the stream segment, as it is associated with it.
+     *
+     * @return True if an index Segment, false otherwise.
+     */
+    // TODO: check on this, do we need role?
+    public boolean isIndex() {
+        return (this.flags & ROLE_INDEX) == ROLE_INDEX;
+    }
+
     @Override
     public String toString() {
         StringBuilder result = new StringBuilder();
@@ -180,6 +198,10 @@ public class SegmentType {
 
         if (isInternal()) {
             result.append(", Internal");
+        }
+
+        if (isIndex()) {
+            result.append(", Index");
         }
 
         return result.toString();
@@ -282,6 +304,11 @@ public class SegmentType {
 
         public Builder internal() {
             this.flags |= ROLE_INTERNAL;
+            return this;
+        }
+
+        public Builder index() {
+            this.flags |= ROLE_INDEX;
             return this;
         }
 

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
@@ -159,8 +159,7 @@ public class SegmentType {
     public boolean isCritical() {
         return (this.flags & ROLE_CRITICAL) == ROLE_CRITICAL;
     }
-
-
+    
     @Override
     public String toString() {
         StringBuilder result = new StringBuilder();

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -130,6 +130,8 @@ import static io.pravega.segmentstore.contracts.Attributes.CREATION_TIME;
 import static io.pravega.segmentstore.contracts.Attributes.ROLLOVER_SIZE;
 import static io.pravega.segmentstore.contracts.Attributes.SCALE_POLICY_RATE;
 import static io.pravega.segmentstore.contracts.Attributes.SCALE_POLICY_TYPE;
+import static io.pravega.segmentstore.contracts.Attributes.ATTRIBUTE_SEGMENT_TYPE;
+import static io.pravega.segmentstore.contracts.Attributes.EVENT_COUNT;
 import static io.pravega.segmentstore.contracts.ReadResultEntryType.Cache;
 import static io.pravega.segmentstore.contracts.ReadResultEntryType.EndOfStreamSegment;
 import static io.pravega.segmentstore.contracts.ReadResultEntryType.Future;

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -248,6 +248,11 @@ public final class NameUtils {
      */
     private static final String CONTAINER_EVENT_PROCESSOR_SEGMENT_NAME = INTERNAL_CONTAINER_PREFIX + "event_processor_%s_%d";
 
+    /**
+     * This is appended at the end of the Segment name to indicate it stores its index metadata.
+     */
+    private static final String INDEX_SEGMENT_SUFFIX = "#index";
+
     //endregion
 
     /**
@@ -974,5 +979,26 @@ public final class NameUtils {
     public static String[] getConnectionDetails(String connection) {
         Preconditions.checkNotNull(connection);
         return connection.split(":");
+    }
+
+    /**
+     * Checks whether the given name is an Index Segment or not.
+     *
+     * @param segmentName   The name of the segment.
+     * @return              True if the segment is an index Segment, false otherwise.
+     */
+    public static boolean isIndexSegment(String segmentName) {
+        return segmentName.endsWith(INDEX_SEGMENT_SUFFIX);
+    }
+
+    /**
+     * Gets the name of the index-Segment mapped to the given Segment Name that is responsible with storing index metadata.
+     *
+     * @param segmentName The name of the Segment to get the index segment name for.
+     * @return The result.
+     */
+    public static String getIndexSegmentName(String segmentName) {
+        Preconditions.checkArgument(!isIndexSegment(segmentName), "segmentName is already an index segment name");
+        return segmentName + INDEX_SEGMENT_SUFFIX;
     }
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -234,6 +234,8 @@ public class NameUtilsTest {
         String stream = "stream";
         String qualifiedStreamSegmentName = NameUtils.getQualifiedStreamSegmentName(scope, stream, 0L);
         String indexSegmentName = NameUtils.getIndexSegmentName(qualifiedStreamSegmentName);
+        Assert.assertTrue("Passed segment is an index segment", NameUtils.isIndexSegment(indexSegmentName));
         AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateStreamName(indexSegmentName));
+        AssertExtensions.assertThrows("", () -> NameUtils.getIndexSegmentName(indexSegmentName), ex -> ex instanceof IllegalArgumentException);
     }
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -227,4 +227,13 @@ public class NameUtilsTest {
         Assert.assertEquals("localhost", NameUtils.getConnectionDetails("localhost :12345")[0].trim());
         Assert.assertEquals("12345", NameUtils.getConnectionDetails("localhost :12345")[1].trim());
     }
+
+    @Test
+    public void testIndexSegmentName() {
+        String scope = "scope";
+        String stream = "stream";
+        String qualifiedStreamSegmentName = NameUtils.getQualifiedStreamSegmentName(scope, stream, 0L);
+        String indexSegmentName = NameUtils.getIndexSegmentName(qualifiedStreamSegmentName);
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateStreamName(indexSegmentName));
+    }
 }


### PR DESCRIPTION
**Change log description**  
To add an API to create a segment which is a child segment and who's lifecycle is tied to the parent segment. Enforce that appends to this segment are fixed size records.
If main segment is deleted then this child segment should be deleted.

**Purpose of the change**  
(_e.g._, Fixes #666, Closes #1234)

**What the code does**  
(Detailed description of the code changes)

**How to verify it**  
(Optional: steps to verify that the changes are effective)
