### PR TITLE
Issue 6581: LTS - Throttle SLTS on slow or unstable LTS

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3ChunkStorage.java
+++ b/bindings/src/main/java/io/pravega/storage/extendeds3/ExtendedS3ChunkStorage.java
@@ -36,6 +36,7 @@ import io.pravega.segmentstore.storage.chunklayer.ChunkInfo;
 import io.pravega.segmentstore.storage.chunklayer.ChunkNotFoundException;
 import io.pravega.segmentstore.storage.chunklayer.ChunkStorage;
 import io.pravega.segmentstore.storage.chunklayer.ChunkStorageException;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageUnavailableException;
 import io.pravega.segmentstore.storage.chunklayer.ConcatArgument;
 import io.pravega.segmentstore.storage.chunklayer.InvalidOffsetException;
 import lombok.SneakyThrows;
@@ -337,6 +338,11 @@ public class ExtendedS3ChunkStorage extends BaseChunkStorage {
                     || errorCode.equals("MethodNotAllowed")
                     || s3Exception.getHttpCode() == HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE) {
                 throw new IllegalArgumentException(chunkName, e);
+            }
+
+            if (s3Exception.getHttpCode() == HttpStatus.SC_GATEWAY_TIMEOUT
+                    || s3Exception.getHttpCode() == HttpStatus.SC_SERVICE_UNAVAILABLE) {
+                retValue = new ChunkStorageUnavailableException(chunkName, e);
             }
 
             if (errorCode.equals("AccessDenied")) {

--- a/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageMockTests.java
+++ b/bindings/src/test/java/io/pravega/storage/extendeds3/ExtendedS3SimpleStorageMockTests.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.storage.extendeds3;
+
+import com.emc.object.s3.S3Client;
+import com.emc.object.s3.S3Exception;
+import com.emc.object.s3.request.PutObjectRequest;
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageUnavailableException;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import lombok.val;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+
+
+
+import java.io.ByteArrayInputStream;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link ExtendedS3ChunkStorage} using {@link org.mockito.Mockito}.
+ */
+public class ExtendedS3SimpleStorageMockTests extends ThreadPooledTestSuite {
+    @Test
+    public void testUnavailableException503() throws Exception {
+        val status = HttpStatus.SC_SERVICE_UNAVAILABLE;
+        testUnavailableException(status);
+    }
+
+    @Test
+    public void testUnavailableException504() throws Exception {
+        val status = HttpStatus.SC_GATEWAY_TIMEOUT;
+        testUnavailableException(status);
+    }
+
+    private void testUnavailableException(int status) {
+        val s3Client = mock(S3Client.class);
+        val toThrow = new S3Exception("unavailable", status);
+        doThrow(toThrow).when(s3Client).putObject(any(PutObjectRequest.class));
+        val chunkStorage = new ExtendedS3ChunkStorage(s3Client,
+                ExtendedS3StorageConfig.builder()
+                        .with(ExtendedS3StorageConfig.CONFIGURI, "http://127.0.0.1?identity=x&secretKey=x")
+                        .with(ExtendedS3StorageConfig.BUCKET, "test")
+                        .with(ExtendedS3StorageConfig.PREFIX, "samplePrefix")
+                        .with(ExtendedS3StorageConfig.USENONEMATCH, true)
+                        .build(),
+                executorService(), false, true);
+        AssertExtensions.assertFutureThrows("Should throw an exception",
+                chunkStorage.createWithContent("test", 10, new ByteArrayInputStream(new byte[10])),
+                ex -> ex instanceof ChunkStorageUnavailableException);
+    }
+
+}

