### PR TITLE
Client side changes to get next stream cut

### DIFF
--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -105,7 +105,7 @@ public interface BatchClientFactory extends AutoCloseable {
     List<SegmentRange> getSegmentRangeBetweenStreamCuts(final StreamCut startStreamCut, final StreamCut endStreamCut);
 
     /**
-     * Provides a nextStreamCut to an approxDistance based on the startingStreamCut
+     * Provides a nextStreamCut to an approxDistance based on the startingStreamCut.
      * @param startingStreamCut Starting streamcut
      * @param approxDistanceToNextOffset approx distance to nextoffset in bytes
      * @return A streamcut

--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -103,4 +103,12 @@ public interface BatchClientFactory extends AutoCloseable {
      * @return A list of segment range in between a start and end stream cut.
      */
     List<SegmentRange> getSegmentRangeBetweenStreamCuts(final StreamCut startStreamCut, final StreamCut endStreamCut);
+
+    /**
+     * Provides a nextStreamCut to an approxDistance based on the startingStreamCut
+     * @param startingStreamCut Starting streamcut
+     * @param approxDistanceToNextOffset approx distance to nextoffset in bytes
+     * @return A streamcut
+     */
+    StreamCut getNextStreamCut(final StreamCut startingStreamCut, long approxDistanceToNextOffset);
 }

--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -22,6 +22,7 @@ import io.pravega.client.batch.StreamSegmentsIterator;
 import io.pravega.client.batch.impl.BatchClientFactoryImpl;
 import io.pravega.client.connection.impl.SocketConnectionFactoryImpl;
 import io.pravega.client.segment.impl.NoSuchSegmentException;
+import io.pravega.client.segment.impl.SearchFailedException;
 import io.pravega.client.stream.EventStreamReader;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.Stream;
@@ -109,6 +110,8 @@ public interface BatchClientFactory extends AutoCloseable {
      * @param startingStreamCut Starting streamcut
      * @param approxDistanceToNextOffset approx distance to nextoffset in bytes
      * @return A streamcut
+     * @throws NoSuchSegmentException If the provided segment does not exit.
+     * @throws SearchFailedException If unable to locate the next offset for the segment.
      */
-    StreamCut getNextStreamCut(final StreamCut startingStreamCut, long approxDistanceToNextOffset);
+    StreamCut getNextStreamCut(final StreamCut startingStreamCut, long approxDistanceToNextOffset) throws NoSuchSegmentException, SearchFailedException;
 }

