### PR TITLE
Issue 7296: Fixes in community joining documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ Pravega can be installed locally or in a distributed environment. The installati
 
 ## Support
 
-Don’t hesitate to ask! Contact the developers and community on [slack](https://pravega-io.slack.com/) ([signup](https://pravega-slack-invite.herokuapp.com/)) if you need any help. Open an issue if you found a bug on [Github Issues](https://github.com/pravega/pravega/issues).
+Don’t hesitate to ask! Contact the developers and community on [slack](https://pravega-io.slack.com/) 
+([signup](https://join.slack.com/t/pravega-io/shared_invite/zt-245sgpw47-vbLBLiLfBdW9TlKemXkUnw)) if you need any help. 
+Open an issue if you found a bug on [Github Issues](https://github.com/pravega/pravega/issues).
 
 ## Documentation
 

--- a/documentation/src/docs/join-community.md
+++ b/documentation/src/docs/join-community.md
@@ -15,10 +15,8 @@ limitations under the License.
 -->
 # Join the Pravega Community
 
-[Slack Channel](https://pravega-io.slack.com/)
+## Slack
+[Slack Channel](https://join.slack.com/t/pravega-io/shared_invite/zt-245sgpw47-vbLBLiLfBdW9TlKemXkUnw)
 
-### User Groups
-pravega-users@googlegroups.com
-
-### Developer Mailing List
-pravega-dev@googlegroups.com
+## Developer Mailing List
+[cncf-pravega-dev@lists.cncf.io](mailto:cncf-pravega-dev@lists.cncf.io)


### PR DESCRIPTION
**Change log description**  
Added self-registration Slack link and updated developer mailing list.

**Purpose of the change**  
Fixes #7296.

**What the code does**  
Updates the information in "Join the Community" documentation page.

**How to verify it**  
A new user has been able to register in the Pravega Slack space with the provided link.