### PR TITLE
Issue 7147: New client API to cancel all outstanding checkpoints

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -47,6 +47,12 @@ public interface ReaderGroup extends ReaderGroupNotificationListener, AutoClosea
      */
     String getScope();
 
+    /**
+     * Cancels the outStanding checkpoints.
+     *
+     * @return true if the outStanding checkpoints are cleared.
+     */
+
     boolean cancelOutstandingCheckpoints();
 
     /**

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -16,6 +16,8 @@
 package io.pravega.client.stream;
 
 import com.google.common.annotations.Beta;
+import io.pravega.client.state.StateSynchronizer;
+import io.pravega.client.stream.impl.ReaderGroupState;
 import io.pravega.client.stream.notifications.ReaderGroupNotificationListener;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +55,7 @@ public interface ReaderGroup extends ReaderGroupNotificationListener, AutoClosea
      * @return true if the outStanding checkpoints are cleared.
      */
 
-    boolean cancelOutstandingCheckpoints();
+    void cancelOutstandingCheckpoints();
 
     /**
      * Returns the name of the group.

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -16,8 +16,6 @@
 package io.pravega.client.stream;
 
 import com.google.common.annotations.Beta;
-import io.pravega.client.state.StateSynchronizer;
-import io.pravega.client.stream.impl.ReaderGroupState;
 import io.pravega.client.stream.notifications.ReaderGroupNotificationListener;
 import java.util.Map;
 import java.util.Set;
@@ -51,8 +49,6 @@ public interface ReaderGroup extends ReaderGroupNotificationListener, AutoClosea
 
     /**
      * Cancels the outStanding checkpoints.
-     *
-     * @return true if the outStanding checkpoints are cleared.
      */
 
     void cancelOutstandingCheckpoints();

--- a/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
+++ b/client/src/main/java/io/pravega/client/stream/ReaderGroup.java
@@ -47,6 +47,8 @@ public interface ReaderGroup extends ReaderGroupNotificationListener, AutoClosea
      */
     String getScope();
 
+    boolean cancelOutstandingCheckpoints();
+
     /**
      * Returns the name of the group.
      *

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -209,9 +209,9 @@ public class CheckpointState {
            uncheckpointedHosts.remove(cp);
            checkpointPositions.remove(cp);
        }
-    recomputeCheckpointIndex();
+       recomputeCheckpointIndex();
        return true;
-}
+    }
 
     /**
      * Get the map of CheckpointId to list of readers blocking that checkpoint.

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -202,13 +202,11 @@ public class CheckpointState {
      */
     boolean removeOutstandingCheckpoints() {
        List<String> checkpoint = getOutstandingCheckpoints();
-       if (checkpoint.isEmpty()) {
-           return false;
-       }
        for (String cp:checkpoint) {
            uncheckpointedHosts.remove(cp);
            checkpointPositions.remove(cp);
        }
+
        recomputeCheckpointIndex();
        return true;
     }

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -197,6 +197,23 @@ public class CheckpointState {
     }
 
     /**
+     * Removes the outstanding checkpoints.
+     * @return false when there are no outstanding checkpoints otherwise true
+     */
+    boolean removeOutstandingCheckpoints() {
+       List<String> checkpoint = getOutstandingCheckpoints();
+       if (checkpoint.isEmpty()) {
+           return false;
+       }
+       for (String cp:checkpoint) {
+           uncheckpointedHosts.remove(cp);
+           checkpointPositions.remove(cp);
+       }
+    recomputeCheckpointIndex();
+       return true;
+}
+
+    /**
      * Get the map of CheckpointId to list of readers blocking that checkpoint.
      * @return the map.
      */