--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -105,7 +105,7 @@ public interface BatchClientFactory extends AutoCloseable {
     List<SegmentRange> getSegmentRangeBetweenStreamCuts(final StreamCut startStreamCut, final StreamCut endStreamCut);
 
     /**
-     * Provides a nextStreamCut to an approxDistance based on the startingStreamCut.
+     * Provides nearest streamcut in future depending on the distance and current streamcut.
      * @param startingStreamCut Starting streamcut
      * @param approxDistanceToNextOffset approx distance to nextoffset in bytes
      * @return A streamcut

--- a/client/src/main/java/io/pravega/client/BatchClientFactory.java
+++ b/client/src/main/java/io/pravega/client/BatchClientFactory.java
@@ -107,6 +107,9 @@ public interface BatchClientFactory extends AutoCloseable {
 
     /**
      * Provides nearest streamcut in future depending on the distance and current streamcut.
+     * Depending on the requested distance per number of segments in the current streamcut, next offset for each segment is requested.
+     * If the current segment offset is at the tail of it, then the successor segment for it is being fetched.
+     * However, in case of scale down if offsets of all the segments participating in the scale down are at the tail then only call to get the next offset of their successor is made.
      * @param startingStreamCut Starting streamcut
      * @param approxDistanceToNextOffset approx distance to nextoffset in bytes
      * @return A streamcut

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
@@ -193,14 +193,13 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
             if (isNextOffsetSame) {
                 // Probably this segment has scaled, so putting it here to later check for its successors
                 scaledSegmentsMap.put(segment, nextOffset);
-            }
-            else {
+            } else {
                 nextPositionsMap.put(segment, nextOffset);
             }
         }
         checkSuccessorSegmentOffset(nextPositionsMap, scaledSegmentsMap, approxDistanceToNextOffset);
         log.debug("Next positions of the segments in the streamcut = {}", nextPositionsMap);
-        return new StreamCutImpl(stream,nextPositionsMap);
+        return new StreamCutImpl(stream, nextPositionsMap);
     }
 
     public long getNextOffsetForSegment(Segment segment, long targetOffset) {
@@ -229,14 +228,13 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
             CompletableFuture<StreamSegmentsWithPredecessors> getSuccessors = controller.getSuccessors(entry.getKey());
             Map<SegmentWithRange, List<Long>> segmentToPredecessorMap = getSuccessors.join().getSegmentToPredecessor();
             int size = segmentToPredecessorMap.size();
-            if(size > 1) { //scale up happened to the segment
+            if (size > 1) { //scale up happened to the segment
                 for (SegmentWithRange segmentWithRange : segmentToPredecessorMap.keySet()) {
                     Segment segment = segmentWithRange.getSegment();
                     long nextOffset = getNextOffsetForSegment(segment, approxDistanceToNextOffset);
                     nextPositionsMap.put(segment, nextOffset);
                 }
-            }
-            else if (size == 1) { //scale down happened to the segments
+            } else if (size == 1) { //scale down happened to the segments
                 List<Long> segmentIds = nextPositionsMap.keySet().stream().map(x -> x.getSegmentId()).collect(Collectors.toList());
                 // Check for any of the predecessor which is present in nextPositionsMap. If so, we will not proceed to successor segment
                 boolean isJoint  = segmentToPredecessorMap.values().stream().findFirst().get().stream().anyMatch(segmentIds::contains);
@@ -247,12 +245,10 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
                         long nextOffset = getNextOffsetForSegment(segment, approxDistanceToNextOffset);
                         nextPositionsMap.put(segment, nextOffset);
                     }
-                }
-                else {
+                } else {
                     nextPositionsMap.put(entry.getKey(), entry.getValue());
                 }
-            }
-            else { //Segment is neither sealed and nor scaled
+            } else { //Segment is neither sealed and nor scaled
                 nextPositionsMap.put(entry.getKey(), entry.getValue());
             }
 

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
@@ -240,7 +240,7 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
         return new StreamCutImpl(stream, nextPositionsMap);
     }
 
-    public long getNextOffsetForSegment(Segment segment, long targetOffset) {
+    private long getNextOffsetForSegment(Segment segment, long targetOffset) {
         RawClient connection = getConnection(segment);
         long requestId = connection.getFlow().getNextSequenceNumber();
         final DelegationTokenProvider tokenProvider = DelegationTokenProviderFactory
@@ -252,11 +252,11 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
         return offsetLocated.getOffset();
     }
 
-    public boolean checkIfNextOffsetSame(long existingOffset, long nextOffset) {
+    private boolean checkIfNextOffsetSame(long existingOffset, long nextOffset) {
         return existingOffset == nextOffset;
     }
 
-    public void checkSuccessorSegmentOffset(Map<Segment, Long> nextPositionsMap, Map<Segment, Long> scaledSegmentsMap, long approxDistanceToNextOffset) {
+    private void checkSuccessorSegmentOffset(Map<Segment, Long> nextPositionsMap, Map<Segment, Long> scaledSegmentsMap, long approxDistanceToNextOffset) {
         log.debug("checkSuccessorSegmentOffset() -> Segments that may have scaled = {}", scaledSegmentsMap);
         scaledSegmentsMap.entrySet().stream().forEach(entry -> {
             CompletableFuture<StreamSegmentsWithPredecessors> getSuccessors = controller.getSuccessors(entry.getKey());

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
@@ -189,34 +189,12 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
 
     private void closeConnection(Reply badReply) {
         log.info("Closing connection as a result of receiving: {}", badReply);
-        RawClient c;
-        synchronized (lock) {
-            c = client;
-            client = null;
-        }
-        if (c != null) {
-            try {
-                c.close();
-            } catch (Exception e) {
-                log.warn("Exception tearing down connection: ", e);
-            }
-        }
+        closeClientConnection();
     }
 
     private void closeConnection(Throwable exceptionToInflightRequests) {
         log.debug("Closing connection with exception: {}", exceptionToInflightRequests.getMessage());
-        RawClient c;
-        synchronized (lock) {
-            c = client;
-            client = null;
-        }
-        if (c != null) {
-            try {
-                c.close();
-            } catch (Exception e) {
-                log.warn("Exception tearing down connection: ", e);
-            }
-        }
+        closeClientConnection();
     }
 
     RawClient getConnection(Segment segment) {
@@ -323,6 +301,21 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
         } else {
             throw new ConnectionFailedException("Unexpected reply of " + reply + " when expecting a "
                     + klass.getName());
+        }
+    }
+
+    private void closeClientConnection() {
+        RawClient c;
+        synchronized (lock) {
+            c = client;
+            client = null;
+        }
+        if (c != null) {
+            try {
+                c.close();
+            } catch (Exception e) {
+                log.warn("Exception tearing down connection: ", e);
+            }
         }
     }
 }

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
@@ -218,6 +218,7 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
     }
 
     @Override
+    // TODO: Need to check if we need to mention throws clause in the method signature here or need to handle Exception.
     public StreamCut getNextStreamCut(final StreamCut startingStreamCut, long approxDistanceToNextOffset) throws NoSuchSegmentException, SearchFailedException {
         log.debug("getNextStreamCut() -> startingStreamCut = {}, approxDistanceToNextOffset = {}", startingStreamCut, approxDistanceToNextOffset);
         Preconditions.checkArgument(approxDistanceToNextOffset > 0, "Ensure approxDistanceToNextOffset must be greater than 0");

--- a/client/src/main/java/io/pravega/client/segment/impl/SearchFailedException.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SearchFailedException.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.client.segment.impl;
+
+/**
+ * Exception that is thrown when unable to locate nextOffset for the segment.
+ */
+public class SearchFailedException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public SearchFailedException(String segment) {
+        super("Search failed while getting segment next offset: " + segment);
+    }
+
+    public SearchFailedException(String segment, Throwable t) {
+        super("Search failed while getting segment next offset: " + segment, t);
+    }
+
+}

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -320,11 +320,13 @@ public class BatchClientImplTest {
         Map<SegmentWithRange, List<Long>> segments = new HashMap<>();
         return CompletableFuture.completedFuture(new StreamSegmentsWithPredecessors(segments, ""));
     }
