### PR TITLE
Issue 7311: Add new storage bindings configuration examples in Pravega configuration file

### DIFF
--- a/bindings/src/main/java/io/pravega/storage/azure/AzureStorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/azure/AzureStorageConfig.java
@@ -30,7 +30,6 @@ public class AzureStorageConfig {
     public static final Property<String> ENDPOINT = Property.named("endpoint", "", "endpoint");
     public static final Property<String> CONTAINER = Property.named("container", "");
     public static final Property<Boolean> CREATE_CONTAINER = Property.named("container.create", false);
-    public static final Property<String> ACCESS_KEY = Property.named("connect.config.access.key", "");
     public static final Property<String> PREFIX = Property.named("prefix", "/");
     private static final String PATH_SEPARATOR = "/";
     private static final String COMPONENT_CODE = "azure";

--- a/bindings/src/main/java/io/pravega/storage/gcp/GCPStorageConfig.java
+++ b/bindings/src/main/java/io/pravega/storage/gcp/GCPStorageConfig.java
@@ -45,37 +45,37 @@ public class GCPStorageConfig {
     //endregion
 
     /**
-     * The GCP use mock. Keep always false in production
+     * The GCP use mock. Keep always false in production.
      */
     @Getter
     boolean useMock;
 
     /**
-     * The access token is a string representation of google service account json.
+     * The access token is a string representation of Google service account json.
      */
     @Getter
     private final String accountType;
 
     /**
-     * The GCP project id
+     * The GCP project id.
      */
     @Getter
     private final String projectId;
 
     /**
-     * The gcp private key id
+     * The GCP private key id.
      */
     @Getter
     private final String privateKeyId;
 
     /**
-     * The GCP private key
+     * The GCP private key.
      */
     @Getter
     private final String privateKey;
 
     /**
-     * The GCP client email
+     * The GCP client email.
      */
     @Getter
     private final String clientEmail;
@@ -87,7 +87,7 @@ public class GCPStorageConfig {
     private final String clientId;
 
     /**
-     * A unique bucket name to store objects
+     * A unique bucket name to store objects.
      */
     @Getter
     private final String bucket;

--- a/bindings/src/test/java/io/pravega/storage/azure/AzureTestContext.java
+++ b/bindings/src/test/java/io/pravega/storage/azure/AzureTestContext.java
@@ -62,7 +62,6 @@ public class AzureTestContext {
                     + "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;")
                 .with(AzureStorageConfig.CONTAINER, "azureunittests" + System.currentTimeMillis())
                 .with(AzureStorageConfig.PREFIX, prefix)
-                .with(AzureStorageConfig.ACCESS_KEY, "access")
                 .with(AzureStorageConfig.CREATE_CONTAINER, false)
                 .build();
     }

--- a/config/config.properties
+++ b/config/config.properties
@@ -99,7 +99,7 @@ pravegaservice.dataLog.impl.name=BOOKKEEPER
 
 # Storage implementation for Long-Term Storage.
 # Valid values: Name of valid storage implementation.
-#       For built in implementations: HDFS, FILESYSTEM, EXTENDEDS3, INMEMORY.
+#       For built-in implementations: S3, AZURE, GCP, EXTENDEDS3, FILESYSTEM, HDFS, INMEMORY.
 #       For custom implementations: Any valid identifier. Eg. MY_STORAGE.
 # Default value: HDFS
 # pravegaservice.storage.impl.name=HDFS
@@ -522,6 +522,93 @@ extendeds3.connect.config.uri=http://localhost:9020?identity=user&secretKey=pass
 
 # Root path where NFS shared directory needs to be mounted before segmentstore starts execution.
 # filesystem.root=
+
+##endregion
+
+##region S3 settings
+
+# Whether to use an endpoint other than default.
+# s3.connect.config.uri.override=false
+
+# Non-default endpoint to use.
+# s3.connect.config.uri=
+
+# The S3 access key id. This is equivalent to the user.
+# s3.connect.config.access.key=
+
+# The S3 secret key associated with the accessKey.
+# s3.connect.config.secret.key=
+
+# The S3 region to use.
+# s3.connect.config.region="us-east-1"
+
+# A unique bucket name to store objects.
+# s3.bucket=
+
+# Prefix of the Pravega owned S3 path under the assigned buckets. All the objects under this path will be exclusively
+# owned by Pravega.
+# s3.prefix=/
+
+# Whether to use if-none-match header or not.
+# s3.noneMatch.enable=false
+
+# Whether to use STS tokens by using assume role.
+# s3.connect.config.assumeRole.enable=false
+
+# The role to assume.
+# s3.connect.config.role=
+
+##endregion
+
+##region Azure settings
+
+# ConnectionString containing authorization information to access the Storage account.
+#azure.connection.string=
+
+# Blob service endpoint that we get from the Storage account created on Azure portal.
+#azure.endpoint=
+
+# A unique container name to store set of blobs.
+#azure.container=
+
+# Whether to create a new container during every run or not.
+#azure.container.create=false
+
+# Prefix of the Pravega owned Azure path under the assigned container. All the objects under this path will be
+# exclusively owned by Pravega.
+#azure.prefix=/
+
+##endregion
+
+##region GCP settings
+
+# The access token is a string representation of google service account json.
+#gcp.account.type=service_account
+
+# The GCP project id.
+#gcp.project.id=
+
+# The GCP private key id.
+#gcp.private.key.id=
+
+# The GCP private key.
+#gcp.private.key=
+
+# The GCP client email.
+#gcp.client.email=
+
+# The GCP client id.
+#gcp.client.id=
+
+# A unique bucket name to store objects.
+#gcp.bucket=
+
+# Prefix of the Pravega owned GCP path under the assigned buckets. All the objects under this path will be exclusively
+# owned by Pravega.
+#gcp.prefix=/
+
+# The GCP use mock. Keep always false in production.
+#gcp.useMock=false
 
 ##endregion
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/AzureIntegrationTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/AzureIntegrationTest.java
@@ -79,7 +79,6 @@ public class AzureIntegrationTest extends BookKeeperIntegrationTestBase {
                                             + "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;")
                                         .with(AzureStorageConfig.CONTAINER, containerName)
                 .with(AzureStorageConfig.PREFIX, prefix)
-                .with(AzureStorageConfig.ACCESS_KEY, "access")
                 .with(AzureStorageConfig.CREATE_CONTAINER, true);
         this.configBuilder.include(builder);
         this.azureClient = new MockAzureClient(builder.build());


### PR DESCRIPTION
**Change log description**  
Added configuration parameters and default values for new bindings in `config.properties` file.

**Purpose of the change**  
Fixes #7311.

**What the code does**  
Improves documentation in `config.properties` file to help users configuring the new storage bindings (S3, Azure, GCP).
Also, it removes one unused property (`accesskey`) in Azure binding configuration file, as apparently the security information is expected in the storage url itself.

**How to verify it**  
No code changes.