### PR TITLE
Issue 7269: Update valid offset on SegmentIterator next TruncatedDataException case

### DIFF
--- a/client/src/main/java/io/pravega/client/batch/SegmentIterator.java
+++ b/client/src/main/java/io/pravega/client/batch/SegmentIterator.java
@@ -27,6 +27,11 @@ import java.util.Iterator;
  *
  * While buffering is used to avoid it, it is possible for {@link #next()} to block on fetching the
  * data.
+ *
+ * While iterating over SegmentIterator using {@link #next()} it can throw {@link io.pravega.client.stream.TruncatedDataException}
+ * if SegmentIterator is pointing to an offset which is already truncated.
+ * If this exception occurs, SegmentIterator will automatically update headOffset to next available offset.
+ * Next call to {@link #next()} will point correctly to valid offset and reader will continue.
  * 
  * At any time {@link #getOffset()} can be called to get the byte offset in the segment the iterator
  * is currently pointing to.

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
@@ -104,7 +104,7 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
 
     @Override
     public <T> SegmentIterator<T> readSegment(final SegmentRange segment, final Serializer<T> deserializer) {
-        return new SegmentIteratorImpl<>(inputStreamFactory, segment.asImpl().getSegment(), deserializer,
+        return new SegmentIteratorImpl<>(inputStreamFactory, segmentMetadataClientFactory, controller, segment.asImpl().getSegment(), deserializer,
                 segment.asImpl().getStartOffset(), segment.asImpl().getEndOffset());
     }
 

--- a/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/BatchClientFactoryImpl.java
@@ -81,6 +81,7 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
     private final SegmentMetadataClientFactory segmentMetadataClientFactory;
     private final StreamCutHelper streamCutHelper;
     private final Retry.RetryWithBackoff retryWithBackoff;
+    private final ClientConfig clientConfig;
 
     public BatchClientFactoryImpl(Controller controller, ClientConfig clientConfig, ConnectionFactory connectionFactory) {
         this(controller, clientConfig, connectionFactory, Retry.withExpBackoff(1, 10, 10, Duration.ofSeconds(30).toMillis()));
@@ -94,6 +95,7 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
         this.segmentMetadataClientFactory = new SegmentMetadataClientFactoryImpl(controller, connectionPool);
         this.streamCutHelper = new StreamCutHelper(controller, connectionPool);
         this.retryWithBackoff = retryWithBackoff;
+        this.clientConfig = clientConfig;
     }
 
     @Override
@@ -104,7 +106,8 @@ public class BatchClientFactoryImpl implements BatchClientFactory {
 
     @Override
     public <T> SegmentIterator<T> readSegment(final SegmentRange segment, final Serializer<T> deserializer) {
-        return new SegmentIteratorImpl<>(inputStreamFactory, segmentMetadataClientFactory, controller, segment.asImpl().getSegment(), deserializer,
+        return new SegmentIteratorImpl<>(inputStreamFactory, segmentMetadataClientFactory, controller, clientConfig,
+                segment.asImpl().getSegment(), deserializer,
                 segment.asImpl().getStartOffset(), segment.asImpl().getEndOffset());
     }
 

--- a/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
+++ b/client/src/main/java/io/pravega/client/batch/impl/SegmentIteratorImpl.java
@@ -104,10 +104,9 @@ public class SegmentIteratorImpl<T> implements SegmentIterator<T> {
         SegmentMetadataClient metadataClient = segmentMetadataClientFactory.createSegmentMetadataClient(segmentId,
                 DelegationTokenProviderFactory.create(controller, segmentId, AccessOperation.READ));
         try {
-            long startingOffset = Futures.getThrowingExceptionWithTimeout(metadataClient.getSegmentInfo(), timeoutInMilli).getStartingOffset();
-            input.setOffset(startingOffset);
+            input.setOffset(Futures.getThrowingExceptionWithTimeout(metadataClient.fetchCurrentSegmentHeadOffset(), timeoutInMilli));
         } catch (TimeoutException te) {
-            log.warn("A timeout has occurred while attempting to retrieve segment information from the server");
+            log.warn("A timeout has occurred while attempting to retrieve segment information from the server for segment {}", segmentId);
         }
     }
 

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
@@ -21,6 +21,7 @@ import io.pravega.client.security.auth.DelegationTokenProviderFactory;
 import io.pravega.client.segment.impl.EndOfSegmentException;
 import io.pravega.client.segment.impl.EventSegmentReader;
 import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.segment.impl.SegmentInfo;
 import io.pravega.client.segment.impl.SegmentInputStreamFactory;
 import io.pravega.client.segment.impl.SegmentMetadataClient;
 import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
@@ -188,6 +189,11 @@ public class SegmentIteratorTest {
         verify(input, times(2)).read();
         when(input.read()).thenThrow(SegmentTruncatedException.class);
         assertThrows(TruncatedDataException.class, () -> iter.next());
+        // Ensure fetchCurrentSegmentHeadOffset returns incompleteFuture.
+        CompletableFuture<SegmentInfo> incompleteFuture = new CompletableFuture();
+        doReturn(incompleteFuture).when(metaClient).fetchCurrentSegmentHeadOffset();
+        SegmentIteratorImpl<String> iter1 = new SegmentIteratorImpl<>(factory, metaFactory, controller, segment, stringSerializer, 0, endOffset);
+        assertThrows(TruncatedDataException.class, () -> iter1.next());
     }
 
     private void sendData(String data, SegmentOutputStream outputStream) {

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
@@ -15,24 +15,33 @@
  */
 package io.pravega.client.batch.impl;
 
+import io.pravega.client.control.impl.Controller;
+import io.pravega.client.security.auth.DelegationTokenProvider;
 import io.pravega.client.security.auth.DelegationTokenProviderFactory;
 import io.pravega.client.segment.impl.EndOfSegmentException;
 import io.pravega.client.segment.impl.EventSegmentReader;
 import io.pravega.client.segment.impl.Segment;
+import io.pravega.client.segment.impl.SegmentInfo;
 import io.pravega.client.segment.impl.SegmentInputStreamFactory;
 import io.pravega.client.segment.impl.SegmentMetadataClient;
+import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
 import io.pravega.client.segment.impl.SegmentOutputStream;
 import io.pravega.client.segment.impl.SegmentTruncatedException;
 import io.pravega.client.stream.EventWriterConfig;
 import io.pravega.client.stream.TruncatedDataException;
 import io.pravega.client.stream.impl.JavaSerializer;
 import io.pravega.client.stream.impl.PendingEvent;
+import io.pravega.client.stream.mock.MockConnectionFactoryImpl;
+import io.pravega.client.stream.mock.MockController;
 import io.pravega.client.stream.mock.MockSegmentStreamFactory;
+import io.pravega.shared.protocol.netty.PravegaNodeUri;
 import io.pravega.test.common.AssertExtensions;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 import lombok.Cleanup;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static io.pravega.test.common.AssertExtensions.assertThrows;
@@ -43,10 +52,34 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
 
 public class SegmentIteratorTest {
 
     private final JavaSerializer<String> stringSerializer = new JavaSerializer<>();
+
+    private Controller controller = null;
+    private MockConnectionFactoryImpl connectionFactory;
+    private SegmentMetadataClientFactory metaFactory;
+
+    @Before
+    public void setUp() {
+        PravegaNodeUri uri = new PravegaNodeUri("endpoint", 12345);
+        this.connectionFactory = new MockConnectionFactoryImpl();
+        this.metaFactory = mock(SegmentMetadataClientFactory.class);
+        this.controller = new MockController(uri.getEndpoint(), uri.getPort(), connectionFactory, true);
+    }
+
+    @After
+    public void tearDown() {
+        if (this.controller != null) {
+            this.controller.close();
+        }
+        if (this.connectionFactory != null) {
+            this.connectionFactory.close();
+        }
+    }
     
     @Test(timeout = 5000)
     public void testHasNext() {
@@ -61,7 +94,7 @@ public class SegmentIteratorTest {
         SegmentMetadataClient metadataClient = factory.createSegmentMetadataClient(segment, DelegationTokenProviderFactory.createWithEmptyToken());
         long length = metadataClient.getSegmentInfo().join().getWriteOffset();
         @Cleanup
-        SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, segment, stringSerializer, 0, length);
+        SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, metaFactory, controller, segment, stringSerializer, 0, length);
         assertTrue(iter.hasNext());
         assertTrue(iter.hasNext());
         assertEquals("1", iter.next());
@@ -88,7 +121,7 @@ public class SegmentIteratorTest {
                 DelegationTokenProviderFactory.createWithEmptyToken());
         long length = metadataClient.getSegmentInfo().join().getWriteOffset();
         @Cleanup
-        SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, segment, stringSerializer, 0, length);
+        SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, metaFactory, controller, segment, stringSerializer, 0, length);
         assertEquals(0, iter.getOffset());
         assertEquals("1", iter.next());
         assertEquals(length / 3, iter.getOffset());
@@ -117,15 +150,21 @@ public class SegmentIteratorTest {
         SegmentMetadataClient metadataClient = factory.createSegmentMetadataClient(segment,
                 DelegationTokenProviderFactory.createWithEmptyToken());
         long length = metadataClient.getSegmentInfo().join().getWriteOffset();
+
+        SegmentMetadataClientFactory metaFactory = mock(SegmentMetadataClientFactory.class);
+        SegmentMetadataClient metaClient = mock(SegmentMetadataClient.class);
+        when(metaFactory.createSegmentMetadataClient(any(Segment.class), any(DelegationTokenProvider.class))).thenReturn(metaClient);
+        doReturn(CompletableFuture.completedFuture(new SegmentInfo(segment, 0L, length, false, 1L)))
+                .when(metaClient).getSegmentInfo();
         @Cleanup
-        SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, segment, stringSerializer, 0, length);
+        SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, metaFactory, controller, segment, stringSerializer, 0, length);
         assertEquals("1", iter.next());
         long segmentLength = metadataClient.fetchCurrentSegmentLength().join();
         assertEquals(0, segmentLength % 3);
         metadataClient.truncateSegment(segmentLength * 2 / 3).join();
         AssertExtensions.assertThrows(TruncatedDataException.class, () -> iter.next());
         @Cleanup
-        SegmentIteratorImpl<String> iter2 = new SegmentIteratorImpl<>(factory, segment, stringSerializer,
+        SegmentIteratorImpl<String> iter2 = new SegmentIteratorImpl<>(factory, metaFactory, controller, segment, stringSerializer,
                                                                       segmentLength * 2 / 3, length);
         assertTrue(iter2.hasNext());
         assertEquals("3", iter2.next());
@@ -140,8 +179,14 @@ public class SegmentIteratorTest {
         EventSegmentReader input = mock(EventSegmentReader.class);
         when(factory.createEventReaderForSegment(segment, 0, endOffset)).thenReturn(input);
         when(input.read()).thenReturn(null).thenReturn(stringSerializer.serialize("s"));
+
+        SegmentMetadataClientFactory metaFactory = mock(SegmentMetadataClientFactory.class);
+        SegmentMetadataClient metaClient = mock(SegmentMetadataClient.class);
+        when(metaFactory.createSegmentMetadataClient(any(Segment.class), any(DelegationTokenProvider.class))).thenReturn(metaClient);
+        doReturn(CompletableFuture.completedFuture(new SegmentInfo(segment, 0L, endOffset, false, 1L)))
+                .when(metaClient).getSegmentInfo();
         @Cleanup
-        SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, segment, stringSerializer, 0, endOffset);
+        SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, metaFactory, controller, segment, stringSerializer, 0, endOffset);
         assertEquals("s", iter.next());
         verify(input, times(2)).read();
         when(input.read()).thenThrow(SegmentTruncatedException.class);

--- a/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
+++ b/client/src/test/java/io/pravega/client/batch/impl/SegmentIteratorTest.java
@@ -21,7 +21,6 @@ import io.pravega.client.security.auth.DelegationTokenProviderFactory;
 import io.pravega.client.segment.impl.EndOfSegmentException;
 import io.pravega.client.segment.impl.EventSegmentReader;
 import io.pravega.client.segment.impl.Segment;
-import io.pravega.client.segment.impl.SegmentInfo;
 import io.pravega.client.segment.impl.SegmentInputStreamFactory;
 import io.pravega.client.segment.impl.SegmentMetadataClient;
 import io.pravega.client.segment.impl.SegmentMetadataClientFactory;
@@ -154,8 +153,7 @@ public class SegmentIteratorTest {
         SegmentMetadataClientFactory metaFactory = mock(SegmentMetadataClientFactory.class);
         SegmentMetadataClient metaClient = mock(SegmentMetadataClient.class);
         when(metaFactory.createSegmentMetadataClient(any(Segment.class), any(DelegationTokenProvider.class))).thenReturn(metaClient);
-        doReturn(CompletableFuture.completedFuture(new SegmentInfo(segment, 0L, length, false, 1L)))
-                .when(metaClient).getSegmentInfo();
+        doReturn(CompletableFuture.completedFuture(10L)).when(metaClient).fetchCurrentSegmentHeadOffset();
         @Cleanup
         SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, metaFactory, controller, segment, stringSerializer, 0, length);
         assertEquals("1", iter.next());
@@ -183,8 +181,7 @@ public class SegmentIteratorTest {
         SegmentMetadataClientFactory metaFactory = mock(SegmentMetadataClientFactory.class);
         SegmentMetadataClient metaClient = mock(SegmentMetadataClient.class);
         when(metaFactory.createSegmentMetadataClient(any(Segment.class), any(DelegationTokenProvider.class))).thenReturn(metaClient);
-        doReturn(CompletableFuture.completedFuture(new SegmentInfo(segment, 0L, endOffset, false, 1L)))
-                .when(metaClient).getSegmentInfo();
+        doReturn(CompletableFuture.completedFuture(10L)).when(metaClient).fetchCurrentSegmentHeadOffset();
         @Cleanup
         SegmentIteratorImpl<String> iter = new SegmentIteratorImpl<>(factory, metaFactory, controller, segment, stringSerializer, 0, endOffset);
         assertEquals("s", iter.next());

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -76,6 +76,7 @@ import org.junit.Test;
 import static io.pravega.shared.NameUtils.computeSegmentId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 @Slf4j
 public class BatchClientTest extends ThreadPooledTestSuite {
@@ -258,6 +259,7 @@ public class BatchClientTest extends ThreadPooledTestSuite {
             eventList.addAll(Lists.newArrayList(segmentIterator));
         } catch (TruncatedDataException e) {
             // Now Offset should be pointing to valid offset after the truncation that is 60 and it should properly read the remaining event in s0
+            assertNotNull(segmentIterator);
             assertEquals(60L, segmentIterator.getOffset());
             eventList.addAll(Lists.newArrayList(segmentIterator));
             assertEquals(DATA_OF_SIZE_30, eventList.get(0));

--- a/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/BatchClientTest.java
@@ -228,6 +228,43 @@ public class BatchClientTest extends ThreadPooledTestSuite {
     }
 
     @Test(timeout = 50000)
+    public void testBatchClientWithStreamTruncationReadAfterException() throws InterruptedException, ExecutionException {
+        @Cleanup
+        EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(SCOPE, clientConfig);
+        createTestStreamWithEvents(clientFactory);
+
+        @Cleanup
+        BatchClientFactory batchClient = BatchClientFactory.withScope(SCOPE, clientConfig);
+        // 1. Fetch Segments.
+        ArrayList<SegmentRange> segmentsPostTruncation = Lists.newArrayList(
+                batchClient.getSegments(Stream.of(SCOPE, STREAM), StreamCut.UNBOUNDED, StreamCut.UNBOUNDED).getIterator());
+
+        // 2. Create a StreamCut at the end of segment 0 ( offset = 2 * 30 = 60)
+        StreamCut streamCut60L = new StreamCutImpl(Stream.of(SCOPE, STREAM),
+                ImmutableMap.of(new Segment(SCOPE, STREAM, 0), 60L));
+        // 3. Truncate stream.
+        assertTrue("truncate stream",
+                controllerWrapper.getController().truncateStream(SCOPE, STREAM, streamCut60L).join());
+        // 4. Use SegmentRange obtained before truncation.
+        SegmentRange s0 = segmentsPostTruncation.stream().filter(
+                segmentRange -> segmentRange.getSegmentId() == 0L).findFirst().get();
+        // 5. Read non existent segment.
+        List<String> eventList = new ArrayList<>();
+
+        @Cleanup
+        SegmentIterator<String> segmentIterator = null;
+        try {
+            segmentIterator = batchClient.readSegment(s0, serializer);
+            eventList.addAll(Lists.newArrayList(segmentIterator));
+        } catch (TruncatedDataException e) {
+            // Now Offset should be pointing to valid offset after the truncation that is 60 and it should properly read the remaining event in s0
+            assertEquals(60L, segmentIterator.getOffset());
+            eventList.addAll(Lists.newArrayList(segmentIterator));
+            assertEquals(DATA_OF_SIZE_30, eventList.get(0));
+        }
+    }
+
+    @Test(timeout = 50000)
     @SuppressWarnings("deprecation")
     public void testGetDistanceBetweenTwoSCwithStartStreamCutAsUnboundedAndEndAtOffset() throws InterruptedException, ExecutionException {
         @Cleanup


### PR DESCRIPTION
**Change log description**  
Update valid offset on SegmentIterator next TruncatedDataException case, so that iterator next call can start reading from valid offset

**Purpose of the change**  
Fixes #7269 

**What the code does**  
It updates the valid offset when TruncateddataException is catched.

**How to verify it**  
After setting Truncation policy Longevity read should not due to TruncatedDataException. 
