### PR TITLE
Fix for Unsupported Format version post backup-restore

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -427,12 +427,12 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                 thenComposeAsync( shouldRecover -> {
                     if (shouldRecover) {
                         return this.adjustLengthsForSegment(NameUtils.getStorageMetadataSegmentName(this.getId()))
-                                .thenComposeAsync(v -> this.adjustLengthsForSegment(NameUtils.getEventProcessorSegmentName(this.getId(), String.format("GC.queue.%d", this.getId()))));
+                                .thenComposeAsync(v -> this.adjustLengthsForSegment(NameUtils.getEventProcessorSegmentName(this.getId(), String.format("GC.queue.%d", this.getId()))), this.executor);
                     } else {
                         log.info("{}: Not recovering from storage. No need to adjust lengths", this.traceObjectId);
                         return CompletableFuture.completedFuture(null);
                     }
-                });
+                }, this.executor);
     }
 
     /**

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -349,7 +349,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
 
         // We are started and ready to accept requests when DurableLog starts. All other (secondary) services
         // are not required for accepting new operations and can still start in the background.
-        delayedStart.thenComposeAsync( v -> this.adjustStorageMetadataLength(), this.executor)
+        delayedStart.thenComposeAsync( v -> this.adjustLengthsPostRecovery(), this.executor)
                 .thenComposeAsync(v -> {
                     val chunkedSegmentStorage = ChunkedSegmentStorage.getReference(this.storage);
                     if (null != chunkedSegmentStorage) {
@@ -384,31 +384,32 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
      * @return a CompletableFuture which when completed indicates successful updation
      * of storage metadata length in container metadata.
      */
