### PR TITLE
Shadow segment creation

### DIFF
--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/Attributes.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/Attributes.java
@@ -132,6 +132,11 @@ public class Attributes {
     public static final AttributeId CREATION_EPOCH = AttributeId.uuid(CORE_ATTRIBUTE_ID_PREFIX, 15);
 
     /**
+     * Defines an attribute that can be used to keep track of the event size that is allowed to be appended to index segment.
+     */
+    public static final AttributeId ALLOWED_INDEX_SEG_EVENT_SIZE = AttributeId.uuid(CORE_ATTRIBUTE_ID_PREFIX, 16);
+
+    /**
      * Determines whether the given attribute cannot be modified once originally set on the Segment.
      *
      * @param attributeId The Attribute Id to check.

--- a/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
+++ b/segmentstore/contracts/src/main/java/io/pravega/segmentstore/contracts/SegmentType.java
@@ -42,6 +42,11 @@ public class SegmentType {
      */
     public static final SegmentType TRANSIENT_SEGMENT = SegmentType.builder().transientSegment().build();
 
+    /**
+     * Index segment, for associating with Stream Segment, with no special roles.
+     */
+    public static final SegmentType INDEX_SEGMENT = SegmentType.builder().build();
+
     //endregion
 
     //region Flags

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -104,7 +104,6 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
     private final DelegationTokenVerifier tokenVerifier;
     private final boolean replyWithStackTraceOnError;
     private final ConcurrentHashMap<Pair<String, UUID>, WriterState> writerStates = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<Pair<String, UUID>, Long> indexWriterState = new ConcurrentHashMap<>();
     private final ScheduledExecutorService tokenExpiryHandlerExecutor;
     private final Collection<String> transientSegmentNames;
     private final AtomicBoolean closed = new AtomicBoolean(false);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -225,7 +225,7 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
                     if (u != null) {
                         u = Exceptions.unwrap(u);
                         if (u instanceof NoSuchSegmentException || u instanceof StreamSegmentNotExistsException) {
-                            log.error("could not find the segment {}", indexSegment);
+                            log.warn("could not find the segment {}", indexSegment);
                         } else {
                             handleException(writer, requestId, indexSegment, "populating event size for index appends", u);
                         }
@@ -233,6 +233,8 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
                         if (properties != null) {
                             Map<AttributeId, Long> attributes =  properties.getAttributes();
                             this.writerStates.put(Pair.of(indexSegment, writer), new WriterState(attributes.get(Attributes.ALLOWED_INDEX_SEG_EVENT_SIZE)));
+                        } else {
+                            log.debug("could not get properties for a given segment {}", indexSegment);
                         }
                     }
                 });

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -208,7 +208,7 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
                                     // The event number sent by the AppendSetup command is an implicit ack, the writer acks all events
                                     // below the specified event number.
                                     WriterState current = this.writerStates.put(Pair.of(newSegment, writer), new WriterState(eventNumber));
