### PR TITLE
Issue 7202: Redirecting stderr to stdout

### DIFF
--- a/docker/pravega/scripts/lts_recovery_backup.sh
+++ b/docker/pravega/scripts/lts_recovery_backup.sh
@@ -49,7 +49,7 @@ set_configuration() {
 flush_container() {
   cd $home_dir
   # Calling flush to storage
-  output=$(./bin/pravega-admin container flush-to-storage all)
+  output=$(./bin/pravega-admin container flush-to-storage all 2>&1)
   message="Flushed all the given segment container to storage."
   if [[ "$output" != *"$message"* ]]
   then


### PR DESCRIPTION
**Change log description**  
The nautilus-cli has an issue with some output being posted to the error channel.

**Purpose of the change**  
Fixes #7202 

**What the code does**  
Redirect stderr to stdout in the lts_recovery_backup.sh

**How to verify it**  
Log in to segment-store container and execute lts_backup_recovery script i.e `./scripts/lts_recovery_backup.sh`