--- a/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/CheckpointState.java
@@ -198,17 +198,15 @@ public class CheckpointState {
 
     /**
      * Removes the outstanding checkpoints.
-     * @return false when there are no outstanding checkpoints otherwise true
      */
-    boolean removeOutstandingCheckpoints() {
+    void removeOutstandingCheckpoints() {
        List<String> checkpoint = getOutstandingCheckpoints();
        for (String cp:checkpoint) {
            uncheckpointedHosts.remove(cp);
            checkpointPositions.remove(cp);
        }
-
        recomputeCheckpointIndex();
-       return true;
+       log.info("Outstanding checkpoints are cleared successfully");
     }
 
     /**

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -546,14 +546,12 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
 
     /**
      * Cancels the outStanding checkpoints.
-     *
-     * @returns true if the outStanding checkpoints are cleared.
      */
     @Override
     public void cancelOutstandingCheckpoints() {
         synchronizer.updateState((state, updates) -> {
             updates.add(new ReaderGroupState.RemoveOutstandingCheckpoints());
-            return true; // Always return true since we are only modifying state
+            return true;
         });
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -18,7 +18,6 @@ package io.pravega.client.stream.impl;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import io.pravega.client.ClientConfig;
 import io.pravega.client.SynchronizerClientFactory;
 import io.pravega.client.connection.impl.ConnectionPool;
 import io.pravega.client.control.impl.Controller;

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -116,15 +116,6 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
         this.notifierFactory = new NotifierFactory(new NotificationSystem(), synchronizer);
     }
 
-    /**
-     * Cancels the outStanding checkpoints.
-     * @returns true if the outStanding checkpoints are cleared.
-     */
-    public boolean cancelOutstandingCheckpoints() {
-   ReaderGroupState state = synchronizer.getState();
-   return state.getCheckpointState().removeOutstandingCheckpoints();
-}
-
     @Override
     public void updateRetentionStreamCut(Map<Stream, StreamCut> streamCuts) {
         synchronizer.fetchUpdates();
@@ -549,5 +540,14 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
     public void close() {
         synchronizer.close();
         sequentialProcessor.close();
+    }
+
+    /**
+     * Cancels the outStanding checkpoints.
+     * @returns true if the outStanding checkpoints are cleared.
+     */
+    public boolean cancelOutstandingCheckpoints() {
+        ReaderGroupState state = synchronizer.getState();
+        return state.getCheckpointState().removeOutstandingCheckpoints();
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -116,6 +116,15 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
         this.notifierFactory = new NotifierFactory(new NotificationSystem(), synchronizer);
     }
 
+    /**
+     * Cancels the outStanding checkpoints.
+     * @returns true if the outStanding checkpoints are cleared.
+     */
+    public boolean cancelOutstandingCheckpoints() {
+   ReaderGroupState state = synchronizer.getState();
+   return state.getCheckpointState().removeOutstandingCheckpoints();
+}
+
     @Override
     public void updateRetentionStreamCut(Map<Stream, StreamCut> streamCuts) {
         synchronizer.fetchUpdates();

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -188,7 +188,7 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
 
     /**
      * Periodically check the state synchronizer if the given Checkpoint is complete.
-     * @param checkpointName     Checkpoint name.
+     * @param checkpointName Checkpoint name.
      * @param backgroundExecutor Executor on which the asynchronous task will run.
      * @return A CompletableFuture will be complete once the Checkpoint is complete.
      */
@@ -204,9 +204,9 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
                         log.info("Waiting on checkpoint: {} currentState is: {}", checkpointName, synchronizer.getState());
                     }
                     return CompletableFuture.completedFuture(null);
-                });
+               });
                return null;
-           }, Duration.ofMillis(500), backgroundExecutor);
+            }, Duration.ofMillis(500), backgroundExecutor);
         }, backgroundExecutor);
     }
 
@@ -271,8 +271,8 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
                         } else {
                           // ReaderGroup IDs matched so our create was updated on Controller
                           return CompletableFuture.completedFuture(conf.getGeneration());
-                        }
-                        }));
+                       }
+                       }));
                     updateConfigInStateSynchronizer(updateConfig, nextGen);
                 } else {
                     // normal code path

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupImpl.java
@@ -549,17 +549,13 @@ public final class ReaderGroupImpl implements ReaderGroup, ReaderGroupMetrics {
      *
      * @returns true if the outStanding checkpoints are cleared.
      */
-    public boolean cancelOutstandingCheckpoints() {
-    ReaderGroupState state = synchronizer.getState();
-    return state.getCheckpointState().removeOutstandingCheckpoints();
+    @Override
+    public void cancelOutstandingCheckpoints() {
+        synchronizer.updateState((state, updates) -> {
+            updates.add(new ReaderGroupState.RemoveOutstandingCheckpoints());
+            return true; // Always return true since we are only modifying state
+        });
     }
-    //public static void cancelOutstandingCheckpoints(
-           // StateSynchronizer<ReaderGroupState> synchronizer) {
-        //boolean rmCheckpoint = synchronizer.updateState((state, updates) -> {
-            // updates.add(new ReaderGroupState.RemoveOutstandingCheckpoints());
-           // return true; // Always return true since we are only modifying state
-       // });
-    }
-
+}
 
 

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -1201,6 +1201,7 @@ public class ReaderGroupState implements Revisioned {
 
         }
 
+
         private static class ClearCheckpointsBeforeSerializer
                 extends VersionedSerializer.WithBuilder<ClearCheckpointsBefore, ClearCheckpointsBeforeBuilder> {
             @Override
@@ -1227,7 +1228,22 @@ public class ReaderGroupState implements Revisioned {
             }
         }
     }