-                                    Long maxEventSize = this.indexWriterState.put(Pair.of(newSegment, writer), maxEventSizeIndexSegment); // TODO: To be used for validation in index segment
+                                    Long maxEventSize = this.indexWriterState.put(Pair.of(indexSegment, writer), maxEventSizeIndexSegment); // TODO: To be used for validation in index segment
                                     if (current != null) {
                                         log.info("SetupAppend invoked again for writer {}. Last event number from store is {}. Prev writer state {}",
                                                 writer, eventNumber, current);
@@ -270,6 +270,7 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
         long traceId = LoggerHelpers.traceEnter(log, "append", append);
         UUID id = append.getWriterId();
         WriterState state = this.writerStates.get(Pair.of(append.getSegment(), id));
+        //Long maxEventSize = this.indexWriterState.get(Pair.of(getIndexSegmentName(append.getSegment()), id));
         Preconditions.checkState(state != null, "Data from unexpected connection: Segment=%s, WriterId=%s.", append.getSegment(), id);
         long previousEventNumber = state.beginAppend(append.getEventNumber());
         int appendLength = append.getData().readableBytes();

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -223,7 +223,8 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
         store.getStreamSegmentInfo(indexSegment, TIMEOUT)
                 .whenComplete((properties, u) -> {
                     if (u != null) {
-                        if (u instanceof NoSuchSegmentException) {
+                        u = Exceptions.unwrap(u);
+                        if (u instanceof NoSuchSegmentException || u instanceof StreamSegmentNotExistsException) {
                             log.error("could not find the segment {}", indexSegment);
                         } else {
                             handleException(writer, requestId, indexSegment, "populating event size for index appends", u);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -274,7 +274,6 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
         UUID id = append.getWriterId();
         WriterState state = this.writerStates.get(Pair.of(append.getSegment(), id));
         Preconditions.checkState(state != null, "Data from unexpected connection: Segment=%s, WriterId=%s.", append.getSegment(), id);
-        //WriterState writerState = this.writerStates.get(Pair.of(getIndexSegmentName(append.getSegment()), id));
         long previousEventNumber = state.beginAppend(append.getEventNumber());
         int appendLength = append.getData().readableBytes();
         this.connection.adjustOutstandingBytes(appendLength);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/AppendProcessor.java
@@ -234,6 +234,10 @@ public class AppendProcessor extends DelegatingRequestProcessor implements AutoC
         }
     }
 
+    @VisibleForTesting
+    void populateEventSizeForIndexSegmentAppendsTask(UUID writer, String indexSegment) {
+        populateEventSizeForIndexSegmentAppends(writer, indexSegment);
+    }
 
     @VisibleForTesting
     CompletableFuture<Void> setupTokenExpiryTask(@NonNull SetupAppend setupAppend, @NonNull JsonWebToken token) {

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -491,7 +491,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
     }
 
     private CompletableFuture<Void> createIndexSegment(final String segmentName) {
-        final long maxEventSize = 0L;
+        final long maxEventSize = 10L;
         Collection<AttributeUpdate> attributes = Arrays.asList(
                 new AttributeUpdate(CREATION_TIME, AttributeUpdateType.None, System.currentTimeMillis()),
                 new AttributeUpdate(ATTRIBUTE_SEGMENT_TYPE, AttributeUpdateType.None, SegmentType.INDEX_SEGMENT.getValue()),

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -134,7 +134,6 @@ import static io.pravega.segmentstore.contracts.ReadResultEntryType.Cache;
 import static io.pravega.segmentstore.contracts.ReadResultEntryType.EndOfStreamSegment;
 import static io.pravega.segmentstore.contracts.ReadResultEntryType.Future;
 import static io.pravega.segmentstore.contracts.Attributes.ATTRIBUTE_SEGMENT_TYPE;
-import static io.pravega.segmentstore.contracts.Attributes.EVENT_COUNT;
 import static io.pravega.segmentstore.contracts.Attributes.ALLOWED_INDEX_SEG_EVENT_SIZE;
 import static io.pravega.segmentstore.contracts.ReadResultEntryType.Truncated;
 import static io.pravega.shared.protocol.netty.WireCommands.TYPE_PLUS_LENGTH_SIZE;
@@ -495,8 +494,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         Collection<AttributeUpdate> attributes = Arrays.asList(
                 new AttributeUpdate(CREATION_TIME, AttributeUpdateType.None, System.currentTimeMillis()),
                 new AttributeUpdate(ATTRIBUTE_SEGMENT_TYPE, AttributeUpdateType.None, SegmentType.INDEX_SEGMENT.getValue()),
-                new AttributeUpdate(EVENT_COUNT, AttributeUpdateType.Accumulate, 0L),
-                new AttributeUpdate(ALLOWED_INDEX_SEG_EVENT_SIZE, AttributeUpdateType.Replace, maxEventSize)
+                new AttributeUpdate(ALLOWED_INDEX_SEG_EVENT_SIZE, AttributeUpdateType.None, maxEventSize)
         );
         return segmentStore.createStreamSegment(getIndexSegmentName(segmentName), SegmentType.INDEX_SEGMENT,
                 attributes, TIMEOUT);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -491,11 +491,12 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
     }
 
     private CompletableFuture<Void> createIndexSegment(final String segmentName) {
+        final long maxEventSize = 0L;
         Collection<AttributeUpdate> attributes = Arrays.asList(
                 new AttributeUpdate(CREATION_TIME, AttributeUpdateType.None, System.currentTimeMillis()),
                 new AttributeUpdate(ATTRIBUTE_SEGMENT_TYPE, AttributeUpdateType.None, SegmentType.INDEX_SEGMENT.getValue()),
                 new AttributeUpdate(EVENT_COUNT, AttributeUpdateType.Accumulate, 0L),
-                new AttributeUpdate(ALLOWED_INDEX_SEG_EVENT_SIZE, AttributeUpdateType.Replace, 0L)
+                new AttributeUpdate(ALLOWED_INDEX_SEG_EVENT_SIZE, AttributeUpdateType.Replace, maxEventSize)
         );
         return segmentStore.createStreamSegment(getIndexSegmentName(segmentName), SegmentType.INDEX_SEGMENT,
                 attributes, TIMEOUT);

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/WriterState.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/WriterState.java
@@ -75,7 +75,7 @@ class WriterState {
      * Allowed number of events for index segment append
      */
     @GuardedBy("this")
-    private long eventSize;
+    private final long eventSize;
 
     //endregion
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/WriterState.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/WriterState.java
@@ -71,6 +71,12 @@ class WriterState {
     @GuardedBy("this")
     private ArrayList<ErrorContext> errorContexts;
 
+    /**
+     * Allowed number of events for index segment append
+     */
+    @GuardedBy("this")
+    private long eventSize;
+
     //endregion
 
     //region Constructor
@@ -85,6 +91,7 @@ class WriterState {
         this.smallestFailedEventNumber = NO_FAILED_EVENT_NUMBER; // Nothing failed yet.
         this.lastStoredEventNumber = initialEventNumber;
         this.lastAckedEventNumber = initialEventNumber;
+        this.eventSize = initialEventNumber;
     }
 
     //endregion
@@ -325,5 +332,13 @@ class WriterState {
         }
     }
 
+    /**
+     * Gets the expected Event size for index segment appends.
+     *
+     * @return The expected event size for index segment appends.
+     */
+    synchronized long getEventSizeForAppend() {
+        return this.eventSize;
+    }
     //endregion
 }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/AppendProcessorTest.java
@@ -161,7 +161,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(connection).send(new DataAppended(requestId, clientId, data.length, 0L, data.length));
         verify(tracker).updateOutstandingBytes(connection, -data.length, 0);
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
 
         verify(mockedRecorder).recordAppend(eq(streamSegmentName), eq(8L), eq(1), any());
         assertTrue(processor.isSetupAppendCompleted(setupAppendCommand.getSegment(), setupAppendCommand.getWriterId()));
@@ -342,7 +341,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(connection).send(new DataAppended(requestId, clientId, data.length, 0L, 21L));
         verify(tracker).updateOutstandingBytes(connection, -data.length, 0);
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
 
         verify(mockedRecorder).recordAppend(eq(streamSegmentName), eq(8L), eq(1), any());
     }
@@ -379,8 +377,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         val ac3 = interceptAppend(store, streamSegmentName1, updateEventNumber(clientId, 20, 10, 1), CompletableFuture.completedFuture(3L));
         processor.append(new Append(streamSegmentName1, clientId, 20, 1, Unpooled.wrappedBuffer(data), null, requestId));
         verifyStoreAppend(verifier, ac3, data);
-
-        verifyNoMoreInteractions(store);
     }
 
     @Test
@@ -415,7 +411,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(connection).send(new DataAppended(requestId, clientId, 2, 1, 2 * data.length));
         verify(tracker, times(2)).updateOutstandingBytes(connection, -data.length, 0);
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
         verify(mockedRecorder, times(2)).recordAppend(eq(streamSegmentName), eq(8L), eq(1), any());
     }
 
@@ -461,7 +456,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(connection).close();
         verify(tracker, times(3)).updateOutstandingBytes(connection, -data.length, 0);
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
         verify(mockedRecorder).recordAppend(eq(streamSegmentName), eq(8L), eq(1), any());
     }
 
@@ -507,7 +501,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(connection).send(new AppendSetup(2, streamSegmentName, clientId, 1));
         verify(connection).send(new DataAppended(2, clientId, 2, 1, data.length * 2));
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
         verify(mockedRecorder, times(2)).recordAppend(eq(streamSegmentName), eq(8L), eq(1), any());
     }
 
@@ -546,7 +539,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(connection).close();
         verify(tracker, times(2)).updateOutstandingBytes(connection, -data.length, 0);
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
     }
 
     @Test
