### PR TITLE
Moving saveEpoch from StreamSegmentContainer to SystemJournal

### DIFF
--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -3061,7 +3061,7 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
             container1.metadata.setContainerEpochAfterRecovery(5);
             container1.flushToStorage(TIMEOUT).join();
             container1.metadata.setContainerEpochAfterRecovery(3);
-            AssertExtensions.assertSuppliedFutureThrows("", () -> container1.flushToStorage(TIMEOUT), ex -> Exceptions.unwrap(ex) instanceof IllegalContainerStateException );
+            AssertExtensions.assertSuppliedFutureThrows("", () -> container1.flushToStorage(TIMEOUT), ex -> Exceptions.unwrap(ex) instanceof IllegalStateException );
             //Test 2 ends
             container1.stopAsync().awaitTerminated();
         }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/EpochInfo.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/EpochInfo.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.pravega.segmentstore.server.containers;
+package io.pravega.segmentstore.storage.chunklayer;
 
 import io.pravega.common.ObjectBuilder;
 import io.pravega.common.io.serialization.RevisionDataInput;

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/SystemJournalTests.java
@@ -202,6 +202,29 @@ public class SystemJournalTests extends ThreadPooledTestSuite {
     }
 
     @Test
+    public void testSaveEpoch() throws Exception {
+        @Cleanup
+        ChunkStorage chunkStorage = getChunkStorage();
+        @Cleanup
+        ChunkMetadataStore metadataStore = getMetadataStore();
+        int containerId = 42;
+        int maxLength = 8;
+        long epoch = 1;
+        @Cleanup
+        val garbageCollector = new GarbageCollector(containerId,
+                chunkStorage,
+                metadataStore,
+                ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                executorService());
+        garbageCollector.initialize(new InMemoryTaskQueueManager()).join();
+        val policy = new SegmentRollingPolicy(maxLength);
+        val config = getDefaultConfigBuilder(policy).build();
+        val journal = new SystemJournal(containerId, chunkStorage, metadataStore, garbageCollector, config, executorService());
+        Assert.assertNotNull(journal.saveEpochInfo(containerId, epoch));
+        Assert.assertNotNull(journal.saveEpochInfo(containerId, epoch + 1));
+    }
+
+    @Test
     public void testIsSystemSegment() throws Exception {
         @Cleanup
         ChunkStorage chunkStorage = getChunkStorage();


### PR DESCRIPTION
**Change log description**  
Refactor and move lts related recovery code at one place. Here we need to move saveEpoch to SystemJournal.

**Purpose of the change**  
Fixes #7291 

**What the code does**  
Moving saveEpoch from StreamSegmentContainer to SystemJournal.

**How to verify it**  
Recovery should work fine after refactor.