+    @Builder
+    @Data
+    @EqualsAndHashCode(callSuper = false)
+    static class RemoveOutstandingCheckpoints extends ReaderGroupStateUpdate {
+        private final String removeOutstandingCheckpoints;
+        /**
+         * @see ReaderGroupState.ReaderGroupStateUpdate#update(ReaderGroupState)
+         */
+        @Override
+        void update(ReaderGroupState state) {
+            state.checkpointState.removeOutstandingCheckpoints();
+        }
 
+        private static class RemoveOutstandingCheckpointsBuilder implements ObjectBuilder<ReaderGroupState.RemoveOutstandingCheckpoints> {
+        }
+    }
     @Builder
     @Data
     @EqualsAndHashCode(callSuper = false)

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -1233,7 +1233,6 @@ public class ReaderGroupState implements Revisioned {
     @Data
     @EqualsAndHashCode(callSuper = false)
     static class RemoveOutstandingCheckpoints extends ReaderGroupStateUpdate {
-        //private final String removeOutstandingCheckpoints;
 
         /**
          * @see ReaderGroupState.ReaderGroupStateUpdate#update(ReaderGroupState)
@@ -1265,8 +1264,8 @@ public class ReaderGroupState implements Revisioned {
                 version(0).revision(0, this::write00, this::read00);
             }
 
-            private void read00(RevisionDataInput in, RemoveOutstandingCheckpointsBuilder builder) throws IOException {
-                builder.build();
+           private void read00(RevisionDataInput in, RemoveOutstandingCheckpointsBuilder builder) throws IOException {
+               builder.build();
             }
 
             private void write00(RemoveOutstandingCheckpoints object, RevisionDataOutput out) throws IOException {

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -1228,6 +1228,7 @@ public class ReaderGroupState implements Revisioned {
             }
         }
     }
+
     @Builder
     @Data
     @EqualsAndHashCode(callSuper = false)
@@ -1390,7 +1391,8 @@ public class ReaderGroupState implements Revisioned {
              .serializer(CreateCheckpoint.class, 9, new CreateCheckpoint.CreateCheckpointSerializer())
              .serializer(ClearCheckpointsBefore.class, 10, new ClearCheckpointsBefore.ClearCheckpointsBeforeSerializer())
              .serializer(UpdateCheckpointPublished.class, 11, new UpdateCheckpointPublished.UpdateCheckpointPublishedSerializer())
-             .serializer(UpdatingConfig.class, 12, new UpdatingConfig.UpdatingConfigSerializer());
+             .serializer(UpdatingConfig.class, 12, new UpdatingConfig.UpdatingConfigSerializer())
+             .serializer(RemoveOutstandingCheckpoints.class, 13, new RemoveOutstandingCheckpoints.RemoveOutstandingCheckpointsSerializer());
         }
     }
     

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -1232,7 +1232,8 @@ public class ReaderGroupState implements Revisioned {
     @Data
     @EqualsAndHashCode(callSuper = false)
     static class RemoveOutstandingCheckpoints extends ReaderGroupStateUpdate {
-        private final String removeOutstandingCheckpoints;
+        //private final String removeOutstandingCheckpoints;
+
         /**
          * @see ReaderGroupState.ReaderGroupStateUpdate#update(ReaderGroupState)
          */
@@ -1241,9 +1242,38 @@ public class ReaderGroupState implements Revisioned {
             state.checkpointState.removeOutstandingCheckpoints();
         }
 
-        private static class RemoveOutstandingCheckpointsBuilder implements ObjectBuilder<ReaderGroupState.RemoveOutstandingCheckpoints> {
+        private static class RemoveOutstandingCheckpointsBuilder implements ObjectBuilder<RemoveOutstandingCheckpoints> {
+
+        }
+
+
+        private static class RemoveOutstandingCheckpointsSerializer
+                extends VersionedSerializer.WithBuilder<RemoveOutstandingCheckpoints, RemoveOutstandingCheckpointsBuilder> {
+            @Override
+            protected RemoveOutstandingCheckpointsBuilder newBuilder() {
+                return builder();
+            }
+
+            @Override
+            protected byte getWriteVersion() {
+                return 0;
+            }
+
+            @Override
+            protected void declareVersions() {
+                version(0).revision(0, this::write00, this::read00);
+            }
+
+            private void read00(RevisionDataInput in, RemoveOutstandingCheckpointsBuilder builder) throws IOException {
+                builder.build();
+            }
+
+            private void write00(RemoveOutstandingCheckpoints object, RevisionDataOutput out) throws IOException {
+                out.writeUTF(object.toString());
+            }
         }
     }
+
     @Builder
     @Data
     @EqualsAndHashCode(callSuper = false)

--- a/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/ReaderGroupState.java
@@ -1269,7 +1269,6 @@ public class ReaderGroupState implements Revisioned {
             }
 
             private void write00(RemoveOutstandingCheckpoints object, RevisionDataOutput out) throws IOException {
-                out.writeUTF(object.toString());
             }
         }
     }