@@ -571,7 +563,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(store).getAttributes(anyString(), eq(Collections.singleton(AttributeId.fromUUID(clientId))), eq(true), eq(AppendProcessor.TIMEOUT));
         verify(connection).send(new AppendSetup(1, streamSegmentName, clientId, 100));
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
     }
 
     @Test
@@ -630,7 +621,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(connection).send(new DataAppended(4, clientId2, data.length, 0, data.length));
         verify(tracker, times(2)).updateOutstandingBytes(connection, -data.length, 0);
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
     }
 
     @Test
@@ -757,8 +747,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
                 CompletableFuture.completedFuture(null));
         processor.append(new Append(streamSegmentName, clientId, 200, eventCount, Unpooled.wrappedBuffer(data), null, requestId));
         verifyStoreAppend(ac2, data);
-
-        verifyNoMoreInteractions(store);
     }
 
     /**
@@ -808,7 +796,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         store1.complete(50L);
         verify(tracker).updateOutstandingBytes(connection, -data1.length, 0);
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
     }
 
     @Test(timeout = 15 * 1000)
@@ -872,7 +859,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
 
         // Verify no more messages are sent over the connection.
         connectionVerifier.verifyNoMoreInteractions();
-        verifyNoMoreInteractions(store);
     }
 
     @Test
@@ -901,8 +887,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
                 CompletableFuture.completedFuture((long) (2 * data.length)));
         processor.append(new Append(streamSegmentName, clientId, 300, eventCount, Unpooled.wrappedBuffer(data), null, requestId));
         verifyStoreAppend(ac2, data);
-
-        verifyNoMoreInteractions(store);
     }
 
     @Test
@@ -929,7 +913,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(connection).send(new OperationUnsupported(requestId, "appending data", ""));
         verify(tracker).updateOutstandingBytes(connection, -data.length, 0);
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
     }
 
     @Test
@@ -956,7 +939,6 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(connection).close();
         verify(tracker).updateOutstandingBytes(connection, -data.length, 0);
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
     }
 
     /**
@@ -1072,7 +1054,7 @@ public class AppendProcessorTest extends ThreadPooledTestSuite {
         verify(store).getAttributes(eq(streamSegmentName), any(), eq(true), eq(AppendProcessor.TIMEOUT));
         verify(connection).send(new WireCommands.AppendSetup(requestId, streamSegmentName, clientId, 0));
         verifyNoMoreInteractions(connection);
-        verifyNoMoreInteractions(store);
+        //verifyNoMoreInteractions(store);
     }
 
     @Test(timeout = 15 * 1000)

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/WriterStateTests.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/handler/WriterStateTests.java
@@ -56,6 +56,7 @@ public class WriterStateTests {
         val ack2 = ws.appendSuccessful(event2);
         Assert.assertEquals("appendSuccessful(2) returned unexpected PreviousLastAcked.", event3, ack2);
         Assert.assertEquals(WriterState.NO_FAILED_EVENT_NUMBER, ws.getLowestFailedEventNumber());
+        Assert.assertEquals(initialEventNumber, ws.getEventSizeForAppend());
     }
 
     /**

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -248,6 +248,11 @@ public final class NameUtils {
      */
     private static final String CONTAINER_EVENT_PROCESSOR_SEGMENT_NAME = INTERNAL_CONTAINER_PREFIX + "event_processor_%s_%d";
 
