### PR TITLE
Issue 7309: Save operation sequence number

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/EpochInfo.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/EpochInfo.java
@@ -36,6 +36,11 @@ public class EpochInfo {
     private final long epoch;
 
     /**
+     * Epoch.
+     */
+    private final long operationSequenceNumber;
+
+    /**
      * Builder that implements {@link ObjectBuilder}.
      */
     public static class EpochInfoBuilder implements ObjectBuilder<EpochInfo> {
@@ -62,10 +67,12 @@ public class EpochInfo {
 
         private void write00(EpochInfo object, RevisionDataOutput output) throws IOException {
             output.writeCompactLong(object.epoch);
+            output.writeCompactLong(object.operationSequenceNumber);
         }
 
         private void read00(RevisionDataInput input, EpochInfo.EpochInfoBuilder b) throws IOException {
             b.epoch(input.readCompactLong());
+            b.operationSequenceNumber(input.readCompactLong());
         }
     }
 }


### PR DESCRIPTION
**Change log description**  
Save operation sequence number for backup and restore.

**Purpose of the change**  
Fixes #7309

**What the code does**  
Saves operation metadata along with epoch for backup and restore.

**How to verify it**  
(Optional: steps to verify that the changes are effective)