--- a/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
@@ -96,6 +96,24 @@ public class CheckpointStateTest {
     }
 
     @Test
+    public void testRemoveOutstandingCheckpointsCleared() {
+        CheckpointState state = new CheckpointState();
+        state.beginNewCheckpoint("1", ImmutableSet.of("a", "b"), Collections.emptyMap());
+        state.beginNewCheckpoint("2", ImmutableSet.of("a", "b"), Collections.emptyMap());
+        state.beginNewCheckpoint("3", ImmutableSet.of("a", "b"), Collections.emptyMap());
+        assertEquals("1", state.getCheckpointForReader("a"));
+        assertEquals("1", state.getCheckpointForReader("b"));
+        assertEquals(null, state.getCheckpointForReader("c"));
+        state.readerCheckpointed("1", "a", Collections.emptyMap());
+        assertEquals("2", state.getCheckpointForReader("a"));
+        assertEquals("1", state.getCheckpointForReader("b"));
+        assertEquals(3, state.getOutstandingCheckpoints().size());
+        assertTrue(state.removeOutstandingCheckpoints());
+        assertEquals(0, state.getOutstandingCheckpoints().size());
+        assertFalse(state.removeOutstandingCheckpoints());
+    }
+
+    @Test
     public void testOutstandingCheckpoint() {
         CheckpointState state = new CheckpointState();
         state.beginNewCheckpoint("1", ImmutableSet.of("a"), Collections.emptyMap());

--- a/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/CheckpointStateTest.java
@@ -108,9 +108,8 @@ public class CheckpointStateTest {
         assertEquals("2", state.getCheckpointForReader("a"));
         assertEquals("1", state.getCheckpointForReader("b"));
         assertEquals(3, state.getOutstandingCheckpoints().size());
-        assertTrue(state.removeOutstandingCheckpoints());
+        state.removeOutstandingCheckpoints();
         assertEquals(0, state.getOutstandingCheckpoints().size());
-        assertFalse(state.removeOutstandingCheckpoints());
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -170,9 +170,6 @@ public class ReaderGroupImplTest {
     @Test
     public void testCancelOutstanding() {
         CheckpointState state = new CheckpointState();
-        ReaderGroupState rGstate = mock(ReaderGroupState.class);
-        when(synchronizer.getState()).thenReturn(rGstate);
-        when(rGstate.getCheckpointState()).thenReturn(state);
         state.beginNewCheckpoint("1", ImmutableSet.of("a", "b"), Collections.emptyMap());
         state.beginNewCheckpoint("2", ImmutableSet.of("a", "b"), Collections.emptyMap());
         state.beginNewCheckpoint("3", ImmutableSet.of("a", "b"), Collections.emptyMap());
@@ -182,6 +179,7 @@ public class ReaderGroupImplTest {
         state.readerCheckpointed("1", "a", Collections.emptyMap());
         assertEquals("2", state.getCheckpointForReader("a"));
         assertEquals("1", state.getCheckpointForReader("b"));
+        assertEquals(3, state.getOutstandingCheckpoints().size());
         state.removeOutstandingCheckpoints();
         assertEquals(0, state.getOutstandingCheckpoints().size());
     }

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -28,14 +28,14 @@ import io.pravega.client.state.InitialUpdate;
 import io.pravega.client.state.StateSynchronizer;
 import io.pravega.client.state.SynchronizerConfig;
 import io.pravega.client.state.Update;
-import io.pravega.client.stream.Checkpoint;
-import io.pravega.client.stream.ReaderGroupConfig;
-import io.pravega.client.stream.ReaderSegmentDistribution;
-import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Serializer;
+import io.pravega.client.stream.ReaderGroupConfig;
 import io.pravega.client.stream.Stream;
-import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
+import io.pravega.client.stream.ReaderSegmentDistribution;
+import io.pravega.client.stream.StreamConfiguration;
+import io.pravega.client.stream.Checkpoint;
+import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.impl.ReaderGroupState.ClearCheckpointsBefore;
 import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
 import io.pravega.client.stream.mock.MockController;
@@ -169,19 +169,46 @@ public class ReaderGroupImplTest {
 
     @Test
     public void testCancelOutstanding() {
-        CheckpointState state = new CheckpointState();
-        state.beginNewCheckpoint("1", ImmutableSet.of("a", "b"), Collections.emptyMap());
-        state.beginNewCheckpoint("2", ImmutableSet.of("a", "b"), Collections.emptyMap());
-        state.beginNewCheckpoint("3", ImmutableSet.of("a", "b"), Collections.emptyMap());
-        assertEquals("1", state.getCheckpointForReader("a"));
-        assertEquals("1", state.getCheckpointForReader("b"));
-        assertEquals(null, state.getCheckpointForReader("c"));
-        state.readerCheckpointed("1", "a", Collections.emptyMap());
-        assertEquals("2", state.getCheckpointForReader("a"));
-        assertEquals("1", state.getCheckpointForReader("b"));
-        assertEquals(3, state.getOutstandingCheckpoints().size());
-        state.removeOutstandingCheckpoints();
-        assertEquals(0, state.getOutstandingCheckpoints().size());
+        PravegaNodeUri endpoint = new PravegaNodeUri("localhost", 12345);
+        MockConnectionFactoryImpl connectionFactory = new MockConnectionFactoryImpl();
+        MockController mkController = new MockController(endpoint.getEndpoint(), endpoint.getPort(), connectionFactory, false);
+        createScopeAndStream("scope", "stream", mkController);
+        MockSegmentStreamFactory streamFactory = new MockSegmentStreamFactory();
+
+        @Cleanup
+        SynchronizerClientFactory syncClientFactory = new ClientFactoryImpl("scope", mkController, connectionFactory, streamFactory,
+                streamFactory, streamFactory, streamFactory);
+        SynchronizerConfig syncConfig = SynchronizerConfig.builder().build();
+        Map<SegmentWithRange, Long> segments = new HashMap<>();
+        Segment s1 = new Segment("scope", "stream", 1);
+        Segment s2 = new Segment("scope", "stream", 2);
+        segments.put(new SegmentWithRange(s1, 0.0, 0.5), 1L);
+        segments.put(new SegmentWithRange(s2, 0.5, 1.0), 2L);
+        createScopeAndStream("scope", NameUtils.getStreamForReaderGroup(GROUP_NAME), mkController);
+        readerGroup = new ReaderGroupImpl("scope", GROUP_NAME, syncConfig, initSerializer,
+                updateSerializer, syncClientFactory, mkController, connectionPool);
+
+        @Cleanup("shutdown")
+        InlineExecutor executor = new InlineExecutor();
+        StateSynchronizer<ReaderGroupState> rgStateSynchronizer = readerGroup.getSynchronizer();
+        rgStateSynchronizer.initialize(new ReaderGroupState.ReaderGroupStateInit(
+                ReaderGroupConfig.builder().stream(Stream.of("scope", "stream")).maxOutstandingCheckpointRequest(3).build(), segments, Collections.emptyMap(), false));
+        CheckpointState rgState = rgStateSynchronizer.getState().getCheckpointState();
+        rgState.beginNewCheckpoint("1", ImmutableSet.of("a", "b"), Collections.emptyMap());
+        CompletableFuture<Checkpoint> c1 = readerGroup.initiateCheckpoint("test1", executor);
+        rgState.beginNewCheckpoint("2", ImmutableSet.of("a", "b"), Collections.emptyMap());
+        CompletableFuture<Checkpoint> c2 = readerGroup.initiateCheckpoint("test2", executor);
+        rgState.beginNewCheckpoint("3", ImmutableSet.of("a", "b"), Collections.emptyMap());
+        CompletableFuture<Checkpoint> c3 = readerGroup.initiateCheckpoint("test3", executor);
+        assertEquals("1", rgState.getCheckpointForReader("a"));
+        assertEquals("1", rgState.getCheckpointForReader("b"));
+        assertEquals(null, rgState.getCheckpointForReader("c"));
+        rgState.readerCheckpointed("1", "a", Collections.emptyMap());
+        assertEquals("2", rgState.getCheckpointForReader("a"));
+        assertEquals("1", rgState.getCheckpointForReader("b"));
+        assertEquals(3, rgState.getOutstandingCheckpoints().size());
+        readerGroup.cancelOutstandingCheckpoints();
+        assertEquals(0, rgState.getOutstandingCheckpoints().size());
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ReaderGroupImplTest.java
@@ -182,9 +182,8 @@ public class ReaderGroupImplTest {
         state.readerCheckpointed("1", "a", Collections.emptyMap());
         assertEquals("2", state.getCheckpointForReader("a"));
         assertEquals("1", state.getCheckpointForReader("b"));
-        assertTrue(readerGroup.cancelOutstandingCheckpoints());
+        state.removeOutstandingCheckpoints();
         assertEquals(0, state.getOutstandingCheckpoints().size());
-        assertFalse(readerGroup.cancelOutstandingCheckpoints());
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/impl/SerializationTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/SerializationTest.java
@@ -303,6 +303,7 @@ public class SerializationTest {
         verify(serializer, new CreateCheckpoint(createString()));
         verify(serializer, new ClearCheckpointsBefore(createString()));
         verify(serializer, new UpdatingConfig(r.nextBoolean()));
+        verify(serializer, new ReaderGroupState.RemoveOutstandingCheckpoints());
     }
     
     @Test

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -115,10 +115,7 @@ public class CheckpointTest {
         eventWriter.writeEvent(testString);
         eventWriter.writeEvent(testString);
         eventWriter.writeEvent(testString);
-        //eventWriter.writeEvent(testString);
-        //eventWriter.writeEvent(testString);
         eventWriter.flush();
-
         AtomicLong clock = new AtomicLong();
         @Cleanup
         EventStreamReader<String> reader1 = clientFactory.createReader("reader1", readerGroupName, serializer,
@@ -147,13 +144,10 @@ public class CheckpointTest {
 
         CompletableFuture<Checkpoint> checkpoint1 = readerGroup.initiateCheckpoint("Checkpoint1", backgroundExecutor1);
         assertFalse(checkpoint1.isDone());
-
         CompletableFuture<Checkpoint> checkpoint2 = readerGroup.initiateCheckpoint("Checkpoint2", backgroundExecutor2);
         assertFalse(checkpoint2.isDone());
-
         CompletableFuture<Checkpoint> checkpoint3 = readerGroup.initiateCheckpoint("Checkpoint3", backgroundExecutor3);
         assertFalse(checkpoint3.isDone());
-
         CompletableFuture<Checkpoint> checkpoint4 = readerGroup.initiateCheckpoint("Checkpoint4", backgroundExecutor4);
         assertTrue(checkpoint4.isCompletedExceptionally());
         try {
@@ -166,8 +160,6 @@ public class CheckpointTest {
         assertTrue(readerGroup.cancelOutstandingCheckpoints());
 
         CompletableFuture<Checkpoint> checkpoint5 = readerGroup.initiateCheckpoint("Checkpoint5", backgroundExecutor5);
-
-        // will create one more check point
 
         EventRead<String> read = reader1.readNextEvent(100);
         assertTrue(read.isCheckpoint());
@@ -196,14 +188,10 @@ public class CheckpointTest {
         assertTrue(read.isCheckpoint());
         assertEquals("Checkpoint1", read.getCheckpointName());
 
-        //assertTrue(checkpoint5.isDone());
         readerGroup.resetReaderGroup(ReaderGroupConfig.builder().startFromCheckpoint(checkpoint5.get()).disableAutomaticCheckpoints().build());
-        assertThrows("Checkpoint was cleared before results could be read." , ExecutionException.class , () -> checkpoint1.get(5 , TimeUnit.SECONDS));
-
-        assertThrows("Checkpoint was cleared before results could be read." , ExecutionException.class , () -> checkpoint2.get(5 , TimeUnit.SECONDS));
-
-        assertThrows("Checkpoint was cleared before results could be read." , ExecutionException.class , () -> checkpoint3.get(5 , TimeUnit.SECONDS));
-
+        assertThrows("Checkpoint was cleared before results could be read.", ExecutionException.class, () -> checkpoint1.get(5, TimeUnit.SECONDS));
+        assertThrows("Checkpoint was cleared before results could be read.", ExecutionException.class, () -> checkpoint2.get(5, TimeUnit.SECONDS));
+        assertThrows("Checkpoint was cleared before results could be read.", ExecutionException.class, () -> checkpoint3.get(5, TimeUnit.SECONDS));
         assertTrue(checkpoint5.isDone());
     }
 

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -58,7 +58,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 public class CheckpointTest {

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -32,9 +32,9 @@ import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
 import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
 import io.pravega.client.stream.impl.MaxNumberOfCheckpointsExceededException;
 import io.pravega.client.stream.impl.StreamCutImpl;
-import io.pravega.client.stream.impl.UTF8StringSerializer;
 import io.pravega.client.stream.mock.MockClientFactory;
 import io.pravega.client.stream.mock.MockStreamManager;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
@@ -58,12 +58,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 public class CheckpointTest {
@@ -81,6 +76,135 @@ public class CheckpointTest {
     @AfterClass
     public static void teardown() {
         SERVICE_BUILDER.close();
+    }
+
+    @Test(timeout = 20000)
+    public void testCancelOutstandingCheckpoints() throws InterruptedException, ExecutionException {
+
+        String endpoint = "localhost";
+        String streamName = "testCancelOutstandingCheckpoints";
+        String readerGroupName = "testCancelOutstandingCheckpoints-group1";
+        int port = TestUtils.getAvailableListenPort();
+        String testString = "Hello world\n";
+        String scope = "testCancelOutstandingCheckpoints-Scope";
+        StreamSegmentStore store = SERVICE_BUILDER.createStreamSegmentService();
+        TableStore tableStore = SERVICE_BUILDER.createTableStoreService();
+        @Cleanup
+        PravegaConnectionListener server = new PravegaConnectionListener(false, port, store, tableStore, SERVICE_BUILDER.getLowPriorityExecutor());
+        server.startListening();
+        @Cleanup
+        MockStreamManager streamManager = new MockStreamManager(scope, endpoint, port);
+        @Cleanup
+        MockClientFactory clientFactory = streamManager.getClientFactory();
+        int maxOutstandingCheckpointRequest = 3;
+        ReaderGroupConfig groupConfig = ReaderGroupConfig.builder()
+                .stream(Stream.of(scope, streamName))
+                .maxOutstandingCheckpointRequest(maxOutstandingCheckpointRequest)
+                .build();
+        streamManager.createScope(scope);
+        streamManager.createStream(scope, streamName, StreamConfiguration.builder()
+                .scalingPolicy(ScalingPolicy.fixed(3))
+                .build());
+        streamManager.createReaderGroup(readerGroupName, groupConfig);
+        @Cleanup
+        ReaderGroup readerGroup = streamManager.getReaderGroup(readerGroupName);
+        JavaSerializer<String> serializer = new JavaSerializer<>();
+        @Cleanup
+        EventStreamWriter<String> eventWriter = clientFactory.createEventWriter(streamName, serializer,
+                EventWriterConfig.builder().build());
+        eventWriter.writeEvent(testString);
+        eventWriter.writeEvent(testString);
+        eventWriter.writeEvent(testString);
+        //eventWriter.writeEvent(testString);
+        //eventWriter.writeEvent(testString);
+        eventWriter.flush();
+
+        AtomicLong clock = new AtomicLong();
+        @Cleanup
+        EventStreamReader<String> reader1 = clientFactory.createReader("reader1", readerGroupName, serializer,
+                ReaderConfig.builder().build(), clock::get,
+                clock::get);
+        @Cleanup
+        EventStreamReader<String> reader2 = clientFactory.createReader("reader2", readerGroupName, serializer,
+                ReaderConfig.builder().build(), clock::get,
+                clock::get);
+        @Cleanup
+        EventStreamReader<String> reader3 = clientFactory.createReader("reader3", readerGroupName, serializer,
+                ReaderConfig.builder().build(), clock::get,
+                clock::get);
+        clock.addAndGet(CLOCK_ADVANCE_INTERVAL);
+
+        @Cleanup("shutdown")
+        final InlineExecutor backgroundExecutor1 = new InlineExecutor();
+        @Cleanup("shutdown")
+        final InlineExecutor backgroundExecutor2 = new InlineExecutor();
+        @Cleanup("shutdown")
+        final InlineExecutor backgroundExecutor3 = new InlineExecutor();
+        @Cleanup("shutdown")
+        final InlineExecutor backgroundExecutor4 = new InlineExecutor();
+        @Cleanup("shutdown")
+        final InlineExecutor backgroundExecutor5 = new InlineExecutor();
+
+        CompletableFuture<Checkpoint> checkpoint1 = readerGroup.initiateCheckpoint("Checkpoint1", backgroundExecutor1);
+        assertFalse(checkpoint1.isDone());
+
+        CompletableFuture<Checkpoint> checkpoint2 = readerGroup.initiateCheckpoint("Checkpoint2", backgroundExecutor2);
+        assertFalse(checkpoint2.isDone());
+
+        CompletableFuture<Checkpoint> checkpoint3 = readerGroup.initiateCheckpoint("Checkpoint3", backgroundExecutor3);
+        assertFalse(checkpoint3.isDone());
+
+        CompletableFuture<Checkpoint> checkpoint4 = readerGroup.initiateCheckpoint("Checkpoint4", backgroundExecutor4);
+        assertTrue(checkpoint4.isCompletedExceptionally());
+        try {
+            checkpoint4.get();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof MaxNumberOfCheckpointsExceededException);
+            assertTrue(e.getCause().getMessage()
+                    .equals("rejecting checkpoint request since pending checkpoint reaches max allowed limit"));
+        }
+        assertTrue(readerGroup.cancelOutstandingCheckpoints());
+
+        CompletableFuture<Checkpoint> checkpoint5 = readerGroup.initiateCheckpoint("Checkpoint5", backgroundExecutor5);
+
+        // will create one more check point
+
+        EventRead<String> read = reader1.readNextEvent(100);
+        assertTrue(read.isCheckpoint());
+        assertEquals("Checkpoint5", read.getCheckpointName());
+        assertNull(read.getEvent());
+
+        read = reader2.readNextEvent(100);
+        assertTrue(read.isCheckpoint());
+        assertEquals("Checkpoint5", read.getCheckpointName());
+        assertNull(read.getEvent());
+
+        read = reader3.readNextEvent(100);
+        assertTrue(read.isCheckpoint());
+        assertEquals("Checkpoint5", read.getCheckpointName());
+        assertNull(read.getEvent());
+
+        read = reader1.readNextEvent(100);
+        assertTrue(read.isCheckpoint());
+        assertEquals("Checkpoint1", read.getCheckpointName());
+
+        read = reader2.readNextEvent(100);
+        assertTrue(read.isCheckpoint());
+        assertEquals("Checkpoint1", read.getCheckpointName());
+
+        read = reader3.readNextEvent(100);
+        assertTrue(read.isCheckpoint());
+        assertEquals("Checkpoint1", read.getCheckpointName());
+
+        //assertTrue(checkpoint5.isDone());
+        readerGroup.resetReaderGroup(ReaderGroupConfig.builder().startFromCheckpoint(checkpoint5.get()).disableAutomaticCheckpoints().build());
+        assertThrows("Checkpoint was cleared before results could be read." , ExecutionException.class , () -> checkpoint1.get(5 , TimeUnit.SECONDS));
+
+        assertThrows("Checkpoint was cleared before results could be read." , ExecutionException.class , () -> checkpoint2.get(5 , TimeUnit.SECONDS));
+
+        assertThrows("Checkpoint was cleared before results could be read." , ExecutionException.class , () -> checkpoint3.get(5 , TimeUnit.SECONDS));
+
+        assertTrue(checkpoint5.isDone());
     }
 
     @Test(timeout = 20000)

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -31,7 +31,10 @@ import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
-import io.pravega.client.stream.impl.*;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
+import io.pravega.client.stream.impl.StreamCutImpl;
+import io.pravega.client.stream.impl.MaxNumberOfCheckpointsExceededException;
+import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.mock.MockClientFactory;
 import io.pravega.client.stream.mock.MockStreamManager;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
@@ -173,16 +176,13 @@ public class CheckpointTest {
         assertNull(read.getEvent());
 
         read = reader1.readNextEvent(100);
-        assertTrue(read.isCheckpoint());
-        assertEquals("Checkpoint1", read.getCheckpointName());
+        assertFalse(read.isCheckpoint());
 
         read = reader2.readNextEvent(100);
-        assertTrue(read.isCheckpoint());
-        assertEquals("Checkpoint1", read.getCheckpointName());
+        assertFalse(read.isCheckpoint());
 
         read = reader3.readNextEvent(100);
-        assertTrue(read.isCheckpoint());
-        assertEquals("Checkpoint1", read.getCheckpointName());
+        assertFalse(read.isCheckpoint());
 
         readerGroup.resetReaderGroup(ReaderGroupConfig.builder().startFromCheckpoint(checkpoint5.get()).disableAutomaticCheckpoints().build());
         assertThrows("Checkpoint was cleared before results could be read.", ExecutionException.class, () -> checkpoint1.get(5, TimeUnit.SECONDS));

--- a/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/CheckpointTest.java
@@ -31,10 +31,7 @@ import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.Stream;
 import io.pravega.client.stream.StreamConfiguration;
 import io.pravega.client.stream.StreamCut;
-import io.pravega.client.stream.impl.JavaSerializer;
-import io.pravega.client.stream.impl.UTF8StringSerializer;
-import io.pravega.client.stream.impl.MaxNumberOfCheckpointsExceededException;
-import io.pravega.client.stream.impl.StreamCutImpl;
+import io.pravega.client.stream.impl.*;
 import io.pravega.client.stream.mock.MockClientFactory;
 import io.pravega.client.stream.mock.MockStreamManager;
 import io.pravega.segmentstore.contracts.StreamSegmentStore;
@@ -157,8 +154,7 @@ public class CheckpointTest {
             assertTrue(e.getCause().getMessage()
                     .equals("rejecting checkpoint request since pending checkpoint reaches max allowed limit"));
         }
-        assertTrue(readerGroup.cancelOutstandingCheckpoints());
-
+        readerGroup.cancelOutstandingCheckpoints();
         CompletableFuture<Checkpoint> checkpoint5 = readerGroup.initiateCheckpoint("Checkpoint5", backgroundExecutor5);
 
         EventRead<String> read = reader1.readNextEvent(100);


### PR DESCRIPTION
**Change log description**  
Adding a new client API, which will cancel all outstanding checkpoints.
**Purpose of the change**  
Fixes #7147 

**What the code does**  
Addition of cancelOutstandingCheckpoints() in ReaderGroup which calls removeOutstandingCheckpoints() in checkpointState class to remove the outstanding checkpoints.

**How to verify it**  
When cancelOutstandingCheckpoints() is called, it must clear the outstanding checkpoints.