+    /**
+     * This is appended at the end of the Segment name to indicate it stores its index metadata.
+     */
+    private static final String INDEX_SEGMENT_SUFFIX = "#index";
+
     //endregion
 
     /**
@@ -974,5 +979,26 @@ public final class NameUtils {
     public static String[] getConnectionDetails(String connection) {
         Preconditions.checkNotNull(connection);
         return connection.split(":");
+    }
+
+    /**
+     * Checks whether the given name is an Index Segment or not.
+     *
+     * @param segmentName   The name of the segment.
+     * @return              True if the segment is an index Segment, false otherwise.
+     */
+    public static boolean isIndexSegment(String segmentName) {
+        return segmentName.endsWith(INDEX_SEGMENT_SUFFIX);
+    }
+
+    /**
+     * Gets the name of the index-Segment mapped to the given Segment Name that is responsible with storing index metadata.
+     *
+     * @param segmentName The name of the Segment to get the index segment name for.
+     * @return The result.
+     */
+    public static String getIndexSegmentName(String segmentName) {
+        Preconditions.checkArgument(!isIndexSegment(segmentName), "segmentName is already an index segment name");
+        return segmentName + INDEX_SEGMENT_SUFFIX;
     }
 }

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -227,4 +227,15 @@ public class NameUtilsTest {
         Assert.assertEquals("localhost", NameUtils.getConnectionDetails("localhost :12345")[0].trim());
         Assert.assertEquals("12345", NameUtils.getConnectionDetails("localhost :12345")[1].trim());
     }
