### PR TITLE
Issue 7264: Fix for admin cli port

### DIFF
--- a/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/FlushToStorageCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/FlushToStorageCommand.java
@@ -16,6 +16,7 @@
 package io.pravega.cli.admin.segmentstore;
 
 import com.google.common.base.Preconditions;
+import com.google.common.net.InetAddresses;
 import io.pravega.cli.admin.CommandArgs;
 import io.pravega.cli.admin.utils.AdminSegmentHelper;
 import io.pravega.cli.admin.utils.ZKHelper;
@@ -24,6 +25,7 @@ import io.pravega.common.concurrent.Futures;
 import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.shared.protocol.netty.WireCommands;
 import lombok.Cleanup;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.curator.framework.CuratorFramework;
 
@@ -81,12 +83,20 @@ public class FlushToStorageCommand extends ContainerCommand {
     }
 
     private CompletableFuture<WireCommands.StorageFlushed> flushContainerToStorage(AdminSegmentHelper adminSegmentHelper, int containerId) throws Exception {
+        String ssHost = this.getHostByContainer(containerId);
         CompletableFuture<WireCommands.StorageFlushed> reply = adminSegmentHelper.flushToStorage(containerId,
-                new PravegaNodeUri(this.getHostByContainer(containerId), getServiceConfig().getAdminGatewayPort()), super.authHelper.retrieveMasterToken());
+                new PravegaNodeUri( ssHost, getAdminPortForHost(getServiceConfig().getAdminGatewayPort(), ssHost)), super.authHelper.retrieveMasterToken());
         return reply.thenApply(result -> {
             output("Flushed the Segment Container with containerId %d to Storage.", containerId);
             return result;
         });