-    private CompletableFuture<Void> adjustStorageMetadataLength() {
+    /**
+     * Adjusting storage metadata segment length in container metadata.
+     * @return a CompletableFuture which when completed indicates successful updation
+     * of storage metadata length in container metadata.
+     */
+    private CompletableFuture<Void> adjustLengthsForSegment(String segmentName) {
         try {
             // No-op for non-recovery container startup.
-            if (!shouldRecoverFromStorage().get()) {
-                log.info("{}: Non-recovery startup. No need to adjust storage metadata length", this.traceObjectId);
-                return CompletableFuture.completedFuture(null);
-            }
             // Adjust always the storage metadata segment length in container metadata. This is the planned migration
             // recovery usecase where we would flush-to-storage, so should be safe to invoke the below adjust-length flow if not taken effect.
             val extension = this.getExtension(ContainerTableExtension.class);
-            val storageSegment = this.storage.getStreamSegmentInfo(NameUtils.getStorageMetadataSegmentName(this.getId()), this.config.getMetadataStoreInitTimeout()).get();
-            log.debug("{}: Storage Metadata segment details retrieved: {}", this.traceObjectId, storageSegment);
-            return this.metadataStore.getSegmentInfoInternal(NameUtils.getStorageMetadataSegmentName(this.getId()), this.config.getMetadataStoreInitTimeout())
-                    .thenComposeAsync( storageMetadataSegmentBytes -> {
-                        val storageMetadataSegmentInfo = MetadataStore.SegmentInfo.deserialize(storageMetadataSegmentBytes);
-                        val toBeSerializedSM = constructStorageMetadataSegmentInfoWithLength(storageMetadataSegmentInfo, storageSegment.getLength());
-                        val serializedStorageSegment = MetadataStore.SegmentInfo.serialize(toBeSerializedSM);
-                        val unversionedEntry = TableEntry.unversioned(new ByteArraySegment(NameUtils.getStorageMetadataSegmentName(this.getId()).getBytes(Charsets.UTF_8)), serializedStorageSegment);
+            val storageSegment = this.storage.getStreamSegmentInfo(segmentName, this.config.getMetadataStoreInitTimeout()).get();
+            log.debug("{}: Storage Metadata segment details retrieved for: {}", this.traceObjectId, storageSegment);
+            return this.metadataStore.getSegmentInfoInternal(segmentName, this.config.getMetadataStoreInitTimeout())
+                    .thenComposeAsync( segmentInfoBytes -> {
+                        val segmentInfo = MetadataStore.SegmentInfo.deserialize(segmentInfoBytes);
+                        val tobeSerializedSegment = constructStorageMetadataSegmentInfoWithLength(segmentInfo, storageSegment.getLength());
+                        val toBeSerializedSegmentInSM = MetadataStore.SegmentInfo.serialize(tobeSerializedSegment);
+                        val unversionedEntry = TableEntry.unversioned(new ByteArraySegment(segmentName.getBytes(Charsets.UTF_8)), toBeSerializedSegmentInSM);
                         try {
-                            extension.put(NameUtils.getMetadataSegmentName(this.getId()), Collections.singletonList(unversionedEntry), this.config.getMetadataStoreInitTimeout())
-                                     .get(this.config.getMetadataStoreInitTimeout().toMillis(), TimeUnit.MILLISECONDS);
+                            extension.put(NameUtils.getMetadataSegmentName(this.getId()), Collections.singletonList(unversionedEntry), this.config.getMetadataStoreInitTimeout()).get(this.config.getMetadataStoreInitTimeout().toMillis(), TimeUnit.MILLISECONDS);
                         } catch (Exception e) {
                             log.error("{}: Could not save storage metadata info in container metadata. Failed with exception {}", this.traceObjectId, e );
                             return Futures.failedFuture(e);
                         }
+                        log.info("{}: Reconciled lengths for segment {}", this.traceObjectId, segmentName);
                         return CompletableFuture.completedFuture(null);
                     }, this.executor);
         } catch (Exception ex) {
@@ -417,22 +418,36 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         }
     }
 
+    private CompletableFuture<Void> adjustLengthsPostRecovery() {
+        return shouldRecoverFromStorage().
+                thenComposeAsync( shouldRecover -> {
+                    if (shouldRecover) {
+                        return this.adjustLengthsForSegment(NameUtils.getStorageMetadataSegmentName(this.getId()))
+                                .thenComposeAsync(v -> this.adjustLengthsForSegment(NameUtils.getEventProcessorSegmentName(this.getId(), String.format("GC.queue.%d", this.getId()))));
+                    } else {
+                        log.info("{}: Not recovering from storage. No need to adjust lengths", this.traceObjectId);
+                        return CompletableFuture.completedFuture(null);
+                    }
+                });
+    }
+
     /**
      * Constructs a SegmentInfo object from the passed SegmentInfo object and setting the provided length.
-     * @param storageMetadataSegmentInfo SegmentInfo object to construct from.
+     * @param segmentInfo SegmentInfo object to construct from.
      * @param length length to be set in the constructed SegmentInfo object.
      * @return constructed SegmentInfo object
      */
-    private MetadataStore.SegmentInfo constructStorageMetadataSegmentInfoWithLength(MetadataStore.SegmentInfo storageMetadataSegmentInfo, long length) {
-        Map<AttributeId, Long> attribs = new HashMap<>(storageMetadataSegmentInfo.getProperties().getAttributes());
-        attribs.put(TableAttributes.INDEX_OFFSET, length);
-        // On LTS restore, reset the PERSIST_SEQ_NO as a new BK log is created with operation seq no's resetting or starting afresh.
-        attribs.put(TableAttributes.ATTRIBUTE_SEGMENT_PERSIST_SEQ_NO, Operation.NO_SEQUENCE_NUMBER);
-        StreamSegmentInformation newStorageMetadata = StreamSegmentInformation.from(storageMetadataSegmentInfo.getProperties()).length(length)
+    private MetadataStore.SegmentInfo constructStorageMetadataSegmentInfoWithLength(MetadataStore.SegmentInfo segmentInfo, long length) {
+        Map<AttributeId, Long> attribs = new HashMap<>(segmentInfo.getProperties().getAttributes());
+        if (SegmentType.fromAttributes(segmentInfo.getProperties().getAttributes()).isTableSegment()) {
+            attribs.put(TableAttributes.INDEX_OFFSET, length);
+            attribs.put(TableAttributes.ATTRIBUTE_SEGMENT_PERSIST_SEQ_NO, Operation.NO_SEQUENCE_NUMBER);
+        }
+        StreamSegmentInformation newStorageMetadata = StreamSegmentInformation.from(segmentInfo.getProperties()).length(length)
                 .attributes(attribs)
                 .build();
         return MetadataStore.SegmentInfo.builder()
-                .segmentId(storageMetadataSegmentInfo.getSegmentId())
+                .segmentId(segmentInfo.getSegmentId())
                 .properties(newStorageMetadata)
                 .build();
     }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -380,12 +380,8 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
     }
 
     /**
-     * Adjusting storage metadata segment length in container metadata.
-     * @return a CompletableFuture which when completed indicates successful updation
-     * of storage metadata length in container metadata.
-     */
-    /**
-     * Adjusting storage metadata segment length in container metadata.
+     * Adjusting lengths for the passed segment in container metadata taking
+     * storage metadata as truth.
      * @return a CompletableFuture which when completed indicates successful updation
      * of storage metadata length in container metadata.
      */
@@ -418,6 +414,12 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         }
     }
 
+    /**
+     * Adjust lengths for segments that might have possible mismatch or a difference
+     * in their lengths in the container and storage metadata after the container
+     * boots up in recover-from-storage mode.
+     * @return a CompletableFuture that indicates completion.
+     */
     private CompletableFuture<Void> adjustLengthsPostRecovery() {
         return shouldRecoverFromStorage().
                 thenComposeAsync( shouldRecover -> {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -400,7 +400,9 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                         val toBeSerializedSegmentInSM = MetadataStore.SegmentInfo.serialize(tobeSerializedSegment);
                         val unversionedEntry = TableEntry.unversioned(new ByteArraySegment(segmentName.getBytes(Charsets.UTF_8)), toBeSerializedSegmentInSM);
                         try {
-                            extension.put(NameUtils.getMetadataSegmentName(this.getId()), Collections.singletonList(unversionedEntry), this.config.getMetadataStoreInitTimeout()).get(this.config.getMetadataStoreInitTimeout().toMillis(), TimeUnit.MILLISECONDS);
+                            extension.put(NameUtils.getMetadataSegmentName(this.getId()), Collections.singletonList(unversionedEntry),
+                                    this.config.getMetadataStoreInitTimeout())
+                                    .get(this.config.getMetadataStoreInitTimeout().toMillis(), TimeUnit.MILLISECONDS);
                         } catch (Exception e) {
                             log.error("{}: Could not save storage metadata info in container metadata. Failed with exception {}", this.traceObjectId, e );
                             return Futures.failedFuture(e);


### PR DESCRIPTION
**Change log description**  
Fixes the cases where we see "Unsupported format version" serialization exception after a container recovers in restore-from-lts mode. 

**Purpose of the change**  
Fixes #7282

**What the code does**  
The issue was occurring due to there being difference in lengths recorded between container and storage metadata after the backup is done for the container event processor segments. This can happen on the container event processor segments especially due to them being constantly updated internally for GC purposes. This change basically takes the storage metadata length of the container event processor segments as the source of truth post a container restores and updates them in container metadata which results in correct reads/deserialization of events.

**How to verify it**  
Perform backup-restore and make sure there are no serialization errors for EventProcessors.
