### PR TITLE
Fix admin port issue by using cluster internal host names

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/FlushToStorageCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/FlushToStorageCommand.java
@@ -101,7 +101,10 @@ public class FlushToStorageCommand extends ContainerCommand {
         if (host == null || host.isEmpty()) {
             throw new RuntimeException("No host found for given container: " + containerId);
         }
-        return host;
+        // Quick Fix : Needs proper parsing and fixing
+        String[] parts = host.split("\\.");
+        Preconditions.checkState(parts.length >= 1);
+        return parts[0];
     }
 
     private Map<Integer, String> getHosts() {

--- a/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/FlushToStorageCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/FlushToStorageCommand.java
@@ -16,6 +16,7 @@
 package io.pravega.cli.admin.segmentstore;
 
 import com.google.common.base.Preconditions;
+import com.google.common.net.InetAddresses;
 import io.pravega.cli.admin.CommandArgs;
 import io.pravega.cli.admin.utils.AdminSegmentHelper;
 import io.pravega.cli.admin.utils.ZKHelper;
@@ -101,10 +102,18 @@ public class FlushToStorageCommand extends ContainerCommand {
         if (host == null || host.isEmpty()) {
             throw new RuntimeException("No host found for given container: " + containerId);
         }
+        return extractHostName(host);
+    }
+
+    static String extractHostName(String host) {
         // Quick Fix : Needs proper parsing and fixing
-        String[] parts = host.split("\\.");
-        Preconditions.checkState(parts.length >= 1);
-        return parts[0];
+        if (InetAddresses.isInetAddress(host)) {
+            return host;
+        } else {
+            String[] parts = host.split("\\.");
+            Preconditions.checkState(parts.length >= 1);
+            return parts[0];
+        }
     }
 
     private Map<Integer, String> getHosts() {

--- a/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/AbstractSegmentStoreCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/AbstractSegmentStoreCommandsTest.java
@@ -594,6 +594,15 @@ public abstract class AbstractSegmentStoreCommandsTest {
         public void startUp() throws Exception {
             setup(false, false);
         }
+
+        @Test
+        public void testExtractHostName() {
+            Assert.assertEquals("1.2.3.4", FlushToStorageCommand.extractHostName("1.2.3.4"));
+            Assert.assertEquals("localhost", FlushToStorageCommand.extractHostName("localhost"));
+            Assert.assertEquals("host1", FlushToStorageCommand.extractHostName("host1"));
+            Assert.assertEquals("host1", FlushToStorageCommand.extractHostName("host1.example.com"));
+            Assert.assertEquals("host1", FlushToStorageCommand.extractHostName("host1.subdomain.example.com"));
+        }
     }
 
     //endregion


### PR DESCRIPTION
**Change log description**  
Fix admin port issue by using cluster internal host names

**Purpose of the change**  
Fix admin port issue by using cluster internal host names

**What the code does**  
Extract hostname from fully qualified name

**How to verify it**  
(Optional: steps to verify that the changes are effective)
