### PR TITLE
Fix async issues with saveEpoch and flushToStorage.

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -800,12 +800,10 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         val chunkedSegmentStorage = (ChunkedSegmentStorage) storage;
         val chunk = NameUtils.getContainerEpochFileName(containerId);
         val epochInfo = new EpochInfo(containerEpoch);
-        val wrapper = new UtilsWrapper(chunkedSegmentStorage, BUFFER_SIZE, timeout);
         val isDone = new AtomicBoolean(false);
         val attempts = new AtomicInteger();
         try {
             val epochBytes = EPOCH_INFO_SERIALIZER.serialize(epochInfo);
-            val inputStream = new ByteArrayInputStream(epochBytes.array(), 0, epochBytes.getLength());
             return Futures.loop(
                     () -> !isDone.get(),
                     () -> chunkedSegmentStorage.getChunkStorage().exists(chunk)
@@ -817,29 +815,27 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                                                     return CompletableFuture.failedFuture(
                                                             new IllegalContainerStateException(String.format("Unexpected epoch. Expected = {} actual = {}", epochInfo, savedEpoch)));
                                                 } else {
-                                                    return wrapper.overwriteChunk(chunk, inputStream, epochBytes.getLength())
-                                                            .thenAccept(x -> log.debug("{}: Updated epochInfo {}", this.traceObjectId, epochInfo));
+                                                    return chunkedSegmentStorage.getChunkStorage().delete(ChunkHandle.writeHandle(chunk));
                                                 }
                                             }, executor);
                                 } else {
-                                    return chunkedSegmentStorage.getChunkStorage().createWithContent(chunk, epochBytes.getLength(), inputStream)
-                                            .thenAccept(y -> log.debug("{}: Created epochInfo", this.traceObjectId));
+                                    return CompletableFuture.completedFuture(null);
                                 }
                             }, this.executor)
+                            .thenComposeAsync(v -> chunkedSegmentStorage.getChunkStorage().createWithContent(chunk, epochBytes.getLength(),
+                                    new ByteArrayInputStream(epochBytes.array(), 0, epochBytes.getLength())), executor)
                             .thenAcceptAsync( v -> log.debug("{}: Epoch info saved to epochInfoFile. File {}. info = {}", this.traceObjectId, chunk, epochInfo))
-                            .thenComposeAsync( v -> {
-                                return readEpochInfo(chunk, chunkedSegmentStorage, epochBytes.getLength());
-                            }, executor)
+                            .thenComposeAsync( v -> readEpochInfo(chunk, chunkedSegmentStorage, epochBytes.getLength()), executor)
                             .thenApplyAsync( readBackInfo -> {
                                 if (readBackInfo.getEpoch() > epochInfo.getEpoch()) {
-                                    return CompletableFuture.failedFuture(
+                                    throw new CompletionException(
                                             new IllegalContainerStateException(String.format("Unexpected epochInfo. Expected = {} actual = {}", epochInfo, readBackInfo)));
                                 }
                                 if (!epochInfo.equals(readBackInfo)) {
-                                    return CompletableFuture.failedFuture(
+                                    throw new CompletionException(
                                             new IllegalStateException(String.format("Unexpected epochInfo. Expected = {} actual = {}", epochInfo, readBackInfo)));
                                 }
-                                return CompletableFuture.completedFuture(null);
+                                return null;
                             }, executor)
                             .handleAsync((v, e) -> {
                                 if (null != e) {
@@ -874,7 +870,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                     try {
                         return EPOCH_INFO_SERIALIZER.deserialize(readBuffer);
                     } catch (IOException e) {
-                        throw new RuntimeException(e);
+                        throw new CompletionException(e);
                     }
                 }, this.executor);
 

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -604,14 +604,13 @@ public class SystemJournal {
                                 .thenComposeAsync(v -> readSnapshotInfoFromFile(), executor)
                                 .thenApplyAsync( readBackInfo -> {
                                     if (readBackInfo.getEpoch() > epoch) {
-                                        return CompletableFuture.failedFuture(
-                                                new StorageNotPrimaryException(String.format("SystemJournal[{}] Unexpected snapshot. Expected = {} actual = {}", info, readBackInfo)));
+                                        throw new CompletionException(new StorageNotPrimaryException(String.format("SystemJournal[{}] Unexpected snapshot. Expected = {} actual = {}", info, readBackInfo)));
                                     }
                                     if (!info.equals(readBackInfo)) {
-                                        return CompletableFuture.failedFuture(
+                                        throw new CompletionException(
                                                 new IllegalStateException(String.format("SystemJournal[{}] Unexpected snapshot. Expected = {} actual = {}", info, readBackInfo)));
                                     }
-                                    return CompletableFuture.completedFuture(null);
+                                    return null;
                                 }, executor)
                                 .handleAsync((v, e) -> {
                                     if (null != e) {


### PR DESCRIPTION
**Change log description**  
Fix async issues with saveEpoch and flushToStorage.

**Purpose of the change**  
Fix async issues with saveEpoch and flushToStorage. 

**What the code does** 
Fix following
- avoid sharing inputeStream between retry attempts
- always wait on io task futures to complete (use compose instead of apply)
- minor change to fix unnecessary wrapping of exceptions
- 
**How to verify it**  
(Optional: steps to verify that the changes are effective)