+    }
+
+    private int getAdminPortForHost(int configuredAdminPort, String ssHost) {
+        String[] ssHostParts = ssHost.split("-");
+        String ssHostIndex = ssHostParts[ssHostParts.length-1];
+        Preconditions.checkState(ssHostParts.length > 1 && !ssHostIndex.isEmpty() && StringUtils.isNumeric(ssHostIndex), "Unexpected host-name retrieved");
+        return  configuredAdminPort + Integer.parseInt(ssHostIndex);
     }
 
     public static CommandDescriptor descriptor() {
@@ -101,7 +111,18 @@ public class FlushToStorageCommand extends ContainerCommand {
         if (host == null || host.isEmpty()) {
             throw new RuntimeException("No host found for given container: " + containerId);
         }
-        return host;
+        return extractHostName(host);
+    }
+
+    static String extractHostName(String host) {
+        // Quick Fix : Needs proper parsing and fixing
+        if (InetAddresses.isInetAddress(host)) {
+            return host;
+        } else {
+            String[] parts = host.split("\\.");
+            Preconditions.checkState(parts.length >= 1);
+            return parts[0];
+        }
     }
 
     private Map<Integer, String> getHosts() {

--- a/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/FlushToStorageCommand.java
+++ b/cli/admin/src/main/java/io/pravega/cli/admin/segmentstore/FlushToStorageCommand.java
@@ -93,6 +93,9 @@ public class FlushToStorageCommand extends ContainerCommand {
     }
 
     private int getAdminPortForHost(int configuredAdminPort, String ssHost) {
+        if (InetAddresses.isInetAddress(ssHost)) {
+            return configuredAdminPort;
+        }
         String[] ssHostParts = ssHost.split("-");
         String ssHostIndex = ssHostParts[ssHostParts.length-1];
         Preconditions.checkState(ssHostParts.length > 1 && !ssHostIndex.isEmpty() && StringUtils.isNumeric(ssHostIndex), "Unexpected host-name retrieved");

--- a/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/AbstractSegmentStoreCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/AbstractSegmentStoreCommandsTest.java
@@ -241,7 +241,7 @@ public abstract class AbstractSegmentStoreCommandsTest {
 
     @Test
     public void testFlushToStorageCommand() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         String commandResult = TestUtils.executeCommand("container flush-to-storage 0", STATE.get());
         Assert.assertTrue(commandResult.contains("Flushed the Segment Container with containerId 0 to Storage."));
         Assert.assertNotNull(FlushToStorageCommand.descriptor());
@@ -249,7 +249,7 @@ public abstract class AbstractSegmentStoreCommandsTest {
 
     @Test
     public void testFlushToStorageCommandRangeCase() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         String commandResult = TestUtils.executeCommand("container flush-to-storage 0 " + (CONTAINER_COUNT - 1), STATE.get());
         Assert.assertTrue(commandResult.contains("Flushed the Segment Container with containerId 0 to Storage."));
         Assert.assertNotNull(FlushToStorageCommand.descriptor());
@@ -257,28 +257,28 @@ public abstract class AbstractSegmentStoreCommandsTest {
 
     @Test
     public void testFlushToStorageCommandWithEndContainerNotNumber() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         AssertExtensions.assertThrows("End container id must be a number.", () -> TestUtils.executeCommand("container flush-to-storage 0 all", STATE.get()),
                 ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test
     public void testFlushToStorageCommandWithoutGettingSegmentStoreHost() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         AssertExtensions.assertThrows("Error getting segment store hosts for containers.", () -> TestUtils.executeCommand("container flush-to-storage 0 all", STATE.get()),
                 ex -> ex instanceof RuntimeException);
     }
 
     @Test
     public void testFlushToStorageCommandWithThreeArguments() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         AssertExtensions.assertThrows("Incorrect argument count.", () -> TestUtils.executeCommand("container flush-to-storage 0 1 1", STATE.get()),
                 ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test
     public void testFlushToStorageCommandWithoutGettingSegmentStoreHostForGivenContainer() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         Properties pravegaProperties = new Properties();
         pravegaProperties.setProperty("pravegaservice.container.count", "8");
         STATE.get().getConfigBuilder().include(pravegaProperties);
@@ -290,42 +290,42 @@ public abstract class AbstractSegmentStoreCommandsTest {
 
     @Test
     public void testFlushToStorageCommandWithoutArguments() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         AssertExtensions.assertThrows("Incorrect argument count.", () -> TestUtils.executeCommand("container flush-to-storage", STATE.get()),
                 ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test
     public void testFlushToStorageCommandAllCaseWithRange() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         AssertExtensions.assertThrows("Incorrect argument count.", () -> TestUtils.executeCommand("container flush-to-storage all 0", STATE.get()),
                 ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test
     public void testFlushToStorageCommandWithInvalidStartContainer() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         AssertExtensions.assertThrows("Incorrect argument count.", () -> TestUtils.executeCommand("container flush-to-storage 100", STATE.get()),
                 ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test
     public void testFlushToStorageCommandWithInvalidEndContainer() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         AssertExtensions.assertThrows("Incorrect argument count.", () -> TestUtils.executeCommand("container flush-to-storage 0 100", STATE.get()),
                 ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test
     public void testFlushToStorageCommandWithNegativeStartContainerId() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         AssertExtensions.assertThrows("The start container id must be a positive number.", () -> TestUtils.executeCommand("container flush-to-storage -1", STATE.get()),
                 ex -> ex instanceof IllegalArgumentException);
     }
 
     @Test
     public void testFlushToStorageCommandWithNegativeEndContainerId() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         AssertExtensions.assertThrows("The end container id must be a positive number.", () -> TestUtils.executeCommand("container flush-to-storage 0 -1", STATE.get()),
                 ex -> ex instanceof IllegalArgumentException);
     }

--- a/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/AbstractSegmentStoreCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/AbstractSegmentStoreCommandsTest.java
@@ -231,7 +231,7 @@ public abstract class AbstractSegmentStoreCommandsTest {
 
     @Test
     public void testFlushToStorageCommandAllCase() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.1.1", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.0.1", 1234);
         String commandResult = TestUtils.executeCommand("container flush-to-storage all", STATE.get());
         for (int id = 0; id < CONTAINER_COUNT; id++) {
             Assert.assertTrue(commandResult.contains("Flushed the Segment Container with containerId " + id + " to Storage."));

--- a/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/AbstractSegmentStoreCommandsTest.java
+++ b/cli/admin/src/test/java/io/pravega/cli/admin/segmentstore/AbstractSegmentStoreCommandsTest.java
@@ -231,7 +231,7 @@ public abstract class AbstractSegmentStoreCommandsTest {
 
     @Test
     public void testFlushToStorageCommandAllCase() throws Exception {
-        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "localhost", 1234);
+        TestUtils.createDummyHostContainerAssignment(SETUP_UTILS.getZkTestServer().getConnectString(), "127.0.1.1", 1234);
         String commandResult = TestUtils.executeCommand("container flush-to-storage all", STATE.get());
         for (int id = 0; id < CONTAINER_COUNT; id++) {
             Assert.assertTrue(commandResult.contains("Flushed the Segment Container with containerId " + id + " to Storage."));


### PR DESCRIPTION
**Change log description**  
Fix for Admin CLI port with externalAccessEnabled.

**Purpose of the change**  
Fixes #7264

**What the code does**  
Gets the correct port for every ss host retrieved from ZK.

**How to verify it**  
Run FlushTOStorageCommand with the change.
