### PR TITLE
Lookup offset on event boundary

### DIFF
--- a/common/src/main/java/io/pravega/common/util/SortUtils.java
+++ b/common/src/main/java/io/pravega/common/util/SortUtils.java
@@ -1,4 +1,3 @@
-
 /**
  * Copyright Pravega Authors.
  *
@@ -22,8 +21,7 @@ import java.util.Map;
 import java.util.function.LongFunction;
 
 public class SortUtils {
-
-    /**
+     /**
      * Newtonian search: Identical to binary search, but specialized to searching lists of longs.
      * The difference is in how the midpoint is chosen. In a standard binary search, the middle
      * element is always chosen for the guess. In Newtonian search, the midpoint is chosen to be the
@@ -40,8 +38,7 @@ public class SortUtils {
      * @return an Entry object containing the closest index and its value
      * @throws IllegalArgumentException if the input list is empty
      */
-    public static Map.Entry<Long, Long> newtonianSearch(LongFunction<Long> getValue, long fromIdx, long toIdx,
-                                                        long target, boolean greater) {
+     public static Map.Entry<Long, Long> newtonianSearch(LongFunction<Long> getValue, long fromIdx, long toIdx, long target, boolean greater) {
         if (fromIdx > toIdx || fromIdx < 0) {
             throw new IllegalArgumentException("Index size was negative");
         } else if (fromIdx == toIdx) {
@@ -51,19 +48,18 @@ public class SortUtils {
         long fromValue = getValue.apply(fromIdx);
         long toValue = getValue.apply(toIdx);
 
-        if (target <= fromValue) {
-            return new AbstractMap.SimpleEntry<>(fromIdx, fromValue);
-        }
-        if (target >= toValue) {
-            return new AbstractMap.SimpleEntry<>(toIdx, toValue);
+        AbstractMap.SimpleEntry<Long, Long> fromIdx1 = getSimpleEntry(fromIdx, toIdx, target, greater, fromValue, toValue);
+
+        if (fromIdx1 != null) {
+            return fromIdx1;
         }
         double beginSlope = calculateSlope(fromIdx, toIdx, fromValue, toValue);
         double endSlope = beginSlope;
         while (toIdx > fromIdx + 1) {
             double guessProportion = ((double) target - (double) fromValue) / ((double) toValue - (double) fromValue);
-            double slope = (1.0 - guessProportion) * beginSlope + (guessProportion) * endSlope;
+            double slope = (1.0 - guessProportion) * beginSlope + guessProportion * endSlope;
             long guessIdx;
-            if (guessProportion < 0.5) {
+            if ( guessProportion < 0.5 ) {
                 guessIdx = fromIdx + (long) (((double) (target - fromValue)) / slope);
             } else {
                 guessIdx = toIdx - (long) (((double) (toValue - target)) / slope);
@@ -84,6 +80,10 @@ public class SortUtils {
                 return new AbstractMap.SimpleEntry<>(guessIdx, guessValue);
             }
         }
+         return getSimpleEntryBasedOnGreater(fromIdx, toIdx, greater, fromValue, toValue);
+     }
+
+    private static AbstractMap.SimpleEntry<Long, Long> getSimpleEntryBasedOnGreater(long fromIdx, long toIdx, boolean greater, long fromValue, long toValue) {
         if (greater) {
             return new AbstractMap.SimpleEntry<>(toIdx, toValue);
         } else {
@@ -91,14 +91,23 @@ public class SortUtils {
         }
     }
 
+    private static AbstractMap.SimpleEntry<Long, Long> getSimpleEntry(long fromIdx, long toIdx, long target, boolean greater, long fromValue, long toValue) {
+        if (target <= fromValue) {
+            return new AbstractMap.SimpleEntry<>(fromIdx, fromValue);
+        } else if (target >= toValue) {
+            return new AbstractMap.SimpleEntry<>(toIdx, toValue);
+        }
+        return null;
+    }
+
     private static double calculateSlope(long fromIdx, long toIdx, long fromValue, long toValue) {
         //Divide and multiply by 2 to prevent wrapping issues for large values.
-        return 2 * ((double) (toValue/2 - fromValue/2) / (double) (toIdx - fromIdx));
+        return 2 * ((double) (toValue / 2 - fromValue / 2) / (double) (toIdx - fromIdx));
     }
 
     /**
      * Binary search over an external collection of longs.
-     * This is mainly a tests function for reference. Use {@link #newtonianSearch(LongFunction, int, int, long)}
+     * This is mainly a tests function for reference. Use {@link #newtonianSearch(LongFunction, long, long, long, boolean)}
      * If there is an approximately uniform or slowly changing value density.
      *
      * @param getValue The function that returns a long given an index
@@ -109,8 +118,7 @@ public class SortUtils {
      * @throws IllegalArgumentException if the input list is empty
      */
     @VisibleForTesting
-    static Map.Entry<Integer, Long> binarySearch(LongFunction<Long> getValue, int fromIdx, int toIdx,
-                                                 long target) {
+    static Map.Entry<Integer, Long> binarySearch(LongFunction<Long> getValue, int fromIdx, int toIdx, long target) {
         if (fromIdx > toIdx) {
             throw new IllegalArgumentException("Index size was negitive");
         } else if (fromIdx == toIdx) {
@@ -119,11 +127,9 @@ public class SortUtils {
         long fromValue = getValue.apply(fromIdx);
         long toValue = getValue.apply(toIdx);
 
-        if (target <= fromValue) {
-            return new AbstractMap.SimpleEntry<>(fromIdx, fromValue);
-        }
-        if (target >= toValue) {
-            return new AbstractMap.SimpleEntry<>(toIdx, toValue);
+        AbstractMap.SimpleEntry<Integer, Long> fromIdx1 = getIntLongSimpleEntry(fromIdx, toIdx, target, fromValue, toValue);
+        if (fromIdx1 != null) {
+            return fromIdx1;
         }
 
         while (toIdx > fromIdx + 1) {
@@ -141,6 +147,16 @@ public class SortUtils {
             }
         }
         return new AbstractMap.SimpleEntry<>(fromIdx, fromValue);
+    }
+
+    private static AbstractMap.SimpleEntry<Integer, Long> getIntLongSimpleEntry(int fromIdx, int toIdx, long target, long fromValue, long toValue) {
+        if (target <= fromValue) {
+            return new AbstractMap.SimpleEntry<>(fromIdx, fromValue);
+        }
+        if (target >= toValue) {
+            return new AbstractMap.SimpleEntry<>(toIdx, toValue);
+        }
+        return null;
     }
 
 }

--- a/common/src/main/java/io/pravega/common/util/SortUtils.java
+++ b/common/src/main/java/io/pravega/common/util/SortUtils.java
@@ -1,0 +1,146 @@
+
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.pravega.common.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.pravega.common.MathHelpers;
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.function.LongFunction;
+
+public class SortUtils {
+
+    /**
+     * Newtonian search: Identical to binary search, but specialized to searching lists of longs.
+     * The difference is in how the midpoint is chosen. In a standard binary search, the middle
+     * element is always chosen for the guess. In Newtonian search, the midpoint is chosen to be the
+     * index at the percentile the target element would be if the list items were uniformly spaced.
+     * For example, if a list were provided with a minimum element of 0 and a max of 100 and the
+     * target value of 70, then the midpoint would be chosen to be 70% of the way through the list.
+     *
+     * @param getValue The function that returns a long given an index
+     * @param fromIdx The index from which to start the search
+     * @param toIdx The index at which to end the search
+     * @param target The value to search for
+     * @param greater If the element is not in the list true indicates that the next larger element
+     *            should be returned false indicates the next smaller element should be returned
+     * @return an Entry object containing the closest index and its value
+     * @throws IllegalArgumentException if the input list is empty
+     */
+    public static Map.Entry<Long, Long> newtonianSearch(LongFunction<Long> getValue, long fromIdx, long toIdx,
+                                                        long target, boolean greater) {
+        if (fromIdx > toIdx || fromIdx < 0) {
+            throw new IllegalArgumentException("Index size was negative");
+        } else if (fromIdx == toIdx) {
+            return new AbstractMap.SimpleEntry<>(fromIdx, getValue.apply(fromIdx));
+        }
+
+        long fromValue = getValue.apply(fromIdx);
+        long toValue = getValue.apply(toIdx);
+
+        if (target <= fromValue) {
+            return new AbstractMap.SimpleEntry<>(fromIdx, fromValue);
+        }
+        if (target >= toValue) {
+            return new AbstractMap.SimpleEntry<>(toIdx, toValue);
+        }
+        double beginSlope = calculateSlope(fromIdx, toIdx, fromValue, toValue);
+        double endSlope = beginSlope;
+        while (toIdx > fromIdx + 1) {
+            double guessProportion = ((double) target - (double) fromValue) / ((double) toValue - (double) fromValue);
+            double slope = (1.0 - guessProportion) * beginSlope + (guessProportion) * endSlope;
+            long guessIdx;
+            if (guessProportion < 0.5) {
+                guessIdx = fromIdx + (long) (((double) (target - fromValue)) / slope);
+            } else {
+                guessIdx = toIdx - (long) (((double) (toValue - target)) / slope);
+            }
+            guessIdx = MathHelpers.minMax(guessIdx, fromIdx + 1, toIdx - 1);
+
+            long guessValue = getValue.apply(guessIdx);
+            beginSlope = calculateSlope(fromIdx, guessIdx, fromValue, guessValue);
+            endSlope = calculateSlope(guessIdx, toIdx, guessValue, toValue);
+
+            if (guessValue < target) {
+                fromIdx = guessIdx;
+                fromValue = guessValue;
+            } else if (guessValue > target) {
+                toIdx = guessIdx;
+                toValue = guessValue;
+            } else {
+                return new AbstractMap.SimpleEntry<>(guessIdx, guessValue);
+            }
+        }
+        if (greater) {
+            return new AbstractMap.SimpleEntry<>(toIdx, toValue);
+        } else {
+            return new AbstractMap.SimpleEntry<>(fromIdx, fromValue);
+        }
+    }
+
+    private static double calculateSlope(long fromIdx, long toIdx, long fromValue, long toValue) {
+        //Divide and multiply by 2 to prevent wrapping issues for large values.
+        return 2 * ((double) (toValue/2 - fromValue/2) / (double) (toIdx - fromIdx));
+    }
+
+    /**
+     * Binary search over an external collection of longs.
+     * This is mainly a tests function for reference. Use {@link #newtonianSearch(LongFunction, int, int, long)}
+     * If there is an approximately uniform or slowly changing value density.
+     *
+     * @param getValue The function that returns a long given an index
+     * @param fromIdx The index from which to start the search
+     * @param toIdx The index at which to end the search
+     * @param target The value to search for
+     * @return an Entry object containing the closest index and its value
+     * @throws IllegalArgumentException if the input list is empty
+     */
+    @VisibleForTesting
+    static Map.Entry<Integer, Long> binarySearch(LongFunction<Long> getValue, int fromIdx, int toIdx,
+                                                 long target) {
+        if (fromIdx > toIdx) {
+            throw new IllegalArgumentException("Index size was negitive");
+        } else if (fromIdx == toIdx) {
+            return new AbstractMap.SimpleEntry<>(fromIdx, getValue.apply(fromIdx));
+        }
+        long fromValue = getValue.apply(fromIdx);
+        long toValue = getValue.apply(toIdx);
+
+        if (target <= fromValue) {
+            return new AbstractMap.SimpleEntry<>(fromIdx, fromValue);
+        }
+        if (target >= toValue) {
+            return new AbstractMap.SimpleEntry<>(toIdx, toValue);
+        }
+
+        while (toIdx > fromIdx + 1) {
+            int mid = fromIdx + (toIdx - fromIdx) / 2;
+            long midValue = getValue.apply(mid);
+
+            if (midValue < target) {
+                fromIdx = mid;
+                fromValue = midValue;
+            } else if (midValue > target) {
+                toIdx = mid;
+                toValue = midValue;
+            } else {
+                return new AbstractMap.SimpleEntry<>(mid, midValue);
+            }
+        }
+        return new AbstractMap.SimpleEntry<>(fromIdx, fromValue);
+    }
+
+}

--- a/common/src/test/java/io/pravega/common/util/SortUtilTest.java
+++ b/common/src/test/java/io/pravega/common/util/SortUtilTest.java
@@ -136,8 +136,8 @@ public class SortUtilTest {
             expected = new AbstractMap.SimpleEntry<>(toIdx, getValue.apply(toIdx));
         } else {
             maxExpectedInvocationCount = Math.min(length, 4);
-            long expected_idx = (target/multiple);
-            expected = new AbstractMap.SimpleEntry<>(expected_idx, getValue.apply(expected_idx));
+            long expectedIdx = target / multiple;
+            expected = new AbstractMap.SimpleEntry<>(expectedIdx, getValue.apply(expectedIdx));
         }
 
         getValue.resetInvocationCount();
@@ -148,8 +148,6 @@ public class SortUtilTest {
                 expected.getKey(), actual.getKey());
         assertEquals("Incorrect value for length " + length + " multiple " + multiple + " and target " + target,
                 expected.getValue(), actual.getValue());
-
-
         assertTrue("Incorrect number of invocations for length " + length + " multiple " + multiple + " and target " + target,
                 getValue.getInvocationCount() <= maxExpectedInvocationCount);
     }
@@ -205,7 +203,7 @@ public class SortUtilTest {
 
     @Test
     public void testNonUniformDistrobution() {
-        CountingFunction getValue = new CountingFunction(i -> i*i);
+        CountingFunction getValue = new CountingFunction(i -> i * i);
         binarySearch(getValue, 0, 10_000, 1234);
         int baseline = getValue.getInvocationCount();
         getValue.resetInvocationCount();
@@ -220,7 +218,7 @@ public class SortUtilTest {
         long[] sortedArray = new long[arraySize];
         Random random = new Random(0);
         for (int i = 0; i < arraySize; i++) {
-            sortedArray[i] = (random.nextLong());
+            sortedArray[i] = random.nextLong();
         }
         Arrays.sort(sortedArray);
 
@@ -229,7 +227,7 @@ public class SortUtilTest {
 
         // Test the efficiency of the search
 
-        long target = (random.nextLong());
+        long target = random.nextLong();
         countingFunction.resetInvocationCount();
         newtonianSearch(countingFunction, 0, arraySize - 1, target, true);
         long newtonianCount = countingFunction.invocationCount;
@@ -237,7 +235,7 @@ public class SortUtilTest {
         binarySearch(countingFunction, 0, arraySize - 1, target);
         long binaryCount = countingFunction.invocationCount;
 
-        double ratio = (double) newtonianCount / (double ) binaryCount;
+        double ratio = (double) newtonianCount / (double) binaryCount;
         System.out.println("Cost: " + newtonianCount + " compared to binary search: " + binaryCount);
         assertTrue(ratio < 0.5);
 
@@ -246,9 +244,9 @@ public class SortUtilTest {
         long totalInvocationCount = 0;
         for (int i = 0; i < iterations; i++) {
             countingFunction.resetInvocationCount();
-            target = (random.nextLong());
+            target = random.nextLong();
             newtonianSearch(countingFunction, 0, arraySize - 1, target, true);
-            System.out.println("Count: "+ countingFunction.invocationCount);
+            System.out.println("Count: " + countingFunction.invocationCount);
             totalInvocationCount += countingFunction.invocationCount;
         }
 

--- a/common/src/test/java/io/pravega/common/util/SortUtilTest.java
+++ b/common/src/test/java/io/pravega/common/util/SortUtilTest.java
@@ -1,0 +1,437 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.pravega.common.util;
+
+import io.pravega.test.common.AssertExtensions;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.function.LongFunction;
+import lombok.Data;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.pravega.common.util.SortUtils.binarySearch;
+import static io.pravega.common.util.SortUtils.newtonianSearch;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SortUtilTest {
+
+    @Test
+    public void targetValuePresent() {
+        LongFunction<Long> getValue = i -> (long) (i * 2); // Custom data structure where values are
+        // twice the index
+        int start = 0;
+        int end = 9;
+        long target = 8;
+
+        Entry<Long, Long> result = newtonianSearch(getValue, start, end, target, false);
+
+        assertNotNull(result);
+        assertEquals(4, result.getKey().intValue()); // Expected index of the target
+        assertEquals(8, result.getValue().longValue()); // Expected value at the target index
+
+        result = newtonianSearch(getValue, start, end, target, true);
+
+        assertNotNull(result);
+        assertEquals(4, result.getKey().intValue());
+        assertEquals(8, result.getValue().longValue());
+    }
+
+    @Test
+    public void twoElementList() {
+        LongFunction<Long> getValue = i -> (long) (i * 2);
+
+        int start = 0;
+        int end = 1;
+
+        Entry<Long, Long> result = newtonianSearch(getValue, start, end, 3, false);
+        assertEquals(1, result.getKey().intValue());
+        assertEquals(2, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, -1, false);
+        assertEquals(0, result.getKey().intValue());
+        assertEquals(0, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, 0, false);
+        assertEquals(0, result.getKey().intValue());
+        assertEquals(0, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, 1, false);
+        assertEquals(0, result.getKey().intValue());
+        assertEquals(0, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, 2, false);
+        assertEquals(1, result.getKey().intValue());
+        assertEquals(2, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, 3, false);
+        assertEquals(1, result.getKey().intValue());
+        assertEquals(2, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, 3, true);
+        assertEquals(1, result.getKey().intValue());
+        assertEquals(2, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, -1, true);
+        assertEquals(0, result.getKey().intValue());
+        assertEquals(0, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, 0, true);
+        assertEquals(0, result.getKey().intValue());
+        assertEquals(0, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, 1, true);
+        assertEquals(1, result.getKey().intValue());
+        assertEquals(2, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, 2, true);
+        assertEquals(1, result.getKey().intValue());
+        assertEquals(2, result.getValue().longValue());
+
+        result = newtonianSearch(getValue, start, end, 3, true);
+        assertEquals(1, result.getKey().intValue());
+        assertEquals(2, result.getValue().longValue());
+    }
+
+    @Test
+    public void testNewtonianLengthsAndPositions() {
+        for (int length = 1; length <= 10; length++) {
+            for (int multiple = 1; multiple <= 5; multiple++) {
+                for (int target = -1; target <= length * multiple; target++) {
+                    testNewtonianSearchForLengthAndPosition(multiple, length, target);
+                }
+            }
+        }
+    }
+
+    private void testNewtonianSearchForLengthAndPosition(int multiple, int length, int target) {
+        CountingFunction getValue = new CountingFunction(i -> i * multiple);
+
+        long fromIdx = 0;
+        long toIdx = length - 1;
+        int maxExpectedInvocationCount;
+
+        Map.Entry<Long, Long> expected;
+        if (target <= 0) {
+            maxExpectedInvocationCount = Math.min(length, 2);
+            expected = new AbstractMap.SimpleEntry<>(fromIdx, getValue.apply(fromIdx));
+        } else if (target >= (length - 1) * multiple ) {
+            maxExpectedInvocationCount = Math.min(length, 2);
+            expected = new AbstractMap.SimpleEntry<>(toIdx, getValue.apply(toIdx));
+        } else {
+            maxExpectedInvocationCount = Math.min(length, 4);
+            long expected_idx = (target/multiple);
+            expected = new AbstractMap.SimpleEntry<>(expected_idx, getValue.apply(expected_idx));
+        }
+
+        getValue.resetInvocationCount();
+
+        Entry<Long, Long> actual = newtonianSearch(getValue, fromIdx, toIdx, target, false);
+
+        assertEquals("Incorrect index for length " + length + " multiple " + multiple + " and target " + target,
+                expected.getKey(), actual.getKey());
+        assertEquals("Incorrect value for length " + length + " multiple " + multiple + " and target " + target,
+                expected.getValue(), actual.getValue());
+
+
+        assertTrue("Incorrect number of invocations for length " + length + " multiple " + multiple + " and target " + target,
+                getValue.getInvocationCount() <= maxExpectedInvocationCount);
+    }
+
+    @Test
+    public void testBinaryLengthsAndPositions() {
+        for (int length = 1; length <= 10; length++) {
+            for (int position = -1; position <= length; position++) {
+                testBinarySearchForLengthAndPosition(length, position);
+            }
+        }
+    }
+
+    private void testBinarySearchForLengthAndPosition(int length, int position) {
+        CountingFunction getValue = new CountingFunction(i -> i);
+
+        int fromIdx = 0;
+        int toIdx = length - 1;
+        long target = position;
+
+        Map.Entry<Integer, Long> expected;
+        if (position <= 0) {
+            expected = new AbstractMap.SimpleEntry<>(fromIdx, getValue.apply(fromIdx));
+        } else if (position >= length - 1) {
+            expected = new AbstractMap.SimpleEntry<>(toIdx, getValue.apply(toIdx));
+        } else {
+            expected = new AbstractMap.SimpleEntry<>(position, getValue.apply(position));
+        }
+
+        Map.Entry<Integer, Long> actual = binarySearch(getValue, fromIdx, toIdx, target);
+
+        assertEquals("Incorrect index for length " + length + " and position " + position,
+                expected.getKey(), actual.getKey());
+        assertEquals("Incorrect value for length " + length + " and position " + position,
+                expected.getValue(), actual.getValue());
+    }
+
+    @Data
+    private static class CountingFunction implements LongFunction<Long> {
+        private int invocationCount;
+        private final LongFunction<Long> call;
+
+        @Override
+        public Long apply(long value) {
+            invocationCount++;
+            return call.apply(value);
+        }
+
+        public void resetInvocationCount() {
+            invocationCount = 0;
+        }
+    }
+
+    @Test
+    public void testNonUniformDistrobution() {
+        CountingFunction getValue = new CountingFunction(i -> i*i);
+        binarySearch(getValue, 0, 10_000, 1234);
+        int baseline = getValue.getInvocationCount();
+        getValue.resetInvocationCount();
+        newtonianSearch(getValue, 0, 10_000, 1234, false);
+        assertTrue("Implementation should be more efficent that binary search", getValue.invocationCount <= baseline);
+    }
+
+    @Test
+    public void targetEfficency() {
+        // Create a sorted array of random numbers
+        int arraySize = 100000;
+        long[] sortedArray = new long[arraySize];
+        Random random = new Random(0);
+        for (int i = 0; i < arraySize; i++) {
+            sortedArray[i] = (random.nextLong());
+        }
+        Arrays.sort(sortedArray);
+
+        // Create an instance of the counting function
+        CountingFunction countingFunction = new CountingFunction(countingValue -> sortedArray[(int) countingValue]);
+
+        // Test the efficiency of the search
+
+        long target = (random.nextLong());
+        countingFunction.resetInvocationCount();
+        newtonianSearch(countingFunction, 0, arraySize - 1, target, true);
+        long newtonianCount = countingFunction.invocationCount;
+        countingFunction.resetInvocationCount();
+        binarySearch(countingFunction, 0, arraySize - 1, target);
+        long binaryCount = countingFunction.invocationCount;
+
+        double ratio = (double) newtonianCount / (double ) binaryCount;
+        System.out.println("Cost: " + newtonianCount + " compared to binary search: " + binaryCount);
+        assertTrue(ratio < 0.5);
+
+        // Test the efficiency of the search
+        int iterations = 100;
+        long totalInvocationCount = 0;
+        for (int i = 0; i < iterations; i++) {
+            countingFunction.resetInvocationCount();
+            target = (random.nextLong());
+            newtonianSearch(countingFunction, 0, arraySize - 1, target, true);
+            System.out.println("Count: "+ countingFunction.invocationCount);
+            totalInvocationCount += countingFunction.invocationCount;
+        }
+
+        double averageInvocationCount = (double) totalInvocationCount / iterations;
+        System.out.println("Average invocation count: " + averageInvocationCount);
+
+    }
+
+    @Test
+    public void targetValueNotPresent() {
+        LongFunction<Long> getValue = i -> (long) (i * 2); // Custom data structure where values are
+        // twice the index
+        int start = 0;
+        int end = 9;
+        long target = 7;
+
+        Entry<Long, Long> result = newtonianSearch(getValue, start, end, target, false);
+
+        Assert.assertNotNull(result);
+        assertEquals(3, result.getKey().intValue()); // Expected index of the closest value
+        assertEquals(6, result.getValue().longValue()); // Expected value at the closest index
+
+        result = newtonianSearch(getValue, start, end, target, true);
+
+        Assert.assertNotNull(result);
+        assertEquals(4, result.getKey().intValue()); // Expected index of the closest value
+        assertEquals(8, result.getValue().longValue()); // Expected value at the closest index
+    }
+
+    @Test
+    public void exactValue() {
+        LongFunction<Long> getValue = idx -> (long) idx;
+        int fromIdx = 0;
+        int toIdx = 9;
+        long target = 7;
+
+        Entry<Long, Long> expected = new AbstractMap.SimpleEntry<>(7L, 7L);
+        Entry<Long, Long> actual = newtonianSearch(getValue, fromIdx, toIdx, target, false);
+
+        assertEquals("Incorrect index", expected.getKey(), actual.getKey());
+        assertEquals("Incorrect value", expected.getValue(), actual.getValue());
+
+        actual = newtonianSearch(getValue, fromIdx, toIdx, target, true);
+
+        assertEquals("Incorrect index", expected.getKey(), actual.getKey());
+        assertEquals("Incorrect value", expected.getValue(), actual.getValue());
+    }
+
+    @Test
+    public void testRoundDown() {
+        LongFunction<Long> getValue = idx -> (long) (idx * 10);
+        int fromIdx = 0;
+        int toIdx = 9;
+        long target = 75;
+
+        Entry<Long, Long> expected = new AbstractMap.SimpleEntry<>(7L, 70L);
+        Entry<Long, Long> actual = newtonianSearch(getValue, fromIdx, toIdx, target, false);
+
+        assertEquals("Incorrect index", expected.getKey(), actual.getKey());
+        assertEquals("Incorrect value", expected.getValue(), actual.getValue());
+
+        getValue = idx -> (long) (idx * 5);
+        fromIdx = 0;
+        toIdx = 5;
+        target = 18;
+
+        expected = new AbstractMap.SimpleEntry<>(3L, 15L);
+        actual = newtonianSearch(getValue, fromIdx, toIdx, target, false);
+
+        assertEquals("Incorrect index", expected.getKey(), actual.getKey());
+        assertEquals("Incorrect value", expected.getValue(), actual.getValue());
+    }
+
+    @Test
+    public void testRoundUp() {
+        LongFunction<Long> getValue = idx -> (long) (idx * 10);
+        int fromIdx = 0;
+        int toIdx = 9;
+        long target = 75;
+
+        Entry<Long, Long> expected = new AbstractMap.SimpleEntry<>(8L, 80L);
+        Entry<Long, Long> actual = newtonianSearch(getValue, fromIdx, toIdx, target, true);
+
+        Assert.assertEquals("Incorrect index", expected.getKey(), actual.getKey());
+        Assert.assertEquals("Incorrect value", expected.getValue(), actual.getValue());
+
+        getValue = idx -> (long) (idx * 5);
+        fromIdx = 0;
+        toIdx = 5;
+        target = 18;
+
+        expected = new AbstractMap.SimpleEntry<>(4L, 20L);
+        actual = newtonianSearch(getValue, fromIdx, toIdx, target, true);
+
+        Assert.assertEquals("Incorrect index", expected.getKey(), actual.getKey());
+        Assert.assertEquals("Incorrect value", expected.getValue(), actual.getValue());
+    }
+
+    @Test
+    public void emptyList() {
+        LongFunction<Long> getValue = idx -> (long) idx;
+        int fromIdx = 0;
+        int toIdx = -1; // Empty list, invalid index range
+        long target = 7;
+        AssertExtensions.assertThrows(
+                IllegalArgumentException.class, () -> newtonianSearch(getValue, fromIdx, toIdx, target, false));
+    }
+
+    @Test
+    public void singleItem() {
+        LongFunction<Long> getValue = idx -> (long) idx;
+        int fromIdx = 0;
+        int toIdx = 0;
+        long target = 7;
+        Entry<Long, Long> expected = new AbstractMap.SimpleEntry<>(0L, 0L);
+        Entry<Long, Long> actual = newtonianSearch(getValue, fromIdx, toIdx, target, false);
+
+        assertEquals("Incorrect index", expected.getKey(), actual.getKey());
+        assertEquals("Incorrect value", expected.getValue(), actual.getValue());
+    }
+
+    @Test
+    public void targetBeforeRange() {
+        LongFunction<Long> getValue = idx -> (long) idx;
+        int fromIdx = 5;
+        int toIdx = 10;
+        long target = 3; // Target is before the range of values
+
+        Entry<Long, Long> expected = new AbstractMap.SimpleEntry<>(5L, 5L);
+        Entry<Long, Long> actual = newtonianSearch(getValue, fromIdx, toIdx, target, false);
+
+        assertEquals("Incorrect index", expected.getKey(), actual.getKey());
+        assertEquals("Incorrect value", expected.getValue(), actual.getValue());
+    }
+
+    @Test
+    public void targetAfterRange() {
+        LongFunction<Long> getValue = idx -> (long) idx;
+        int fromIdx = 0;
+        int toIdx = 5;
+        long target = 10; // Target is after the range of values
+
+        Entry<Long, Long> expected = new AbstractMap.SimpleEntry<>(5L, 5L);
+        Entry<Long, Long> actual = newtonianSearch(getValue, fromIdx, toIdx, target, true);
+
+        assertEquals("Incorrect index", expected.getKey(), actual.getKey());
+        assertEquals("Incorrect value", expected.getValue(), actual.getValue());
+    }
+
+    @Test
+    public void testLargeRange() {
+        // Create a large range of values from 1 to 1 million
+        int rangeSize = 1_000;
+        LongFunction<Long> getValue = idx -> idx * (long) idx;
+
+        // Test a target value within the range
+        long target = 10_000;
+        Entry<Long, Long> result = newtonianSearch(getValue, 0, rangeSize, target, false);
+        assertEquals(100, result.getKey().intValue());
+        assertEquals(10_000, result.getValue().longValue());
+
+        // Test a target value within the range
+        target = 10_001;
+        result = newtonianSearch(getValue, 0, rangeSize, target, false);
+        assertEquals(100, result.getKey().intValue());
+        assertEquals(10_000, result.getValue().longValue());
+
+        // Test a target value before the range
+        target = 0;
+        result = newtonianSearch(getValue, 0, rangeSize, target, false);
+        assertEquals(0, result.getKey().intValue());
+        assertEquals(0, result.getValue().longValue());
+
+        target = 0;
+        result = newtonianSearch(getValue, 10, rangeSize, target, false);
+        assertEquals(10, result.getKey().intValue());
+        assertEquals(100, result.getValue().longValue());
+
+        // Test a target value after the range
+        target = 1_000_000 + 100;
+        result = newtonianSearch(getValue, 0, rangeSize, target, false);
+        assertEquals(rangeSize, result.getKey().intValue());
+        assertEquals(rangeSize * rangeSize, result.getValue().longValue());
+    }
+
+}

--- a/config/config.properties
+++ b/config/config.properties
@@ -695,3 +695,27 @@ pravegaservice.admin.gateway.port=9999
 #pravegaservice.default.single.connections.max.outstanding.bytes=134217728
 
 ##endregion
+
+##region connection tracker
+
+#Maximum allowed outstanding bytes from all connections. If we exceed this value, all connections should be paused.
+#default value is 512*1024*1024
+#pravegaservice.default.all.connections.max.outstanding.bytes=536870912
+
+#Maximum allowed outstanding bytes from a single connection. If we exceed this value, that connection should be paused.
+#Default value is one-fourth of default.all.connections.max.outstanding.bytes i.e 128*1024*1024
+#pravegaservice.default.single.connections.max.outstanding.bytes=134217728
+
+##endregion
+
+##region connection tracker
+
+#Maximum allowed outstanding bytes from all connections. If we exceed this value, all connections should be paused.
+#default value is 512*1024*1024
+#pravegaservice.default.all.connections.max.outstanding.bytes=536870912
+
+#Maximum allowed outstanding bytes from a single connection. If we exceed this value, that connection should be paused.
+#Default value is one-fourth of default.all.connections.max.outstanding.bytes i.e 128*1024*1024
+#pravegaservice.default.single.connections.max.outstanding.bytes=134217728
+
+##endregion

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/IndexRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/IndexRequestProcessor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.pravega.segmentstore.server.host.handler;
 
 import io.pravega.common.util.BufferView;
@@ -68,7 +83,7 @@ public final class IndexRequestProcessor {
                 case EndOfStreamSegment:
                 case Truncated:
                 default:
-                    throw new SearchFailedException("Index segment was of unexpected size: "+ firstElement.getType());
+                    throw new SearchFailedException("Index segment was of unexpected size: " + firstElement.getType());
             }
         }, startIdx, endIdx, targetOffset, true).getValue();
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/IndexRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/IndexRequestProcessor.java
@@ -1,0 +1,78 @@
+package io.pravega.segmentstore.server.host.handler;
+
+import io.pravega.common.util.BufferView;
+import io.pravega.common.util.BufferView.Reader;
+import io.pravega.common.util.ByteArraySegment;
+import io.pravega.common.util.SortUtils;
+import io.pravega.segmentstore.contracts.ReadResult;
+import io.pravega.segmentstore.contracts.ReadResultEntry;
+import io.pravega.segmentstore.contracts.SegmentProperties;
+import io.pravega.segmentstore.contracts.StreamSegmentStore;
+import io.pravega.shared.NameUtils;
+import java.time.Duration;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class IndexRequestProcessor {
+    private static final Duration TIMEOUT = Duration.ofMinutes(1);
+    private static final int ENTRY_SIZE = 16; //TODO obtain from property.
+
+    static final class SearchFailedException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public SearchFailedException(String message) {
+            super(message);
+        }
+    }
+
+    @Data
+    private static final class IndexEntry {
+        private final long eventCount;
+        private final long offset;
+
+        BufferView toBytes() {
+            ByteArraySegment result = new ByteArraySegment(new byte[16]);
+            result.setLong(0, eventCount);
+            result.setLong(8, offset);
+            return result;
+        }
+
+        static IndexEntry fromBytes(BufferView view) {
+            Reader reader = view.getBufferViewReader();
+            long eventCount = reader.readLong();
+            long offset = reader.readLong();
+            return new IndexEntry(eventCount, offset);
+        }
+    }
+
+    public static long locateOffsetForStream(StreamSegmentStore store, String stream, long targetOffset) throws SearchFailedException {
+        String indexSegmentName = NameUtils.getIndexSegmentName(stream);
+
+        //Fetch start and end idx.
+        SegmentProperties properties = store.getStreamSegmentInfo(indexSegmentName, TIMEOUT).join();
+        long startIdx = properties.getStartOffset() / ENTRY_SIZE;
+        long endIdx = properties.getLength() / ENTRY_SIZE;
+
+        return SortUtils.newtonianSearch(idx -> {
+            ReadResult result = store.read(indexSegmentName, idx * ENTRY_SIZE, ENTRY_SIZE, TIMEOUT).join();
+            ReadResultEntry firstElement = result.next();
+            // TODO deal with element which is split over multiple entries.
+            switch (firstElement.getType()) {
+                case Cache: // fallthrough
+                case Storage:
+                    BufferView content = firstElement.getContent().join();
+                    IndexEntry entry = IndexEntry.fromBytes(content);
+                    return entry.offset;
+                case Future:
+                case EndOfStreamSegment:
+                case Truncated:
+                default:
+                    throw new SearchFailedException("Index segment was of unexpected size: "+ firstElement.getType());
+            }
+        }, startIdx, endIdx, targetOffset, true).getValue();
+
+    }
+
+
+}

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaRequestProcessor.java
@@ -59,11 +59,9 @@ import io.pravega.segmentstore.contracts.tables.TableStore;
 import io.pravega.segmentstore.server.IllegalContainerStateException;
 import io.pravega.segmentstore.server.host.delegationtoken.DelegationTokenVerifier;
 import io.pravega.segmentstore.server.host.delegationtoken.PassingTokenVerifier;
-import io.pravega.segmentstore.server.host.handler.IndexRequestProcessor.SearchFailedException;
 import io.pravega.segmentstore.server.host.stat.SegmentStatsRecorder;
 import io.pravega.segmentstore.server.host.stat.TableSegmentStatsRecorder;
 import io.pravega.segmentstore.server.tables.DeltaIteratorState;
-import io.pravega.shared.NameUtils;
 import io.pravega.shared.protocol.netty.ByteBufWrapper;
 import io.pravega.shared.protocol.netty.FailingRequestProcessor;
 import io.pravega.shared.protocol.netty.RequestProcessor;
@@ -698,7 +696,7 @@ public class PravegaRequestProcessor extends FailingRequestProcessor implements 
             handleException(requestId, segment, operation, e);
         }
     }
-    s
+
     @Override
     public void getTableSegmentInfo(WireCommands.GetTableSegmentInfo getInfo) {
         final String operation = "getTableSegmentInfo";

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -968,7 +968,6 @@ public final class NameUtils {
         sb.append(stream);
         return sb.toString();
     }
-    // endregion
 
     /**
      * Parse the connection name to fetch the connection details.

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/DelegatingRequestProcessor.java
@@ -157,6 +157,11 @@ public abstract class DelegatingRequestProcessor implements RequestProcessor {
     }
 
     @Override
+    public void locateOffset(WireCommands.LocateOffset locateOffset) {
+        getNextRequestProcessor().locateOffset(locateOffset);
+    }
+    
+    @Override
     public void connectionDropped() {
         getNextRequestProcessor().connectionDropped();
     }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingReplyProcessor.java
@@ -230,6 +230,11 @@ public abstract class FailingReplyProcessor implements ReplyProcessor {
     public void tableEntriesDeltaRead(WireCommands.TableEntriesDeltaRead tableEntriesDeltaRead) {
         throw new IllegalStateException("Unexpected operation: " + tableEntriesDeltaRead);
     }
+    
+    @Override
+    public void offsetLocated(WireCommands.OffsetLocated offsetLocated) {
+        throw new IllegalStateException("Unexpected operation: " + offsetLocated);
+    }
 
     @Override
     public void errorMessage(WireCommands.ErrorMessage errorMessage) {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/FailingRequestProcessor.java
@@ -159,6 +159,11 @@ public class FailingRequestProcessor implements RequestProcessor {
     public void createTransientSegment(WireCommands.CreateTransientSegment createTransientSegment) {
         throw new IllegalStateException("Unexpected operation");
     }
+    
+    @Override
+    public void locateOffset(WireCommands.LocateOffset locateOffset) {
+        throw new IllegalStateException("Unexpected operation");
+    }
 
     @Override
     public void connectionDropped() {

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/ReplyProcessor.java
@@ -101,6 +101,8 @@ public interface ReplyProcessor {
     void tableEntriesRead(WireCommands.TableEntriesRead tableEntriesRead);
 
     void tableEntriesDeltaRead(WireCommands.TableEntriesDeltaRead tableEntriesDeltaRead);
+    
+    void offsetLocated(WireCommands.OffsetLocated offsetLocated);
 
     void errorMessage(WireCommands.ErrorMessage errorMessage);
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/RequestProcessor.java
@@ -86,6 +86,8 @@ public interface RequestProcessor {
     void readTableEntriesDelta(WireCommands.ReadTableEntriesDelta readTableEntriesDelta);
 
     void createTransientSegment(WireCommands.CreateTransientSegment createTransientSegment);
+    
+    void locateOffset(WireCommands.LocateOffset locateOffset);
 
     void connectionDropped();
 }

--- a/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/protocol/netty/WireCommandType.java
@@ -78,6 +78,9 @@ public enum WireCommandType {
     SEGMENT_TRUNCATED(39, WireCommands.SegmentTruncated::readFrom),
 
     CREATE_TRANSIENT_SEGMENT(40, WireCommands.CreateTransientSegment::readFrom),
+    
+    LOCATE_OFFSET(41, WireCommands.LocateOffset::readFrom),
+    OFFSET_LOCATED(42, WireCommands.OffsetLocated::readFrom),
 
     WRONG_HOST(50, WireCommands.WrongHost::readFrom),
     SEGMENT_IS_SEALED(51, WireCommands.SegmentIsSealed::readFrom),


### PR DESCRIPTION
**Change log description**  
This PR has changes to get event boundary near an offset.
- This involves performing a Newtonian search over the index segment to locate an offset near to the on provided. If the offset 
requested is off the end of the segment return the end offset.
- Add the wire commands to support this request and reply.