+
     private CompletableFuture<StreamSegmentsWithPredecessors> getScaleDownReplacement(Segment old1, Segment old2, Segment repacement1) {
         Map<SegmentWithRange, List<Long>> segments = new HashMap<>();
         segments.put(new SegmentWithRange(repacement1, 0, 0.35), Arrays.asList(old1.getSegmentId(), old2.getSegmentId()));
         return CompletableFuture.completedFuture(new StreamSegmentsWithPredecessors(segments, ""));
     }
+    
     private CompletableFuture<StreamSegmentsWithPredecessors> getScaleUpReplacement(Segment old, Segment repacement1, Segment repacement2) {
         Map<SegmentWithRange, List<Long>> segments = new HashMap<>();
         segments.put(new SegmentWithRange(repacement1, 0, 0.25), Collections.singletonList(old.getSegmentId()));

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -386,7 +386,7 @@ public class BatchClientImplTest {
     }
 
     @Test(timeout = 5000)
-    public void testGetNextStreamCut_NoSuchSegmentException() throws Exception {
+    public void testGetNextStreamCutWithNoSuchSegmentException() throws Exception {
         Segment segment1 = new Segment("scope", "stream", 1L);
         Map<Segment, Long> positionMap = new HashMap<>();
         positionMap.put(segment1, 30L);
@@ -415,7 +415,7 @@ public class BatchClientImplTest {
     }
 
     @Test(timeout = 5000)
-    public void testGetNextStreamCut_TokenException() throws Exception {
+    public void testGetNextStreamCutWithTokenException() throws Exception {
         Segment segment1 = new Segment("scope", "stream", 1L);
         Map<Segment, Long> positionMap = new HashMap<>();
         positionMap.put(segment1, 30L);
@@ -499,7 +499,7 @@ public class BatchClientImplTest {
                 GetStreamSegmentInfo request = (GetStreamSegmentInfo) invocation.getArgument(0);
                 connectionFactory.getProcessor(location)
                                  .process(new StreamSegmentInfo(request.getRequestId(), request.getSegmentName(), true,
-                                                        false, false, 0, 0, 0));
+                                                                false, false, 0, 0, 0));
                 return null;
             }
         }).when(connection).send(Mockito.any(GetStreamSegmentInfo.class));

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -227,7 +227,7 @@ public class BatchClientImplTest {
     }
 
     @Test(timeout = 5000)
-    public void testGetNextStreamCut_Segment_ScaleUp() throws Exception {
+    public void testGetNextStreamCutSegmentScaleUp() throws Exception {
         Segment segment1 = new Segment("scope", "stream", 1L);
         Segment segment2 = new Segment("scope", "stream", 2L);
         Segment segment3 = new Segment("scope", "stream", 3L);
@@ -268,7 +268,7 @@ public class BatchClientImplTest {
     }
 
     @Test(timeout = 5000)
-    public void testGetNextStreamCut_Segments_ScaleDown_NotForwarded() throws Exception {
+    public void testGetNextStreamCutSegmentsScaleDownNotForwarded() throws Exception {
         Segment segment1 = new Segment("scope", "stream", 1L);
         Segment segment2 = new Segment("scope", "stream", 2L);
         Segment segment3 = new Segment("scope", "stream", 3L);
@@ -308,7 +308,7 @@ public class BatchClientImplTest {
     }
 
     @Test(timeout = 5000)
-    public void testGetNextStreamCut_Segment_ScaleDown() throws Exception {
+    public void testGetNextStreamCutSegmentScaleDown() throws Exception {
         Segment segment1 = new Segment("scope", "stream", 1L);
         Segment segment2 = new Segment("scope", "stream", 2L);
         Segment segment3 = new Segment("scope", "stream", 3L);
@@ -347,7 +347,7 @@ public class BatchClientImplTest {
     }
 
     @Test(timeout = 5000)
-    public void testGetNextStreamCut_NoScaling() throws Exception {
+    public void testGetNextStreamCutNoScaling() throws Exception {
         Segment segment1 = new Segment("scope", "stream", 1L);
         Segment segment2 = new Segment("scope", "stream", 2L);
         Segment segment3 = new Segment("scope", "stream", 3L);
@@ -445,7 +445,7 @@ public class BatchClientImplTest {
     }
 
     @Test(timeout = 5000)
-    public void testGetNextStreamCut_ApproxOffsetGreaterThan0() {
+    public void testGetNextStreamCutWithApproxOffsetGreaterThanZero() {
         Segment segment1 = new Segment("scope", "stream", 1L);
         Map<Segment, Long> positionMap = new HashMap<>();
         positionMap.put(segment1, 30L);
@@ -486,7 +486,7 @@ public class BatchClientImplTest {
         mockController.createStream(scope, streamName, StreamConfiguration.builder()
                                                        .scalingPolicy(ScalingPolicy.fixed(numSegments))
                                                        .build())
-                       .join();
+                      .join();
         return stream;
     }
 
@@ -499,7 +499,7 @@ public class BatchClientImplTest {
                 GetStreamSegmentInfo request = (GetStreamSegmentInfo) invocation.getArgument(0);
                 connectionFactory.getProcessor(location)
                                  .process(new StreamSegmentInfo(request.getRequestId(), request.getSegmentName(), true,
-                                false, false, 0, 0, 0));
+                                                        false, false, 0, 0, 0));
                 return null;
             }
         }).when(connection).send(Mockito.any(GetStreamSegmentInfo.class));
@@ -509,8 +509,8 @@ public class BatchClientImplTest {
 
     private StreamCut getStreamCut(long offset, int... segments) {
         final Map<Segment, Long> positionMap = Arrays.stream(segments).boxed()
-                .collect(Collectors.toMap(s -> new Segment("scope", STREAM, s),
-                        s -> offset));
+                                                     .collect(Collectors.toMap(s -> new Segment("scope", STREAM, s),
+                                                             s -> offset));
 
         return new StreamCutImpl(Stream.of("scope", STREAM), positionMap);
     }

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -436,9 +436,9 @@ public class BatchClientImplTest {
         Stream stream = new StreamImpl(scope, streamName);
         mockController.createScope(scope);
         mockController.createStream(scope, streamName, StreamConfiguration.builder()
-                        .scalingPolicy(ScalingPolicy.fixed(numSegments))
-                        .build())
-                .join();
+                                                       .scalingPolicy(ScalingPolicy.fixed(numSegments))
+                                                       .build())
+                       .join();
         return stream;
     }
 
@@ -450,7 +450,7 @@ public class BatchClientImplTest {
             public Void answer(InvocationOnMock invocation) throws Throwable {
                 GetStreamSegmentInfo request = (GetStreamSegmentInfo) invocation.getArgument(0);
                 connectionFactory.getProcessor(location)
-                        .process(new StreamSegmentInfo(request.getRequestId(), request.getSegmentName(), true,
+                                 .process(new StreamSegmentInfo(request.getRequestId(), request.getSegmentName(), true,
                                 false, false, 0, 0, 0));
                 return null;
             }

--- a/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/BatchClientImplTest.java
@@ -21,6 +21,7 @@ import io.pravega.client.batch.SegmentRange;
 import io.pravega.client.connection.impl.ClientConnection;
 import io.pravega.client.connection.impl.ConnectionPool;
 import io.pravega.client.segment.impl.NoSuchSegmentException;
+import io.pravega.client.segment.impl.SearchFailedException;
 import io.pravega.client.segment.impl.Segment;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
@@ -412,6 +413,35 @@ public class BatchClientImplTest {
             }
         }).when(connection).send(any(WireCommands.LocateOffset.class));
         AssertExtensions.assertThrows(NoSuchSegmentException.class, () -> client.getNextStreamCut(startingSC, 50L));
+    }
+
+    @Test(timeout = 5000)
+    public void testGetNextStreamCutWithSearchFailedException() throws Exception {
+        Segment segment1 = new Segment("scope", "stream", 1L);
+        Map<Segment, Long> positionMap = new HashMap<>();
+        positionMap.put(segment1, 30L);
+        StreamCut startingSC = new StreamCutImpl(Stream.of("scope", "stream"), positionMap);
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", 0);
+        @Cleanup
+        MockConnectionFactoryImpl cf = new MockConnectionFactoryImpl();
+        @Cleanup
+        MockControllerWithSuccessors controller = new MockControllerWithSuccessors(endpoint.getEndpoint(), endpoint.getPort(), cf, getEmptyReplacement().join());
+        ClientConnection connection = mock(ClientConnection.class);
+        cf.provideConnection(endpoint, connection);
+        @Cleanup
+        BatchClientFactoryImpl client = new BatchClientFactoryImpl(controller, ClientConfig.builder().maxConnectionsPerSegmentStore(1).build(), cf);
+        client.getConnection(segment1);
+        ReplyProcessor processor = cf.getProcessor(endpoint);
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+
+                WireCommands.LocateOffset locateOffset = invocation.getArgument(0);
+                processor.process(new WireCommands.IndexSegmentSearchFailed(locateOffset.getRequestId(), locateOffset.getSegment(), "", 30L));
+                return null;
+            }
+        }).when(connection).send(any(WireCommands.LocateOffset.class));
+        AssertExtensions.assertThrows(SearchFailedException.class, () -> client.getNextStreamCut(startingSC, 50L));
     }
 
     @Test(timeout = 5000)

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -1133,7 +1133,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             log.warn(requestId, "Conditional update on Table segment '{}' failed due to bad key version.", segment);
             invokeSafely(connection::send, new WireCommands.TableKeyBadVersion(requestId, segment, clientReplyStackTrace), failureHandler);
         } else if (u instanceof IndexRequestProcessor.SearchFailedException) {
-            log.warn(requestId, "Next offset search failed for '{}' due to {}.", segment, u.getMessage());
+            log.warn(requestId, "Next offset search failed for {} due to {}.", segment, u.getMessage());
             invokeSafely(connection::send, new WireCommands.IndexSegmentSearchFailed(requestId, segment, clientReplyStackTrace, offset), failureHandler);
         } else if (errorCodeExists(u)) {
             log.warn(requestId, "Operation on segment '{}' failed due to a {}.", segment, u.getClass());

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -1132,6 +1132,9 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
         } else if (u instanceof BadKeyVersionException) {
             log.warn(requestId, "Conditional update on Table segment '{}' failed due to bad key version.", segment);
             invokeSafely(connection::send, new WireCommands.TableKeyBadVersion(requestId, segment, clientReplyStackTrace), failureHandler);
+        } else if (u instanceof IndexRequestProcessor.SearchFailedException) {
+            log.warn(requestId, "Next offset search failed for '{}' due to {}.", segment, u.getMessage());
+            invokeSafely(connection::send, new WireCommands.IndexSegmentSearchFailed(requestId, segment, clientReplyStackTrace, offset), failureHandler);
         } else if (errorCodeExists(u)) {
             log.warn(requestId, "Operation on segment '{}' failed due to a {}.", segment, u.getClass());
             invokeSafely(connection::send,

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -237,6 +237,11 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
     }
 
     @Override
+    public void indexSegmentSearchFailed(WireCommands.IndexSegmentSearchFailed indexSegmentSearchFailed) {
+        throw new IllegalStateException("Unexpected operation: " + indexSegmentSearchFailed);
+    }
+
+    @Override
     public void errorMessage(WireCommands.ErrorMessage errorMessage) {
         throw new IllegalStateException("Unexpected operation: " + errorMessage);
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -38,6 +38,8 @@ public interface ReplyProcessor {
 
     void noSuchSegment(WireCommands.NoSuchSegment noSuchSegment);
 
+    void indexSegmentSearchFailed(WireCommands.IndexSegmentSearchFailed indexSegmentSearchFailed);
+
     void tableSegmentNotEmpty(WireCommands.TableSegmentNotEmpty tableSegmentNotEmpty);
 
     void invalidEventNumber(WireCommands.InvalidEventNumber invalidEventNumber);

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -81,6 +81,7 @@ public enum WireCommandType {
     
     LOCATE_OFFSET(41, WireCommands.LocateOffset::readFrom),
     OFFSET_LOCATED(42, WireCommands.OffsetLocated::readFrom),
+    INDEX_SEGMENT_SEARCH_FAILED(43, WireCommands.IndexSegmentSearchFailed::readFrom),
 
     WRONG_HOST(50, WireCommands.WrongHost::readFrom),
     SEGMENT_IS_SEALED(51, WireCommands.SegmentIsSealed::readFrom),

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommands.java
@@ -320,6 +320,49 @@ public final class WireCommands {
     }
 
     @Data
+    public static final class IndexSegmentSearchFailed implements Reply, WireCommand {
+        final WireCommandType type = WireCommandType.INDEX_SEGMENT_SEARCH_FAILED;
+        final long requestId;
+        final String segment;
+        final String serverStackTrace;
+        /**
+         * This represents the target offset that was sent by the request.
+         */
+        final long offset;
+
+        @Override
+        public void process(ReplyProcessor cp) {
+            cp.indexSegmentSearchFailed(this);
+        }
+
+        @Override
+        public void writeFields(DataOutput out) throws IOException {
+            out.writeLong(requestId);
+            out.writeUTF(segment);
+            out.writeUTF(serverStackTrace);
+            out.writeLong(offset);
+        }
+
+        public static WireCommand readFrom(ByteBufInputStream in, int length) throws IOException {
+            long requestId = in.readLong();
+            String segment = in.readUTF();
+            String serverStackTrace = (in.available() > 0) ? in.readUTF() : EMPTY_STACK_TRACE;
+            long offset = in.readLong();
+            return new IndexSegmentSearchFailed(requestId, segment, serverStackTrace, offset);
+        }
+
+        @Override
+        public String toString() {
+            return "Unable to locate next offset for segment: " + segment;
+        }
+
+        @Override
+        public boolean isFailure() {
+            return true;
+        }
+    }
+
+    @Data
     public static final class TableSegmentNotEmpty implements Reply, WireCommand {
         final WireCommandType type = WireCommandType.TABLE_SEGMENT_NOT_EMPTY;
         final long requestId;

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -364,7 +364,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
                 .scalingPolicy(ScalingPolicy.fixed(1))
                 .build();
         Controller controller = controllerWrapper.getController();
-        controllerWrapper.getControllerService().createScope(SCOPE+"-3", 0L).get();
+        controllerWrapper.getControllerService().createScope(SCOPE + "-3", 0L).get();
         controller.createStream(SCOPE + "-3", STREAM + "-3", config).get();
         @Cleanup
         ConnectionFactory connectionFactory = new SocketConnectionFactoryImpl(ClientConfig.builder().build());

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -352,6 +352,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
         StreamCut  nextStreamCut = batchClient.getNextStreamCut(streamCut, approxDistanceToNextOffset);
         assertTrue(nextStreamCut != null);
         assertTrue(nextStreamCut.asImpl().getPositions().size() == 1);
+        assertTrue(nextStreamCut.asImpl().getPositions().containsKey(segment0));
         assertTrue(nextStreamCut.asImpl().getPositions().get(segment0).equals(120L));
 
         StreamCut  nextStreamCut2 = batchClient.getNextStreamCut(nextStreamCut, approxDistanceToNextOffset);
@@ -494,8 +495,8 @@ public class BatchClientTest extends ThreadPooledTestSuite {
         StreamCut streamCut = new StreamCutImpl(Stream.of(SCOPE + "-4", STREAM + "-4"),
                 ImmutableMap.of(segment1, segment1Offset, segment2, segment2Offset));
 
-        long expectedSegment1Offset = map.get(segment1) > 0L ? (segment1Offset + 30L) : 0;
-        long expectedSegment2Offset = map.get(segment2) > 0L ? (segment2Offset + 30L) : 0;
+        long expectedSegment1Offset = map.get(segment1) > 0L ? (segment1Offset + 30L) : 0L;
+        long expectedSegment2Offset = map.get(segment2) > 0L ? (segment2Offset + 30L) : 0L;
         StreamCut  nextStreamCut = batchClient.getNextStreamCut(streamCut, 80L);
         assertTrue(nextStreamCut != null);
         assertTrue(nextStreamCut.asImpl().getPositions().size() == 2);
@@ -616,7 +617,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
                 batchClient.getSegments(Stream.of(SCOPE + "-6", STREAM + "-6"), StreamCut.UNBOUNDED, StreamCut.UNBOUNDED).getIterator());
         Map<Segment, Long> newPositionMap = allSegmentsList.stream().collect(
                 Collectors.toMap(SegmentRange::getSegment, SegmentRange::getEndOffset));
-        long expectedSegment4Offset = newPositionMap.get(segment4) - map.get(segment4) > 30L ? map.get(segment4) + 30L : map.get(segment4);
+        long expectedSegment4Offset = newPositionMap.get(segment4) - map.get(segment4) >= 30L ? map.get(segment4) + 30L : map.get(segment4);
         long expectedSegment5Offset = newPositionMap.get(segment5) > 60L ? 60L : newPositionMap.get(segment5);
         long expectedSegment6Offset = newPositionMap.get(segment6) > 30L ? 30L : newPositionMap.get(segment6);
         long expectedSegment7Offset = newPositionMap.get(segment7) > 30L ? 30L : newPositionMap.get(segment7);

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -303,7 +303,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
     }
 
     @Test(timeout = 50000)
-    public void testNextStreamCut_ScaleUp() throws ExecutionException, InterruptedException {
+    public void testNextStreamCutWithScaleUp() throws ExecutionException, InterruptedException {
         StreamConfiguration config = StreamConfiguration.builder()
                 .scalingPolicy(ScalingPolicy.byEventRate(1, 2, 1))
                 .build();
@@ -359,7 +359,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
     }
 
     @Test(timeout = 50000)
-    public void testNextStreamCut_ScaleDown() throws ExecutionException, InterruptedException {
+    public void testNextStreamCutWithScaleDown() throws ExecutionException, InterruptedException {
         StreamConfiguration config = StreamConfiguration.builder()
                 .scalingPolicy(ScalingPolicy.fixed(1))
                 .build();
@@ -426,7 +426,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
     }
 
     @Test(timeout = 50000)
-    public void testNextStreamCut_ScaleDown_NotForwarded() throws ExecutionException, InterruptedException {
+    public void testNextStreamCutScaleDownNotForwarded() throws ExecutionException, InterruptedException {
         StreamConfiguration config = StreamConfiguration.builder()
                 .scalingPolicy(ScalingPolicy.fixed(1))
                 .build();
@@ -495,7 +495,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
     }
 
     @Test(timeout = 50000)
-    public void testNextStreamCut_Exception() {
+    public void testNextStreamCutException() {
         @Cleanup
         BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE + "-4", clientConfig);
         log.info("Done creating batch client factory");

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -48,6 +48,7 @@ import io.pravega.segmentstore.server.host.handler.PravegaConnectionListener;
 import io.pravega.segmentstore.server.store.ServiceBuilder;
 import io.pravega.segmentstore.server.store.ServiceBuilderConfig;
 import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.InlineExecutor;
 import io.pravega.test.common.TestUtils;
 import io.pravega.test.common.TestingServerStarter;
 import io.pravega.test.common.ThreadPooledTestSuite;
@@ -111,8 +112,10 @@ public class BatchClientTest extends ThreadPooledTestSuite {
         serviceBuilder.initialize();
         StreamSegmentStore store = serviceBuilder.createStreamSegmentService();
         TableStore tableStore = serviceBuilder.createTableStoreService();
+        @Cleanup
+        InlineExecutor indexExecutor = new InlineExecutor();
         server = new PravegaConnectionListener(false, servicePort, store, tableStore, serviceBuilder.getLowPriorityExecutor(),
-                serviceBuilder.getIndexAppendExecutor());
+                indexExecutor);
         server.startListening();
 
         // Create and start controller service

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -299,7 +299,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
         StreamCut  nextStreamCut = batchClient.getNextStreamCut(streamCut, 93L);
         assertTrue(nextStreamCut != null);
         assertTrue(nextStreamCut.asImpl().getPositions().size() == 1);
-        assertTrue(nextStreamCut.asImpl().getPositions().get(segment).equals(300L));
+        assertEquals(300L, nextStreamCut.asImpl().getPositions().get(segment).longValue());
     }
 
     @Test(timeout = 50000)
@@ -353,7 +353,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
         assertTrue(nextStreamCut != null);
         assertTrue(nextStreamCut.asImpl().getPositions().size() == 1);
         assertTrue(nextStreamCut.asImpl().getPositions().containsKey(segment0));
-        assertTrue(nextStreamCut.asImpl().getPositions().get(segment0).equals(120L));
+        assertEquals(120L, nextStreamCut.asImpl().getPositions().get(segment0).longValue());
 
         StreamCut  nextStreamCut2 = batchClient.getNextStreamCut(nextStreamCut, approxDistanceToNextOffset);
         assertTrue(nextStreamCut2 != null);
@@ -429,7 +429,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
         StreamCut  nextStreamCut = batchClient.getNextStreamCut(streamCut, 80L);
         assertTrue(nextStreamCut != null);
         assertTrue(nextStreamCut.asImpl().getPositions().size() == 1);
-        assertTrue(nextStreamCut.asImpl().getPositions().get(segment3).equals(90L));
+        assertEquals(90L, nextStreamCut.asImpl().getPositions().get(segment3).longValue());
     }
 
     @Test(timeout = 50000)


### PR DESCRIPTION
**Change log description**  
Added a new api in the BatchClientFactory to get the NextStreamCut which is at a bounded location from the current streamcut.

**Purpose of the change**  
Spark attempts to load the whole batch of data into Ram before it processes any of it. This means that if for some reason the readers are slow on one batch and a lot of data is written while it is being processed, and when the workers attempt to load the next batch they will OOM.
The goal is to create a way to create a streamCut that is in a location that has not yet been read but is a bounded distance from the reader's current location.

**What the code does**  
When the current streamcut is passed with an approx distance in bytes to get the next streamcut, this new api calls the new wire command iteratively with each segment in the current streamcut to fetch its next Offset. If the returned offset for the segment is same as the current offset (segment might have scaled), then it fetches the successor of the segment and call the new wire command to fetch its offset. In case of scale down, if for any of the previous segment, the new offset is present, then we will not return the successor segment in the stream cut.

**How to verify it**  
N/A