--- a/bindings/src/test/java/io/pravega/storage/s3/S3SimpleStorageMockTests.java
+++ b/bindings/src/test/java/io/pravega/storage/s3/S3SimpleStorageMockTests.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.storage.s3;
+
+import io.pravega.segmentstore.storage.chunklayer.ChunkStorageUnavailableException;
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import lombok.val;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.ByteArrayInputStream;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link S3ChunkStorage} using {@link org.mockito.Mockito}.
+ */
+public class S3SimpleStorageMockTests extends ThreadPooledTestSuite {
+    @Test
+    public void testUnavailableException503() {
+        testUnavailableException(HttpStatus.SC_SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void testUnavailableException504() {
+        testUnavailableException(HttpStatus.SC_GATEWAY_TIMEOUT);
+    }
+
+    private void testUnavailableException(int status) {
+        val s3Client = mock(S3Client.class);
+        val toThrow = S3Exception.builder()
+                .statusCode(status)
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .sdkHttpResponse(SdkHttpResponse.builder()
+                                .statusCode(status)
+                                .build())
+                        .build())
+                .build();
+        doThrow(toThrow).when(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+        val chunkStorage = new S3ChunkStorage(s3Client, S3StorageConfig.builder().build(), executorService(), false);
+        AssertExtensions.assertFutureThrows("Should throw an exception",
+                chunkStorage.createWithContent("test", 10, new ByteArrayInputStream(new byte[10])),
+                ex -> ex instanceof ChunkStorageUnavailableException);
+    }
+}

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -355,7 +355,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                     if (null != chunkedSegmentStorage) {
                         StorageEventProcessor eventProcessor = new StorageEventProcessor(this.metadata.getContainerId(),
                                 this.containerEventProcessor,
-                                batch -> chunkedSegmentStorage.getGarbageCollector().processBatch(batch),
+                                batch -> chunkedSegmentStorage.processGarbageCollectionBatch(batch),
                                 chunkedSegmentStorage.getConfig().getGarbageCollectionMaxConcurrency());
                         return chunkedSegmentStorage.finishBootstrap(eventProcessor);
                     }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageUnavailableException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/StorageUnavailableException.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.storage;
+
+import io.pravega.segmentstore.contracts.StreamSegmentException;
+
+/**
+ * Indicates that a particular Storage Instance is unavailable.
+ */
+public class StorageUnavailableException extends StreamSegmentException {
+    private static final long serialVersionUID = 1L;
+    /**
+     * Creates a new instance of the StorageUnstableException class.
+     *
+     * @param streamSegmentName The name of the segment for which the Storage is unavailable.
+     */
+    public StorageUnavailableException(String streamSegmentName) {
+        this(streamSegmentName, null, null);
+    }
+
+    /**
+     * Creates a new instance of the StorageUnstableException class.
+     *
+     * @param streamSegmentName The name of the segment for which operation was called.
+     * @param cause             The causing exception.
+     */
+    public StorageUnavailableException(String streamSegmentName, Throwable cause) {
+        this(streamSegmentName, null, cause);
+    }
+
+    /**
+     * Creates a new instance of the StorageUnstableException class.
+     *
+     * @param streamSegmentName The name of the segment for which operation was called.
+     * @param message           Message.
+     * @param cause             The causing exception.
+     */
+    public StorageUnavailableException(String streamSegmentName, String message, Throwable cause) {
+        super(streamSegmentName, "The current storage instance is unavailable." + (message == null ? "" : " " + message),
+                cause);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/AsyncBaseChunkStorage.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/AsyncBaseChunkStorage.java
@@ -20,7 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import io.pravega.common.Exceptions;
 import io.pravega.common.LoggerHelpers;
-import io.pravega.common.Timer;
+
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.concurrent.Callable;
@@ -28,6 +28,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.pravega.common.Timer;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.val;

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageMetrics.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageMetrics.java
@@ -94,4 +94,8 @@ public class ChunkStorageMetrics {
     static final Counter SLTS_SYSTEM_TRUNCATE_COUNT = STATS_LOGGER.createCounter(MetricsNames.SLTS_SYSTEM_TRUNCATE_COUNT);
 
     static final Counter LARGE_CONCAT_COUNT = STATS_LOGGER.createCounter(MetricsNames.STORAGE_LARGE_CONCAT_COUNT);
+
+    static final OpStatsLogger SLTS_HEALTH_PARALLEL_THROTTLE = STATS_LOGGER.createStats(MetricsNames.SLTS_HEALTH_PARALLEL_THROTTLE);
+    static final OpStatsLogger SLTS_HEALTH_EXCLUSIVE_THROTTLE = STATS_LOGGER.createStats(MetricsNames.SLTS_HEALTH_EXCLUSIVE_THROTTLE);
+    static final OpStatsLogger SLTS_HEALTH_GC_THROTTLE = STATS_LOGGER.createStats(MetricsNames.SLTS_HEALTH_GC_THROTTLE);
 }

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageUnavailableException.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkStorageUnavailableException.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+/**
+ * Exception thrown when chunk storage is unavailable.
+ */
+public class ChunkStorageUnavailableException extends ChunkStorageException {
+    /**
+     * Creates a new instance of the exception.
+     *
+     * @param message   The message for this exception.
+     */
+    public ChunkStorageUnavailableException(String message) {
+        super("", String.format("Chunk storage is unavailable. %s", message));
+    }
+
+    /**
+     * Creates a new instance of the exception.
+     *
+     * @param message   The message for this exception.
+     * @param cause     The causing exception.
+     */
+    public ChunkStorageUnavailableException(String message, Throwable cause) {
+        super("", String.format("Chunk storage is unavailable - %s", "", message), cause);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfig.java
@@ -78,6 +78,13 @@ public class ChunkedSegmentStorageConfig {
 
     public static final Property<Integer> MIN_TRUNCATE_RELOCATION_PERCENT = Property.named("truncate.relocate.percent.min", 80);
 
+    public static final Property<Boolean> ENABLE_HEALTH_CHECK = Property.named("health.check.enable", true);
+    public static final Property<Integer> HEALTH_CHECK_FREQUENCY = Property.named("health.check.frequency.seconds", 60);
+    public static final Property<Integer> MAX_LATE_REQUEST_THROTTLE_PERCENT = Property.named("health.throttle.late.percent.max", 75);
+    public static final Property<Integer> MIN_LATE_REQUEST_THROTTLE_PERCENT = Property.named("health.throttle.late.percent.min", 25);
+    public static final Property<Integer> MAX_LATE_REQUEST_THROTTLE_DURATION = Property.named("health.throttle.late.max.ms", 1000);
+    public static final Property<Integer> MIN_LATE_REQUEST_THROTTLE_DURATION = Property.named("health.throttle.late.min.ms", 100);
+
     /**
      * Default configuration for {@link ChunkedSegmentStorage}.
      */
@@ -115,6 +122,12 @@ public class ChunkedSegmentStorageConfig {
             .minSizeForTruncateRelocationInbytes(64 * 1024 * 1024L)
             .maxSizeForTruncateRelocationInbytes(1 * 1024 * 1024 * 1024L)
             .minPercentForTruncateRelocation(80)
+            .healthCheckEnabled(true)
+            .healthCheckFrequencyInSeconds(60)
+            .minLateThrottleDurationInMillis(100)
+            .maxLateThrottleDurationInMillis(1000)
+            .minLateThrottlePercentage(25)
+            .maxLateThrottlePercentage(75)
             .build();
 
     static final String COMPONENT_CODE = "storage";
@@ -327,6 +340,42 @@ public class ChunkedSegmentStorageConfig {
     final private int safeStorageSizeCheckFrequencyInSeconds;
 
     /**
+     * When enabled, SLTS will periodically check health.
+     */
+    @Getter
+    final private boolean healthCheckEnabled;
+
+    /**
+     * Frequency in seconds of how often health checks is performed.
+     */
+    @Getter
+    final private int healthCheckFrequencyInSeconds;
+
+    /**
+     *  Maximum percentage of late requests per iteration beyond which all requests are rejected with {@link io.pravega.segmentstore.storage.StorageUnavailableException}
+     */
+    @Getter
+    final private int maxLateThrottlePercentage;
+
+    /**
+     *  Minimum percentage of late requests per iteration bellow which no requests are throttled.
+     */
+    @Getter
+    final private int minLateThrottlePercentage;
+
+    /**
+     *  Minimum throttle for lateness in millis.
+     */
+    @Getter
+    final private int maxLateThrottleDurationInMillis;
+
+    /**
+     *  Maximum throttle for lateness in millis.
+     */
+    @Getter
+    final private int minLateThrottleDurationInMillis;
+
+    /**
      * Creates a new instance of the ChunkedSegmentStorageConfig class.
      *
      * @param properties The TypedProperties object to read Properties from.
@@ -338,17 +387,27 @@ public class ChunkedSegmentStorageConfig {
         // Don't use appends for concat when appends are disabled.
         this.minSizeLimitForConcat = this.appendEnabled ? properties.getLong(MIN_SIZE_LIMIT_FOR_CONCAT) : 0;
         this.maxSizeLimitForConcat = properties.getPositiveLong(MAX_SIZE_LIMIT_FOR_CONCAT);
+
+        // Read index related properties
         this.maxIndexedSegments = properties.getNonNegativeInt(MAX_INDEXED_SEGMENTS);
         this.maxIndexedChunksPerSegment = properties.getPositiveInt(MAX_INDEXED_CHUNKS_PER_SEGMENTS);
         this.maxIndexedChunks = properties.getPositiveInt(MAX_INDEXED_CHUNKS);
+        this.indexBlockSize = properties.getPositiveLong(READ_INDEX_BLOCK_SIZE);
+
+        // Metadata related properties
         this.storageMetadataRollingPolicy = new SegmentRollingPolicy(properties.getLong(DEFAULT_ROLLOVER_SIZE));
-        this.lateWarningThresholdInMillis = properties.getPositiveInt(SELF_CHECK_LATE_WARNING_THRESHOLD);
+        this.maxEntriesInTxnBuffer = properties.getPositiveInt(MAX_METADATA_ENTRIES_IN_BUFFER);
+        this.maxEntriesInCache = properties.getPositiveInt(MAX_METADATA_ENTRIES_IN_CACHE);
+
+        // Garbage collector related properties
         this.garbageCollectionDelay = Duration.ofSeconds(properties.getPositiveInt(GARBAGE_COLLECTION_DELAY));
         this.garbageCollectionMaxConcurrency = properties.getPositiveInt(GARBAGE_COLLECTION_MAX_CONCURRENCY);
         this.garbageCollectionMaxQueueSize = properties.getPositiveInt(GARBAGE_COLLECTION_MAX_QUEUE_SIZE);
         this.garbageCollectionSleep = Duration.ofMillis(properties.getPositiveInt(GARBAGE_COLLECTION_SLEEP));
         this.garbageCollectionMaxAttempts = properties.getPositiveInt(GARBAGE_COLLECTION_MAX_ATTEMPTS);
         this.garbageCollectionTransactionBatchSize = properties.getPositiveInt(GARBAGE_COLLECTION_MAX_TXN_BATCH_SIZE);
+
+        // System Journals related properties
         this.journalSnapshotInfoUpdateFrequency = Duration.ofMinutes(properties.getPositiveInt(JOURNAL_SNAPSHOT_UPDATE_FREQUENCY));
         this.maxJournalUpdatesPerSnapshot =  properties.getPositiveInt(MAX_PER_SNAPSHOT_UPDATE_COUNT);
         this.maxJournalReadAttempts = properties.getPositiveInt(MAX_JOURNAL_READ_ATTEMPTS);
@@ -357,16 +416,26 @@ public class ChunkedSegmentStorageConfig {
         this.selfCheckForDataEnabled = properties.getBoolean(SELF_CHECK_DATA_INTEGRITY);
         this.selfCheckForMetadataEnabled = properties.getBoolean(SELF_CHECK_METADATA_INTEGRITY);
         this.selfCheckForSnapshotEnabled = properties.getBoolean(SELF_CHECK_SNAPSHOT_INTEGRITY);
-        this.indexBlockSize = properties.getPositiveLong(READ_INDEX_BLOCK_SIZE);
-        this.maxEntriesInTxnBuffer = properties.getPositiveInt(MAX_METADATA_ENTRIES_IN_BUFFER);
-        this.maxEntriesInCache = properties.getPositiveInt(MAX_METADATA_ENTRIES_IN_CACHE);
         this.maxSafeStorageSize = properties.getPositiveLong(MAX_SAFE_SIZE);
         this.safeStorageSizeCheckEnabled = properties.getBoolean(ENABLE_SAFE_SIZE_CHECK);
         this.safeStorageSizeCheckFrequencyInSeconds = properties.getPositiveInt(SAFE_SIZE_CHECK_FREQUENCY);
+
+        // Truncation related properties
         this.relocateOnTruncateEnabled = properties.getBoolean(RELOCATE_ON_TRUNCATE_ENABLED);
         this.minSizeForTruncateRelocationInbytes = properties.getPositiveLong(MIN_TRUNCATE_RELOCATION_SIZE_BYTES);
         this.maxSizeForTruncateRelocationInbytes = properties.getPositiveLong(MAX_TRUNCATE_RELOCATION_SIZE_BYTES);
         this.minPercentForTruncateRelocation = properties.getPositiveInt(MIN_TRUNCATE_RELOCATION_PERCENT);
+
+        // Self check
+        this.lateWarningThresholdInMillis = properties.getPositiveInt(SELF_CHECK_LATE_WARNING_THRESHOLD);
+
+        // Health check
+        this.healthCheckEnabled = properties.getBoolean(ENABLE_HEALTH_CHECK);
+        this.healthCheckFrequencyInSeconds = properties.getPositiveInt(HEALTH_CHECK_FREQUENCY);
+        this.minLateThrottlePercentage = properties.getPositiveInt(MIN_LATE_REQUEST_THROTTLE_PERCENT);
+        this.maxLateThrottlePercentage = properties.getPositiveInt(MAX_LATE_REQUEST_THROTTLE_PERCENT);
+        this.minLateThrottleDurationInMillis = properties.getPositiveInt(MIN_LATE_REQUEST_THROTTLE_DURATION);
+        this.maxLateThrottleDurationInMillis = properties.getPositiveInt(MAX_LATE_REQUEST_THROTTLE_DURATION);
     }
 
     /**

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ConcatOperation.java
@@ -16,6 +16,7 @@
 package io.pravega.segmentstore.storage.chunklayer;
 
 import com.google.common.base.Preconditions;
+import io.pravega.common.AbstractTimer;
 import io.pravega.common.Exceptions;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.Timer;
@@ -24,6 +25,7 @@ import io.pravega.segmentstore.contracts.StreamSegmentTruncatedException;
 import io.pravega.segmentstore.storage.SegmentHandle;
 import io.pravega.segmentstore.storage.StorageFullException;
 import io.pravega.segmentstore.storage.StorageNotPrimaryException;
+import io.pravega.segmentstore.storage.StorageUnavailableException;
 import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
 import io.pravega.segmentstore.storage.metadata.MetadataTransaction;
 import io.pravega.segmentstore.storage.metadata.SegmentMetadata;
@@ -51,7 +53,7 @@ class ConcatOperation implements Callable<CompletableFuture<Void>> {
     private final ChunkedSegmentStorage chunkedSegmentStorage;
     private final List<String> chunksToDelete = new Vector<>();
     private final List<ChunkNameOffsetPair> newReadIndexEntries = new Vector<>();
-    private final Timer timer;
+    private final AbstractTimer timer;
 
     private volatile SegmentMetadata targetSegmentMetadata;
     private volatile SegmentMetadata sourceSegmentMetadata;
@@ -129,6 +131,10 @@ class ConcatOperation implements Callable<CompletableFuture<Void>> {
         if (ex instanceof ChunkStorageFullException) {
             throw new CompletionException(new StorageFullException(targetHandle.getSegmentName(), ex));
         }
+        if (ex instanceof ChunkStorageUnavailableException) {
+            chunkedSegmentStorage.getHealthTracker().reportUnavailable();
+            throw new CompletionException(new StorageUnavailableException(targetHandle.getSegmentName(), ex));
+        }
         throw new CompletionException(ex);
     }
 
@@ -145,7 +151,8 @@ class ConcatOperation implements Callable<CompletableFuture<Void>> {
         SLTS_CONCAT_LATENCY.reportSuccessEvent(elapsed);
         SLTS_CONCAT_COUNT.inc();
         if (chunkedSegmentStorage.getConfig().getLateWarningThresholdInMillis() < elapsed.toMillis()) {
-            log.warn("{} concat - late op={}, target={}, source={}, offset={}, latency={}.",
+            chunkedSegmentStorage.recordLateRequest(elapsed.toMillis());
+            log.warn("{} concat - finished late op={}, target={}, source={}, offset={}, latency={}.",
                     chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), targetHandle.getSegmentName(), sourceSegment, offset, elapsed.toMillis());
         } else {
             log.debug("{} concat - finished op={}, target={}, source={}, offset={}, latency={}.",

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ReadOperation.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/ReadOperation.java
@@ -16,12 +16,14 @@
 package io.pravega.segmentstore.storage.chunklayer;
 
 import com.google.common.base.Preconditions;
+import io.pravega.common.AbstractTimer;
 import io.pravega.common.Exceptions;
 import io.pravega.common.LoggerHelpers;
 import io.pravega.common.Timer;
 import io.pravega.common.concurrent.Futures;
 import io.pravega.segmentstore.contracts.StreamSegmentTruncatedException;
 import io.pravega.segmentstore.storage.SegmentHandle;
+import io.pravega.segmentstore.storage.StorageUnavailableException;
 import io.pravega.segmentstore.storage.metadata.ChunkMetadata;
 import io.pravega.segmentstore.storage.metadata.MetadataTransaction;
 import io.pravega.segmentstore.storage.metadata.ReadIndexBlockMetadata;
@@ -60,7 +62,7 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
     private final int length;
     private final ChunkedSegmentStorage chunkedSegmentStorage;
     private final long traceId;
-    private final Timer timer;
+    private final AbstractTimer timer;
     private volatile SegmentMetadata segmentMetadata;
     private final AtomicInteger bytesRemaining = new AtomicInteger();
     private final AtomicInteger currentBufferOffset = new AtomicInteger();
@@ -112,10 +114,12 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
                                     .exceptionally(ex -> {
                                         log.debug("{} read - exception op={}, segment={}, offset={}, bytesRead={}.",
                                                 chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, totalBytesRead);
-                                        if (ex instanceof CompletionException) {
-                                            throw (CompletionException) ex;
+                                        var e = Exceptions.unwrap(ex);
+                                        if (e instanceof ChunkStorageUnavailableException) {
+                                            chunkedSegmentStorage.getHealthTracker().reportUnavailable();
+                                            throw new CompletionException(new StorageUnavailableException(handle.getSegmentName(), ex));
                                         }
-                                        throw new CompletionException(ex);
+                                        throw new CompletionException(e);
                                     })
                                     .thenApplyAsync(v -> {
                                         logEnd();
@@ -141,7 +145,7 @@ class ReadOperation implements Callable<CompletableFuture<Integer>> {
         }
 
         if (chunkedSegmentStorage.getConfig().getLateWarningThresholdInMillis() < elapsed.toMillis()) {
-            log.warn("{} read - late op={}, segment={}, offset={}, bytesRead={}, latency={}.",
+            log.warn("{} read - finished late op={}, segment={}, offset={}, bytesRead={}, latency={}.",
                     chunkedSegmentStorage.getLogPrefix(), System.identityHashCode(this), handle.getSegmentName(), offset, totalBytesRead, elapsed.toMillis());
         } else {
             log.debug("{} read - finished op={}, segment={}, offset={}, bytesRead={}, latency={}.",

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/StorageHealthTracker.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/StorageHealthTracker.java
@@ -1,0 +1,422 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static io.pravega.shared.MetricsNames.SLTS_HEALTH_SLOW_PERCENTAGE;
+import static io.pravega.shared.MetricsNames.SLTS_STORAGE_USED_BYTES;
+import static io.pravega.shared.MetricsNames.SLTS_STORAGE_USED_PERCENTAGE;
+import static io.pravega.shared.NameUtils.isSegmentInSystemScope;
+
+/**
+ * Tracks the health status of the {@link ChunkedSegmentStorage}.
+ */
+@Slf4j
+@RequiredArgsConstructor
+class StorageHealthTracker implements  StatsReporter {
+    private static final int PARALLEL_OP_MULTIPLIER = 1;
+    private static final int EXCLUSIVE_OP_MULTIPLIER = 1;
+    private static final int GC_OP_MULTIPLIER = 1;
+    /**
+     * Tracks whether storage is slow.
+     */
+    private final AtomicBoolean isStorageDegraded = new AtomicBoolean(false);
+
+    /**
+     * Tracks whether storage should be throttled.
+     */
+    private final AtomicBoolean shouldThrottle = new AtomicBoolean(false);
+
+    /**
+     * Tracks whether storage is unavailable.
+     */
+    private final AtomicBoolean isStorageUnavailable = new AtomicBoolean(false);
+
+    /**
+     * Tracks whether storage is full.
+     */
+    private final AtomicBoolean isStorageFull = new AtomicBoolean(false);
+
+    /**
+     * Tracks percentage late requests in last iteration.
+     */
+    private final AtomicDouble percentageLate = new AtomicDouble(0);
+
+    /**
+     * Tracks storage used in bytes.
+     */
+    private final AtomicLong storageUsed = new AtomicLong(0);
+
+    /**
+     * Tracks number of late requests in current iteration.
+     */
+    private final AtomicLong lateRequestCount = new AtomicLong();
+
+    /**
+     * Tracks number of late requests in current iteration.
+     */
+    private final AtomicLong completedRequestCount = new AtomicLong();
+
+    /**
+     * Tracks number of late requests in current iteration.
+     */
+    private final AtomicLong pendingRequestCount = new AtomicLong();
+
+    /**
+     * Tracks number of unavailable requests in current iteration.
+     */
+    private final AtomicLong unavailableRequestCount = new AtomicLong();
+
+    /**
+     * Tracks number of iterations experiencing unavailable requests .
+     */
+    private final AtomicInteger unavailableIterationCount = new AtomicInteger();
+
+    /**
+     * Container Id.
+     */
+    private final long containerId;
+
+    /**
+     * {@link ChunkedSegmentStorageConfig} instance to use.
+     */
+    @NonNull
+    private final ChunkedSegmentStorageConfig config;
+
+    /**
+     * Function that supplies current time.
+     */
+    @NonNull
+    private final Supplier<Long> currentTimeSupplier;
+
+    /**
+     * Function that supplies delay future.
+     */
+    @NonNull
+    private final Function<Duration, CompletableFuture<Void>> delaySupplier;
+
+    /**
+     *  Calculates Health Stats.
+     */
+    void calculateHealthStats() {
+        // Set the new percentage
+        if (completedRequestCount.get() == 0) {
+            percentageLate.set(0);
+        } else {
+            percentageLate.set((100.0 * lateRequestCount.get()) / completedRequestCount.get());
+        }
+
+        log.debug("StorageHealthTracker[{}]: Calculating Health Stats. Completed={} Pending={} late={} unavailable={} unavailableIterations={}",
+                containerId, completedRequestCount.get(), pendingRequestCount.get(), lateRequestCount.get(),
+                unavailableRequestCount.get(), unavailableIterationCount.get());
+
+        // set degraded status.
+        if (percentageLate.intValue() >= config.getMaxLateThrottlePercentage()) {
+            if (!isStorageDegraded.get()) {
+                log.info("StorageHealthTracker[{}]: Storage is slow. {}% Requests are slow. Max {}% Min {}% allowed.",
+                        containerId, percentageLate.intValue(),
+                        config.getMaxLateThrottlePercentage(), config.getMinLateThrottlePercentage());
+            }
+            isStorageDegraded.set(true);
+        } else {
+            if (isStorageDegraded.get()) {
+                log.info("StorageHealthTracker[{}]: Storage is not slow anymore. {}% Requests are slow. Max {}% Min {}% allowed.",
+                    containerId, percentageLate.intValue(),
+                    config.getMaxLateThrottlePercentage(), config.getMinLateThrottlePercentage());
+            }
+            isStorageDegraded.set(false);
+        }
+
+        // Set unavailable status
+        if (unavailableRequestCount.get() > 0) {
+            if (unavailableIterationCount.get() == 0) {
+                log.info("StorageHealthTracker[{}]: Storage is unavailable.", containerId);
+            }
+            unavailableIterationCount.incrementAndGet();
+            isStorageUnavailable.set(true);
+        } else {
+            if (isStorageUnavailable.get()) {
+                log.info("StorageHealthTracker[{}]: Storage is available again.", containerId);
+            }
+            unavailableIterationCount.set(0);
+            isStorageUnavailable.set(false);
+        }
+
+        // Finally, set whether we should throttle
+        if (percentageLate.intValue() > config.getMinLateThrottlePercentage() || isStorageUnavailable.get()) {
+            if (!shouldThrottle.get()) {
+                log.info("StorageHealthTracker[{}]: Throttle is enabled. {}% Requests are slow.",
+                        containerId, percentageLate.intValue());
+            }
+            shouldThrottle.set(true);
+        } else {
+            if (shouldThrottle.get()) {
+                log.info("StorageHealthTracker[{}]: Throttle is disabled. {}% Requests are slow.",
+                        containerId, percentageLate.intValue());
+            }
+            shouldThrottle.set(false);
+        }
+
+        //Finally, clear state
+        lateRequestCount.set(0);
+        completedRequestCount.set(0);
+        unavailableRequestCount.set(0);
+        lateRequestCount.set(0);
+    }
+
+    @Override
+    public void report() {
+        // Report storage size.
+        ChunkStorageMetrics.DYNAMIC_LOGGER.reportGaugeValue(SLTS_STORAGE_USED_BYTES, getStorageUsed());
+        ChunkStorageMetrics.DYNAMIC_LOGGER.reportGaugeValue(SLTS_STORAGE_USED_PERCENTAGE, getStorageUsedPercentage());
+        // Report slowness percentage
+        ChunkStorageMetrics.DYNAMIC_LOGGER.reportGaugeValue(SLTS_HEALTH_SLOW_PERCENTAGE, getLatePercentage());
+    }
+
+    /**
+     * Method used to report a late request. Late is defined as by "storage.self.check.late" property.
+     * @param latency latency to report.
+     */
+    void reportLate(long latency) {
+        lateRequestCount.accumulateAndGet(1L, this::addValue);
+    }
+
+    /**
+     * Method used to report request did not complete because storage was unavailable.
+     */
+    void reportUnavailable() {
+        isStorageUnavailable.set(true);
+        unavailableRequestCount.accumulateAndGet(1L, this::addValue);
+    }
+
+    /**
+     * Method used to report request completion
+     */
+    void reportCompleted() {
+        completedRequestCount.accumulateAndGet(1L, this::addValue);
+        pendingRequestCount.accumulateAndGet(-1L, this::addValue);
+    }
+
+    /**
+     * Gets the percentage of late requests in last iteration.
+     * @return long between 0 and 100.
+     */
+    long getLatePercentage() {
+        return percentageLate.intValue();
+    }
+
+    /**
+     * Method used to report beginning of request.
+     */
+    void reportStarted() {
+        pendingRequestCount.accumulateAndGet(1L, this::addValue);
+    }
+
+    /**
+     * Indicates whether storage is full.
+     */
+    boolean isStorageFull() {
+        return config.isSafeStorageSizeCheckEnabled() && isStorageFull.get();
+    }
+
+    /**
+     * Sets storage full.
+     */
+    void setStorageFull(boolean isFull) {
+        if (config.isSafeStorageSizeCheckEnabled()) {
+            isStorageFull.set(isFull);
+        }
+    }
+
+    /**
+     * Gets value set of storage usage in bytes.
+     * @return value set of storage usage in bytes.
+     */
+    long getStorageUsed() {
+        return storageUsed.get();
+    }
+
+    /**
+     * Sets value set of storage usage in bytes.
+     */
+    void setStorageUsed(long used) {
+        storageUsed.set(used);
+    }
+
+    /**
+     * Gets storage percentage used.
+     * @return double between 0 and 100.
+     */
+    double getStorageUsedPercentage() {
+        return (100.0 * storageUsed.get()) / config.getMaxSafeStorageSize();
+    }
+
+    /**
+     * Gets whether storage is unavailable.
+     */
+    boolean isStorageUnavailable() {
+        return isStorageUnavailable.get();
+    }
+
+
+    /**
+     * Gets whether storage is degraded.
+     */
+    boolean isStorageDegraded() {
+        return isStorageDegraded.get();
+    }
+
+    /**
+     * Whether this instance is running under the safe mode or not.
+     *
+     * @return True if safe mode, False otherwise.
+     */
+    boolean isSafeMode() {
+        return isStorageFull.get();
+    }
+
+    /**
+     * Throttles a parallel operation if required.
+     * @return A CompletableFuture that will complete after the throttle is applied.
+     * @param segmentNames The names of the Segments involved in this operation.
+     */
+    CompletableFuture<Void> throttleParallelOperation(String... segmentNames) {
+        if (!isSystemOperation(segmentNames) && (shouldThrottle.get() || isStorageUnavailable.get())) {
+            long delay = 0;
+            if (isStorageUnavailable.get()) {
+                delay = getUnavailableThrottleDelay();
+            } else if (isStorageDegraded.get()) {
+                delay = config.getMaxLateThrottleDurationInMillis();
+            } else if (shouldThrottle.get()) {
+                delay = getParallelThrottleDelay();
+            }
+            ChunkStorageMetrics.SLTS_HEALTH_PARALLEL_THROTTLE.reportSuccessValue(delay);
+            return delaySupplier.apply(Duration.ofMillis(delay));
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Throttles an exclusive operation if required.
+     * @param segmentNames The names of the Segments involved in this operation.
+     * @return A CompletableFuture that will complete after the throttle is applied.
+     */
+    CompletableFuture<Void> throttleExclusiveOperation(String... segmentNames) {
+        if (!isSystemOperation(segmentNames) && (shouldThrottle.get() || isStorageUnavailable.get())) {
+            long delay = 0;
+            if (isStorageUnavailable.get()) {
+                delay = getUnavailableThrottleDelay();
+            } else if (isStorageDegraded.get()) {
+                delay = config.getMaxLateThrottleDurationInMillis();
+            } else if (shouldThrottle.get()) {
+                delay = getExclusiveThrottleDelay();
+            }
+            ChunkStorageMetrics.SLTS_HEALTH_EXCLUSIVE_THROTTLE.reportSuccessValue(delay);
+            return delaySupplier.apply(Duration.ofMillis(delay));
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Throttles garbage collection batch if required.
+     * @return A CompletableFuture that will complete after the throttle is applied.
+     */
+    CompletableFuture<Void> throttleGarbageCollectionBatch() {
+        if (shouldThrottle.get() || isStorageUnavailable.get()) {
+            long delay = 0;
+            if (isStorageUnavailable.get()) {
+                delay = getUnavailableThrottleDelay();
+            } else if (isStorageDegraded.get()) {
+                delay = config.getMaxLateThrottleDurationInMillis();
+            } else if (shouldThrottle.get()) {
+                delay = getGarbageCollectionThrottleDelay();
+            }
+            ChunkStorageMetrics.SLTS_HEALTH_GC_THROTTLE.reportSuccessValue(delay);
+            return delaySupplier.apply(Duration.ofMillis(delay));
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Calculate throttle for parallel operations.
+     *
+     * @return Duration for throttle.
+     */
+    private long getParallelThrottleDelay() {
+        return PARALLEL_OP_MULTIPLIER * getLinearlyProportionalDelay();
+    }
+
+    /**
+     *  Calculate delay for exclusive operations.
+     *
+     * @return long Duration in milliseconds for throttle.
+     */
+    private long getExclusiveThrottleDelay() {
+        return EXCLUSIVE_OP_MULTIPLIER * getLinearlyProportionalDelay();
+    }
+
+    /**
+     *  Calculate throttle for garbage collection operations.
+     *
+     * @return long Duration in milliseconds for throttle.
+     */
+    private long getGarbageCollectionThrottleDelay() {
+        return GC_OP_MULTIPLIER * getLinearlyProportionalDelay();
+    }
+
+    /**
+     *  Calculate throttle when storage is unavailable.
+     *
+     * @return long Duration in milliseconds for throttle.
+     */
+    long getUnavailableThrottleDelay() {
+        val multiplier = Math.max(1, unavailableIterationCount.get());
+        return  multiplier * config.getMaxLateThrottleDurationInMillis();
+    }
+
+    /**
+     * Get linearly proportional delay.
+     * Duration is between min and max throttle delay and value is proportional to percentage late requests in most recent iterations.
+     *
+     * @return long linearly proportional delay for throttle
+     */
+    private long getLinearlyProportionalDelay() {
+        val maxRange = config.getMaxLateThrottleDurationInMillis() - config.getMinLateThrottleDurationInMillis();
+        val millis = config.getMinLateThrottleDurationInMillis() + (percentageLate.doubleValue() * maxRange / 100);
+        return Math.round(millis);
+    }
+
+    private long addValue(long incValueParam, long value) {
+        return incValueParam + value;
+    }
+
+    private boolean isSystemOperation(String... segmentNames) {
+        return segmentNames.length >= 1 && isSegmentInSystemScope(segmentNames[0]);
+    }
+}

--- a/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
+++ b/segmentstore/storage/src/main/java/io/pravega/segmentstore/storage/chunklayer/SystemJournal.java
@@ -319,7 +319,7 @@ public class SystemJournal {
         Preconditions.checkState(!reentryGuard.getAndSet(true), "bootstrap called multiple times.");
 
         log.info("SystemJournal[{}] BOOT started.", containerId);
-        Timer t = new Timer();
+        val t = new Timer();
 
         // Start a transaction
         val txn = metadataStore.beginTransaction(false, getSystemSegments());

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/ChunkedSegmentStorageConfigTests.java
@@ -56,6 +56,10 @@ public class ChunkedSegmentStorageConfigTests {
         props.setProperty(ChunkedSegmentStorageConfig.RELOCATE_ON_TRUNCATE_ENABLED.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "false");
         props.setProperty(ChunkedSegmentStorageConfig.MIN_TRUNCATE_RELOCATION_SIZE_BYTES.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "20");
         props.setProperty(ChunkedSegmentStorageConfig.MIN_TRUNCATE_RELOCATION_PERCENT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "21");
+        props.setProperty(ChunkedSegmentStorageConfig.MIN_LATE_REQUEST_THROTTLE_DURATION.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "22");
+        props.setProperty(ChunkedSegmentStorageConfig.MAX_LATE_REQUEST_THROTTLE_DURATION.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "23");
+        props.setProperty(ChunkedSegmentStorageConfig.MIN_LATE_REQUEST_THROTTLE_PERCENT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "24");
+        props.setProperty(ChunkedSegmentStorageConfig.MAX_LATE_REQUEST_THROTTLE_PERCENT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "25");
         props.setProperty(ChunkedSegmentStorageConfig.MAX_TRUNCATE_RELOCATION_SIZE_BYTES.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "22");
         props.setProperty(ChunkedSegmentStorageConfig.SELF_CHECK_DATA_INTEGRITY.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "true");
         props.setProperty(ChunkedSegmentStorageConfig.SELF_CHECK_METADATA_INTEGRITY.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE), "true");
@@ -87,6 +91,10 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertFalse(config.isRelocateOnTruncateEnabled());
         Assert.assertEquals(config.getMinSizeForTruncateRelocationInbytes(), 20);
         Assert.assertEquals(config.getMinPercentForTruncateRelocation(), 21);
+        Assert.assertEquals(config.getMinLateThrottleDurationInMillis(), 22);
+        Assert.assertEquals(config.getMaxLateThrottleDurationInMillis(), 23);
+        Assert.assertEquals(config.getMinLateThrottlePercentage(), 24);
+        Assert.assertEquals(config.getMaxLateThrottlePercentage(), 25);
         Assert.assertEquals(config.getMaxSizeForTruncateRelocationInbytes(), 22);
         Assert.assertEquals(config.isSelfCheckForDataEnabled(), true);
         Assert.assertEquals(config.isSelfCheckForMetadataEnabled(), true);
@@ -128,6 +136,10 @@ public class ChunkedSegmentStorageConfigTests {
         Assert.assertEquals(config.getMinSizeForTruncateRelocationInbytes(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMinSizeForTruncateRelocationInbytes());
         Assert.assertEquals(config.getMaxSizeForTruncateRelocationInbytes(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxSizeForTruncateRelocationInbytes());
         Assert.assertEquals(config.getMinPercentForTruncateRelocation(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMinPercentForTruncateRelocation());
+        Assert.assertEquals(config.getMinLateThrottleDurationInMillis(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMinLateThrottleDurationInMillis());
+        Assert.assertEquals(config.getMaxLateThrottleDurationInMillis(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxLateThrottleDurationInMillis());
+        Assert.assertEquals(config.getMinLateThrottlePercentage(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMinLateThrottlePercentage());
+        Assert.assertEquals(config.getMaxLateThrottlePercentage(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.getMaxLateThrottlePercentage());
         Assert.assertEquals(config.isSelfCheckForDataEnabled(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.isSelfCheckForDataEnabled());
         Assert.assertEquals(config.isSelfCheckForMetadataEnabled(), ChunkedSegmentStorageConfig.DEFAULT_CONFIG.isSelfCheckForMetadataEnabled());
     }
@@ -160,6 +172,10 @@ public class ChunkedSegmentStorageConfigTests {
         testGetPositiveValue(ChunkedSegmentStorageConfig.MIN_TRUNCATE_RELOCATION_SIZE_BYTES.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE));
         testGetPositiveValue(ChunkedSegmentStorageConfig.MIN_TRUNCATE_RELOCATION_PERCENT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE));
         testGetPositiveValue(ChunkedSegmentStorageConfig.SELF_CHECK_LATE_WARNING_THRESHOLD.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE));
+        testGetPositiveValue(ChunkedSegmentStorageConfig.MIN_LATE_REQUEST_THROTTLE_PERCENT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE));
+        testGetPositiveValue(ChunkedSegmentStorageConfig.MAX_LATE_REQUEST_THROTTLE_PERCENT.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE));
+        testGetPositiveValue(ChunkedSegmentStorageConfig.MIN_LATE_REQUEST_THROTTLE_DURATION.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE));
+        testGetPositiveValue(ChunkedSegmentStorageConfig.MAX_LATE_REQUEST_THROTTLE_DURATION.getFullName(ChunkedSegmentStorageConfig.COMPONENT_CODE));
     }
 
     /**

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/StorageHealthTrackerTests.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/StorageHealthTrackerTests.java
@@ -1,0 +1,918 @@
+/**
+ * Copyright Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.segmentstore.storage.chunklayer;
+
+import io.pravega.test.common.AssertExtensions;
+import io.pravega.test.common.ThreadPooledTestSuite;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@Slf4j
+public class StorageHealthTrackerTests extends ThreadPooledTestSuite {
+
+    public static final int CONTAINER_ID = 42;
+
+    @Test
+    public void testDefault() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Call throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // End iteration
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 0);
+    }
+
+    private void checkState(StorageHealthTracker storageHealthTracker,
+                            boolean expectedStorageUnavailable, boolean expectedDegraded, boolean expectedStorageFull,
+                            boolean expectedSafeMode, int expectedPercentLate) {
+        Assert.assertEquals(expectedStorageUnavailable, storageHealthTracker.isStorageUnavailable());
+        Assert.assertEquals(expectedDegraded, storageHealthTracker.isStorageDegraded());
+        Assert.assertEquals(expectedStorageFull, storageHealthTracker.isStorageFull());
+        Assert.assertEquals(expectedSafeMode, storageHealthTracker.isSafeMode());
+        Assert.assertEquals(expectedPercentLate, storageHealthTracker.getLatePercentage());
+    }
+
+    @Test
+    public void testDefaultNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        checkState(storageHealthTracker, false, false, false, false, 0);
+        for (int n = 0; n < 3; n++) {
+            // Start iteration
+            checkState(storageHealthTracker, false, false, false, false, 0);
+
+            // Call throttle
+            checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+            checkState(storageHealthTracker, false, false, false, false, 0);
+            TestUtils.addRequestStats(storageHealthTracker, 0, 5, 0, 0);
+            // End iteration
+            storageHealthTracker.calculateHealthStats();
+            checkState(storageHealthTracker, false, false, false, false, 0);
+        }
+    }
+
+    @Test
+    public void testTransitionNormalSlowNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // make slow.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 6, 4, 0);
+
+        // Should not yet throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 40);
+
+        // Start iteration 2
+        checkState(storageHealthTracker, false, false, false, false, 40);
+
+        // Should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        checkState(storageHealthTracker, false, false, false, false, 40);
+
+        // Make it normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        // No throttling
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+    }
+
+    @Test
+    public void testTransitionNormalSlowDegradedNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // make slow.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 6, 4, 0);
+
+        // Should not yet throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 40);
+
+        // Start iteration 2 - still unavailable
+        checkState(storageHealthTracker, false, false, false, false, 40);
+        // Should now throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        checkState(storageHealthTracker, false, false, false, false, 40);
+
+        // Make degraded
+        TestUtils.addRequestStats(storageHealthTracker, 0, 1, 9, 0);
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, true, false, false, 90);
+
+        // Start iteration 3
+        checkState(storageHealthTracker, false, true, false, false, 90);
+
+        // Should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+        checkState(storageHealthTracker, false, true, false, false, 90);
+
+        // Make it normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        // No throttling
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+    }
+
+    @Test
+    public void testTransitionNormalSlowSlowNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // make degraded.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 6, 4, 0);
+
+        // Should not yet throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 40);
+
+        // Start iteration 2
+
+        checkState(storageHealthTracker, false, false, false, false, 40);
+        // Should now throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        checkState(storageHealthTracker, false, false, false, false, 40);
+
+        // Make slow
+        TestUtils.addRequestStats(storageHealthTracker, 0, 5, 5, 0);
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 50);
+
+        // Start iteration 3
+
+        checkState(storageHealthTracker, false, false, false, false, 50);
+
+        // Should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+        checkState(storageHealthTracker, false, false, false, false, 50);
+
+        // Make it normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        // No throttling
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+    }
+
+    @Test
+    public void testTransitionNormalSlowUnavailableNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // make slow.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 6, 4, 0);
+
+        // Should not yet throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 40);
+
+        // Start iteration 2
+
+        checkState(storageHealthTracker, false, false, false, false, 40);
+        // Should now throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        checkState(storageHealthTracker, false, false, false, false, 40);
+
+        // Make unavailable
+        TestUtils.addRequestStats(storageHealthTracker, 0, 1, 1, 1);
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, true, false, false, false, 33);
+
+        // Start iteration 3
+
+        checkState(storageHealthTracker, true, false, false, false, 33);
+
+        // Should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+        checkState(storageHealthTracker, true, false, false, false, 33);
+
+        // Make it normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+
+        // End iteration 3
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        // No throttling
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+    }
+
+    @Test
+    public void testTransitionNormalDegradedNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // make degraded.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 2, 8, 0);
+
+        // Should not yet throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, true,  false, false, 80);
+
+        // Start iteration 2
+
+        checkState(storageHealthTracker, false, true, false, false, 80);
+
+        // Should still throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        checkState(storageHealthTracker, false, true, false, false, 80);
+
+        // Make it normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+
+        // End iteration 3
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        // No throttling
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+    }
+
+    @Test
+    public void testTransitionNormalDegradedDegradedNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1 - Degraded
+
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // make degraded.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 2, 8, 0);
+
+        // Should not yet throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, true, false, false, 80);
+
+        // Start iteration 2
+
+        checkState(storageHealthTracker, false, true, false, false, 80);
+        // Should now throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        checkState(storageHealthTracker, false, true, false, false, 80);
+
+        // Make degraded again
+        TestUtils.addRequestStats(storageHealthTracker, 0, 1, 9, 0);
+        // No more degraded, but should still throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, true, false, false, 90);
+
+        // Start iteration 3
+
+        checkState(storageHealthTracker, false, true, false, false, 90);
+
+        // Should still throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+        checkState(storageHealthTracker, false, true, false, false, 90);
+
+        // Make it normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+
+        // End iteration 3
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        // No throttling
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+    }
+
+    @Test
+    public void testTransitionNormalDegradedSlowNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // make degraded.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 2, 8, 0);
+
+        // Should not yet throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, true, false, false, 80);
+
+        // Start iteration 2 - still unavailable
+
+        checkState(storageHealthTracker, false, true, false, false, 80);
+        // Should now throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        checkState(storageHealthTracker, false, true, false, false, 80);
+
+        // Make slow
+        TestUtils.addRequestStats(storageHealthTracker, 0, 7, 3, 0);
+        // No more degraded, but should still throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 30);
+
+        // Start iteration 3
+
+        checkState(storageHealthTracker, false, false, false, false, 30);
+
+        // Should still throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+        checkState(storageHealthTracker, false, false, false, false, 30);
+
+        // Make it normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+
+        // End iteration 3
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        // No throttling
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+    }
+
+    @Test
+    public void testTransitionNormalDegradedUnavailableNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // make degraded.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 2, 8, 0);
+
+        // Should not yet throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, true, false, false, 80);
+        // Should now throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        checkState(storageHealthTracker, false, true, false, false, 80);
+
+        // Make unavailable
+        TestUtils.addRequestStats(storageHealthTracker, 0, 1, 1, 1);
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, true, false, false, false, 33);
+
+        // Should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+        checkState(storageHealthTracker, true, false, false, false, 33);
+
+        // Make it normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+
+        // End iteration 3
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        // No throttling
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+    }
+
+    @Test
+    public void testTransitionNormalUnavailableNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // At start it is normal and no throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // Make unavailable
+        TestUtils.addRequestStats(storageHealthTracker, 0, 2, 2, 1);
+
+        // Should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, true, false, false, false, 40);
+
+        // Should still throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+        // Make normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+    }
+
+    @Test
+    public void testTransitionNormalUnavailableDegradedNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // At start it is normal and no throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // Make unavailable
+        TestUtils.addRequestStats(storageHealthTracker, 0, 2, 2, 1);
+
+        // Should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, true, false, false, false, 40);
+
+        // still unavailable should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+        checkState(storageHealthTracker, true, false, false, false, 40);
+
+        // Make degraded
+        TestUtils.addRequestStats(storageHealthTracker, 0, 2, 8, 0);
+
+        // Still throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, true, false, false, 80);
+
+        // Start iteration 3 - Normal
+        // Should still throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 12);
+        // Make normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+        // End iteration 3
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        checkThrottling(storageHealthTracker, delaySupplier, 12);
+    }
+
+    @Test
+    public void testTransitionNormalUnavailableSlowNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+        // At start it is normal and no throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // Make unavailable
+        TestUtils.addRequestStats(storageHealthTracker, 0, 2, 2, 1);
+
+        // Should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, true,  false, false, false, 40);
+
+        // still unavailable should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+        checkState(storageHealthTracker, true, false, false, false, 40);
+
+        // Make slow
+        TestUtils.addRequestStats(storageHealthTracker, 0, 7, 3, 0);
+
+        // Still throttle
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 30);
+
+        // Start iteration 3 - Normal
+        // Should still throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 12);
+        // Make normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+        // End iteration 3
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        checkThrottling(storageHealthTracker, delaySupplier, 12);
+    }
+
+    @Test
+    public void testTransitionNormalUnavailableUnavailableNormal() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID, ChunkedSegmentStorageConfig.DEFAULT_CONFIG,
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+
+        // make unavailable.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 2, 2, 1);
+
+        // Should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, true, false, false, false, 40);
+
+        // Start iteration 2 - still unavailable
+        checkThrottling(storageHealthTracker, delaySupplier, 6);
+        checkState(storageHealthTracker, true, false, false, false, 40);
+
+        // Still unavailable
+        TestUtils.addRequestStats(storageHealthTracker, 0, 1, 1, 1);
+        checkThrottling(storageHealthTracker, delaySupplier, 9);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, true, false, false, false, 33);
+
+        // Start iteration 3 - Unavailable
+        // Should throttle.
+        checkThrottling(storageHealthTracker, delaySupplier, 12);
+        checkState(storageHealthTracker, true, false, false, false, 33);
+
+        // Make it normal.
+        TestUtils.addRequestStats(storageHealthTracker, 0, 9, 1, 0);
+
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+        checkState(storageHealthTracker, false, false, false, false, 10);
+        // No throttling
+        checkThrottling(storageHealthTracker, delaySupplier, 12);
+    }
+
+    private void checkThrottling(StorageHealthTracker storageHealthTracker, TestDelaySupplier delaySupplier, int wantedNumberOfInvocations) {
+        // Call throttle
+        storageHealthTracker.throttleGarbageCollectionBatch().join();
+        storageHealthTracker.throttleParallelOperation().join();
+        storageHealthTracker.throttleExclusiveOperation().join();
+
+        verify(delaySupplier, times(wantedNumberOfInvocations)).apply(any());
+    }
+
+    @Test
+    public void testStorageUsed() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID,
+                ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                        .maxSafeStorageSize(1000)
+                        .build(),
+                System::currentTimeMillis,
+                delaySupplier);
+        storageHealthTracker.setStorageUsed(100);
+        Assert.assertEquals(100, storageHealthTracker.getStorageUsed());
+        Assert.assertEquals(10, storageHealthTracker.getStorageUsedPercentage(), 0);
+    }
+
+    @Test
+    public void testStorageFull() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID,
+                ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                        .maxSafeStorageSize(1000)
+                        .build(),
+                System::currentTimeMillis,
+                delaySupplier);
+        Assert.assertFalse(storageHealthTracker.isStorageFull());
+        Assert.assertFalse(storageHealthTracker.isSafeMode());
+        storageHealthTracker.setStorageFull(true);
+        Assert.assertTrue(storageHealthTracker.isStorageFull());
+        Assert.assertTrue(storageHealthTracker.isSafeMode());
+        storageHealthTracker.setStorageFull(false);
+        Assert.assertFalse(storageHealthTracker.isStorageFull());
+        Assert.assertFalse(storageHealthTracker.isSafeMode());
+    }
+
+    @Test
+    public void testStorageFullDisabled() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID,
+                ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                        .maxSafeStorageSize(1000)
+                        .safeStorageSizeCheckEnabled(false)
+                        .build(),
+                System::currentTimeMillis,
+                delaySupplier);
+        Assert.assertFalse(storageHealthTracker.isStorageFull());
+        Assert.assertFalse(storageHealthTracker.isSafeMode());
+        storageHealthTracker.setStorageFull(true);
+        Assert.assertFalse(storageHealthTracker.isStorageFull());
+        Assert.assertFalse(storageHealthTracker.isSafeMode());
+        storageHealthTracker.setStorageFull(false);
+        Assert.assertFalse(storageHealthTracker.isStorageFull());
+        Assert.assertFalse(storageHealthTracker.isSafeMode());
+    }
+
+    @Test
+    public void testInvalidArgs() {
+        AssertExtensions.assertThrows(
+                " should throw an exception",
+                () -> new StorageHealthTracker(0, null, System::currentTimeMillis, new TestDelaySupplier()),
+                ex -> ex instanceof NullPointerException);
+        AssertExtensions.assertThrows(
+                " should throw an exception",
+                () -> new StorageHealthTracker(0, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, null, new TestDelaySupplier()),
+                ex -> ex instanceof NullPointerException);
+        AssertExtensions.assertThrows(
+                " should throw an exception",
+                () -> new StorageHealthTracker(0, ChunkedSegmentStorageConfig.DEFAULT_CONFIG, System::currentTimeMillis, null),
+                ex -> ex instanceof NullPointerException);
+    }
+
+    @Test
+    public void testThrottleDuration() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID,
+                ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                        .minLateThrottleDurationInMillis(100)
+                        .maxLateThrottleDurationInMillis(1100)
+                        .build(),
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+        verify(delaySupplier, times(0)).apply(Duration.ofMillis(100 + storageHealthTracker.getLatePercentage() * 1000));
+        TestUtils.addRequestStats(storageHealthTracker, 0, 3, 7, 0);
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+
+        // Start iteration 2
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        verify(delaySupplier, times(3)).apply(Duration.ofMillis(800)); // 70% throttle
+        // End iteration 2
+        storageHealthTracker.calculateHealthStats();
+    }
+
+    @Test
+    public void testThrottleDurationForUnavailable() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID,
+                ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                        .minLateThrottleDurationInMillis(100)
+                        .maxLateThrottleDurationInMillis(1100)
+                        .build(),
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+        verify(delaySupplier, times(0)).apply(Duration.ofMillis(100 + storageHealthTracker.getLatePercentage() * 1000));
+        TestUtils.addRequestStats(storageHealthTracker, 0, 1, 1, 1);
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        verify(delaySupplier, times(3)).apply(Duration.ofMillis(1100)); // Full throttle
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+    }
+
+    @Test
+    public void testThrottleDurationForUnavailableMultipleIterations() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID,
+                ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                        .minLateThrottleDurationInMillis(100)
+                        .maxLateThrottleDurationInMillis(1100)
+                        .build(),
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+        verify(delaySupplier, times(0)).apply(Duration.ofMillis(100 + storageHealthTracker.getLatePercentage() * 1000));
+        TestUtils.addRequestStats(storageHealthTracker, 0, 1, 1, 1);
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+
+        // Start iteration 2
+        TestUtils.addRequestStats(storageHealthTracker, 0, 1, 1, 1);
+        storageHealthTracker.calculateHealthStats();
+
+        // Start iteration 3
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        verify(delaySupplier, times(3)).apply(Duration.ofMillis(2200));
+        storageHealthTracker.calculateHealthStats();
+
+        // Start iteration 3
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        verify(delaySupplier, times(3)).apply(Duration.ofMillis(2200));
+    }
+
+    @Test
+    public void testThrottleDurationForDegraded() {
+        val delaySupplier = spy(new TestDelaySupplier());
+        val storageHealthTracker = new StorageHealthTracker(CONTAINER_ID,
+                ChunkedSegmentStorageConfig.DEFAULT_CONFIG.toBuilder()
+                        .minLateThrottleDurationInMillis(100)
+                        .maxLateThrottleDurationInMillis(1100)
+                        .build(),
+                System::currentTimeMillis,
+                delaySupplier);
+
+        // Initial
+        checkState(storageHealthTracker, false, false, false, false, 0);
+
+        // Start iteration 1
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 0);
+        verify(delaySupplier, times(0)).apply(Duration.ofMillis(100 + storageHealthTracker.getLatePercentage() * 1000));
+        TestUtils.addRequestStats(storageHealthTracker, 0, 1, 9, 0);
+        // End iteration 1
+        storageHealthTracker.calculateHealthStats();
+
+        // Start iteration 2
+        // No throttling.
+        checkThrottling(storageHealthTracker, delaySupplier, 3);
+        verify(delaySupplier, times(3)).apply(Duration.ofMillis(1100)); // Full throttle
+        storageHealthTracker.calculateHealthStats();
+    }
+
+    /**
+     * Delay supplier for the tests.
+     */
+    private static class TestDelaySupplier implements Function<Duration, CompletableFuture<Void>> {
+        @Override
+        public CompletableFuture<Void> apply(Duration duration) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+}

--- a/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/TestUtils.java
+++ b/segmentstore/storage/src/test/java/io/pravega/segmentstore/storage/chunklayer/TestUtils.java
@@ -483,4 +483,28 @@ public class TestUtils {
     public static void addChunk(ChunkStorage chunkStorage, String chunkName, long length) {
         ((AbstractInMemoryChunkStorage) chunkStorage).addChunk(chunkName, length);
     }
+
+    /**
+     * Adds given {@link StorageHealthTracker} request stats for testing.
+     * @param storageHealthTracker Instance of {@link StorageHealthTracker} to use.
+     * @param pending Number of pending requests.
+     * @param normal Number of normally completed requests.
+     * @param late Number of late requests.
+     * @param unavailable Number of unavailable requests.
+     */
+    public static void addRequestStats(StorageHealthTracker storageHealthTracker, int pending, int normal, int late, int unavailable) {
+        val total = pending + normal + late + unavailable;
+        for (int i = 0; i < total; i++) {
+            storageHealthTracker.reportStarted();
+        }
+        for (int i = 0; i < total - pending; i++) {
+            storageHealthTracker.reportCompleted();
+        }
+        for (int i = 0; i < late; i++) {
+            storageHealthTracker.reportLate(100);
+        }
+        for (int i = 0; i < unavailable; i++) {
+            storageHealthTracker.reportUnavailable();
+        }
+    }
 }

--- a/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
+++ b/shared/metrics/src/main/java/io/pravega/shared/MetricsNames.java
@@ -182,6 +182,11 @@ public final class MetricsNames {
     public static final String SLTS_STORAGE_USED_BYTES = PREFIX + "segmentstore.storage.used_bytes";
     public static final String SLTS_STORAGE_USED_PERCENTAGE = PREFIX + "segmentstore.storage.used_percentage";
 
+    public static final String SLTS_HEALTH_SLOW_PERCENTAGE = PREFIX + "segmentstore.storage.slts.health.slow_percentage";   // Histogram
+    public static final String SLTS_HEALTH_EXCLUSIVE_THROTTLE = PREFIX + "segmentstore.storage.slts.health.exclusive_throttle_ms";   // Histogram
+    public static final String SLTS_HEALTH_PARALLEL_THROTTLE = PREFIX + "segmentstore.storage.slts.health.parallel_throttle_ms";   // Histogram
+    public static final String SLTS_HEALTH_GC_THROTTLE = PREFIX + "segmentstore.storage.slts.health.gc_throttle_ms";   // Histogram
+
     // SLTS Metadata stats
     public static final String STORAGE_METADATA_SIZE = PREFIX + "segmentstore.storage.size.";
     public static final String STORAGE_METADATA_NUM_CHUNKS = PREFIX + "segmentstore.storage.num_chunks.";

--- a/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
+++ b/shared/protocol/src/main/java/io/pravega/shared/NameUtils.java
@@ -341,6 +341,15 @@ public final class NameUtils {
     }
 
     /**
+     * Checks if the given stream segment name is under system scope.
+     * @param segmentName  The name of the StreamSegment to check.
+     * @return true if stream segment name is under system scope, false otherwise.
+     */
+    public static  boolean isSegmentInSystemScope(String segmentName) {
+        return segmentName.startsWith(INTERNAL_SCOPE_PREFIX);
+    }
+
+    /**
      * Checks if the given stream segment name is formatted for a Transaction Segment or regular segment.
      *
      * @param streamSegmentName The name of the StreamSegment to check for transaction delimiter.

--- a/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
+++ b/shared/protocol/src/test/java/io/pravega/shared/NameUtilsTest.java
@@ -200,6 +200,15 @@ public class NameUtilsTest {
     }
 
     @Test
+    public void testIsSegmentInSystemScope() {
+        Assert.assertTrue(NameUtils.isSegmentInSystemScope("_system/containers/storage_metadata_1"));
+        Assert.assertTrue(NameUtils.isSegmentInSystemScope("_system/foo"));
+        Assert.assertFalse(NameUtils.isSegmentInSystemScope("user"));
+        Assert.assertFalse(NameUtils.isSegmentInSystemScope("user/_system"));
+        Assert.assertFalse(NameUtils.isSegmentInSystemScope(""));
+    }
+
+    @Test
     public void testGetEventProcessorSegmentName() {
         Assert.assertEquals(NameUtils.getEventProcessorSegmentName(0, "test"), "_system/containers/event_processor_test_0");
     }


### PR DESCRIPTION
[ PR against feature branch]
Signed-off-by: Sachin Joshi <sachin.joshi@emc.com>

**Change log description**  
LTS - Throttle major SLTS activities on slow LTS

**Purpose of the change**  
Fixes #6581 

**What the code does**  
New `StorageHealthTracker` that tracks health of `ChunkedSegmentStorage` and reports storage health status periodically.
Based on the 

_how is throttle calculated_
- The already existing current setting for lateness is utilized. (any relevant request more than configured value is considered late. This value needs to be chosen as a small multiple of  expected T99 latency for given storage. Default is 100ms)
- `SLOW` - when % late requests in current iteration is above min throttle threshold, throttling is applied on the _next_ iteration and each updating request is throttled by duration proportional to % late requests.
- `DEGRADED `- when % late requests are above max threshold then ALL update requests are rejected with `StorageUnavailableException`
- `UNAVAILABLE` - when underlying storage itself indicate that storage is too busy or unavailable (Eg http 503)
- In addition , as response to  `StorageUnavailableException`, the `StorageHealthTracker` also throttles any requests until there is at least one successful request. This throttle duration is linearly proportional to number of iteration where storage was unavailable. As soon as there is a successful  non-late request this throttle becomes inactive.

_When LTS is slow or degraded performance._
- throttles SLTS
- throttle  GC activity 

_When LTS is unavailable._
- Reject any SLTS requests
- throttle  GC activity 

_Only following modifying operations are throttled._
- write
- truncate
- concat
- entire GC batch

**How to verify it**  
All tests should pass