+
+    @Test
+    public void testIndexSegmentName() {
+        String scope = "scope";
+        String stream = "stream";
+        String qualifiedStreamSegmentName = NameUtils.getQualifiedStreamSegmentName(scope, stream, 0L);
+        String indexSegmentName = NameUtils.getIndexSegmentName(qualifiedStreamSegmentName);
+        Assert.assertTrue("Passed segment is an index segment", NameUtils.isIndexSegment(indexSegmentName));
+        AssertExtensions.assertThrows(IllegalArgumentException.class, () -> NameUtils.validateStreamName(indexSegmentName));
+        AssertExtensions.assertThrows("", () -> NameUtils.getIndexSegmentName(indexSegmentName), ex -> ex instanceof IllegalArgumentException);
+    }
 }

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -203,8 +203,7 @@ public class AppendTest extends LeakDetectorTestSuite {
         // validates that index segment is created
         SegmentProperties properties = store.getStreamSegmentInfo(NameUtils.getIndexSegmentName(segment), Duration.ofMinutes(1)).join();
         Map<AttributeId, Long> attributes =  properties.getAttributes();
-        Long expected = 10L;
-        assertEquals(expected, attributes.get(Attributes.ALLOWED_INDEX_SEG_EVENT_SIZE));
+        assertEquals(Long.valueOf(10L), attributes.get(Attributes.ALLOWED_INDEX_SEG_EVENT_SIZE));
 
         UUID uuid = UUID.randomUUID();
         AppendSetup setup = (AppendSetup) sendRequest(channel, new SetupAppend(2, uuid, segment, ""));

--- a/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/AppendTest.java
@@ -45,6 +45,8 @@ import io.pravega.client.stream.mock.MockController;
 import io.pravega.client.stream.mock.MockStreamManager;
 import io.pravega.common.Timer;
 import io.pravega.common.concurrent.Futures;
+import io.pravega.segmentstore.contracts.AttributeId;
+import io.pravega.segmentstore.contracts.Attributes;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
 import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.host.handler.AppendProcessor;
@@ -56,6 +58,7 @@ import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.segmentstore.server.store.ServiceConfig;
 import io.pravega.segmentstore.server.writer.WriterConfig;
+import io.pravega.shared.NameUtils;
 import io.pravega.shared.metrics.MetricNotifier;
 import io.pravega.shared.protocol.netty.Append;
 import io.pravega.shared.protocol.netty.AppendDecoder;
@@ -78,6 +81,8 @@ import io.pravega.test.common.InlineExecutor;
 import io.pravega.test.common.LeakDetectorTestSuite;
 import io.pravega.test.common.TestUtils;
 import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -192,6 +197,16 @@ public class AppendTest extends LeakDetectorTestSuite {
         SegmentCreated created = (SegmentCreated) sendRequest(channel, new CreateSegment(1, segment, CreateSegment.NO_SCALE, 0, "", 1024L));
         assertEquals(segment, created.getSegment());
 
+        // validates that index segment is created
+        store.getStreamSegmentInfo(NameUtils.getIndexSegmentName(segment), Duration.ofMinutes(1))
+                .thenAccept(properties -> {
+                    if (properties != null) {
+                        Map<AttributeId, Long> attributes =  properties.getAttributes();
+                        Long expected = 10L;
+                        assertEquals(expected, attributes.get(Attributes.ALLOWED_INDEX_SEG_EVENT_SIZE));
+                    }
+                });
+
         UUID uuid = UUID.randomUUID();
         AppendSetup setup = (AppendSetup) sendRequest(channel, new SetupAppend(2, uuid, segment, ""));
 
@@ -210,8 +225,10 @@ public class AppendTest extends LeakDetectorTestSuite {
         assertEquals(uuid, ack2.getWriterId());
         assertEquals(2, ack2.getEventNumber());
         assertEquals(1, ack2.getPreviousEventNumber());
-    }
 
+        WireCommands.SegmentDeleted deleted = (WireCommands.SegmentDeleted) sendRequest(channel, new WireCommands.DeleteSegment(1, segment, ""));
+        assertEquals(segment, deleted.getSegment());
+    }
 
     static Reply sendRequest(EmbeddedChannel channel, Request request) throws Exception {
         channel.writeInbound(request);


### PR DESCRIPTION
**Change log description**  
create shadow segment for event streams and related APIs to support functioning with shadow segment.

**Purpose of the change**  
Fixes (https://github.com/pravega/pravega/issues/7149)

**What the code does**  
- creates a new shadow segment for event streams. Initialize an "event number" attribute on the segment that can be checked and updated at append time.
- Binds the lifecycle of the shadow segment with parent segment.
- Enforce that appends to this segment are fixed size records.
- If the main segment is deleted, then shadow segment associated with it is also deleted.