### PR TITLE
Issue 9207: Backup container operation seq no

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/EpochInfo.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/EpochInfo.java
@@ -34,6 +34,10 @@ public class EpochInfo {
      * Epoch.
      */
     private final long epoch;
+    /**
+     * OperationSequenceNumber.
+     */
+    private final long operationSequenceNumber;
 
     /**
      * Builder that implements {@link ObjectBuilder}.
@@ -62,10 +66,12 @@ public class EpochInfo {
 
         private void write00(EpochInfo object, RevisionDataOutput output) throws IOException {
             output.writeCompactLong(object.epoch);
+            output.writeCompactLong(object.operationSequenceNumber);
         }
 
         private void read00(RevisionDataInput input, EpochInfo.EpochInfoBuilder b) throws IOException {
             b.epoch(input.readCompactLong());
+            b.operationSequenceNumber(input.readCompactLong());
         }
     }
 }

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -259,7 +259,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
             this.durableLog.overrideEpoch(containerEpoch);
             this.metadata.setContainerEpochAfterRestore(containerEpoch);
             this.metadata.setOperationSequenceNumberAfterRestore(backedUpOperationSeq);
-            log.info("{}: Recovered container epoch {} has been set in the DurableDataLog", this.traceObjectId, containerEpoch);
+            log.info("{}: Recovered container epoch {} has been set in the DurableDataLog", this.traceObjectId, info);
         }
         log.info("{}: Initializing storage with epoch {}", this.traceObjectId, containerEpoch);
         this.storage.initialize(containerEpoch);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -249,12 +249,16 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
      */
     private CompletableFuture<Void> initializeStorage() throws Exception {
         long containerEpoch = this.metadata.getContainerEpoch();
+        long backedUpOperationSeq = 0;
         if (shouldRecoverFromStorage().get()) {
             // If we are recovering from storage, the durableLog will be
             // initialized with 0 epoch. So override the durableLog with backed up epoch.
-            containerEpoch = readContainerEpoch().get();
+            EpochInfo info = readContainerEpoch().get();
+            containerEpoch = info.getEpoch();
+            backedUpOperationSeq = info.getOperationSequenceNumber();
             this.durableLog.overrideEpoch(containerEpoch);
-            this.metadata.setContainerEpochAfterRecovery(containerEpoch);
+            this.metadata.setContainerEpochAfterRestore(containerEpoch);
+            this.metadata.setOperationSequenceNumberAfterRestore(backedUpOperationSeq);
             log.info("{}: Recovered container epoch {} has been set in the DurableDataLog", this.traceObjectId, containerEpoch);
         }
         log.info("{}: Initializing storage with epoch {}", this.traceObjectId, containerEpoch);
@@ -875,17 +879,17 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
         log.info("{}: Starting flush to storage for container ID: {}", this.traceObjectId, containerId);
         val flusher = new LogFlusher(containerId, this.durableLog, this.writer, this.metadataCleaner, this.executor);
         return flusher.flushToStorage(timeout)
-                .thenComposeAsync( v -> saveEpochInfo(containerId, this.metadata.getContainerEpoch(), timeout), this.executor)
+                .thenComposeAsync( v -> saveEpochInfo(containerId, this.metadata.getContainerEpoch(), this.metadata.getOperationSequenceNumber(), timeout), this.executor)
                 .thenAcceptAsync(x -> log.info("{}: Completed flush to storage for container ID: {}", this.traceObjectId, containerId));
     }
 
-    private CompletableFuture<Void> saveEpochInfo(int containerId, long containerEpoch, Duration timeout) {
+    private CompletableFuture<Void> saveEpochInfo(int containerId, long containerEpoch, long operationSequenceNumber, Duration timeout) {
         if (!(storage instanceof ChunkedSegmentStorage)) {
             return CompletableFuture.completedFuture(null);
         }
         val chunkedSegmentStorage = (ChunkedSegmentStorage) storage;
         val chunk = NameUtils.getContainerEpochFileName(containerId);
-        val epochInfo = new EpochInfo(containerEpoch);
+        val epochInfo = new EpochInfo(containerEpoch, operationSequenceNumber);
         val isDone = new AtomicBoolean(false);
         val attempts = new AtomicInteger();
         try {
@@ -897,11 +901,12 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                                 if (exists) {
                                     return readEpochInfo(chunk, chunkedSegmentStorage, epochBytes.getLength())
                                             .thenComposeAsync(savedEpoch -> {
-                                                if (savedEpoch.getEpoch() > epochInfo.getEpoch()) {
+                                                if (savedEpoch.getEpoch() > epochInfo.getEpoch() ||
+                                                        savedEpoch.getOperationSequenceNumber() > epochInfo.getOperationSequenceNumber()) {
                                                     return CompletableFuture.failedFuture(
                                                         new IllegalContainerStateException(String.format(
                                                             "Unexpected epoch. Expected = {} actual = {}",
-                                                            epochInfo.getEpoch(), savedEpoch.getEpoch())));
+                                                            epochInfo, savedEpoch)));
                                                 } else {
                                                     return chunkedSegmentStorage.getChunkStorage().delete(ChunkHandle.writeHandle(chunk));
                                                 }
@@ -916,13 +921,14 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                                 log.debug("{}: Epoch info saved to epochInfoFile. File {}. info = {}", this.traceObjectId, chunk, epochInfo);
                                 return readEpochInfo(chunk, chunkedSegmentStorage, epochBytes.getLength()); }, executor)
                             .thenApplyAsync( readBackInfo -> {
-                                if (readBackInfo.getEpoch() > epochInfo.getEpoch()) {
+                                if (readBackInfo.getEpoch() > epochInfo.getEpoch() || readBackInfo.getOperationSequenceNumber() >
+                                        epochInfo.getOperationSequenceNumber()) {
                                     throw new CompletionException(
-                                            new IllegalContainerStateException(String.format("Unexpected epochInfo. Expected = {} actual = {}", epochInfo.getEpoch(), readBackInfo.getEpoch())));
+                                            new IllegalContainerStateException(String.format("Unexpected epochInfo. Expected = {} actual = {}", epochInfo, readBackInfo)));
                                 }
                                 if (!epochInfo.equals(readBackInfo)) {
                                     throw new CompletionException(
-                                            new IllegalStateException(String.format("Unexpected epochInfo. Expected = {} actual = {}", epochInfo.getEpoch(), readBackInfo.getEpoch())));
+                                            new IllegalStateException(String.format("Unexpected epochInfo. Expected = {} actual = {}", epochInfo, readBackInfo)));
                                 }
                                 return null;
                             }, executor)
@@ -971,7 +977,7 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
      * Container startup in case of recovery mode uses this saved epoch information
      * @return epoch read from storage.
      */
-    private CompletableFuture<Long> readContainerEpoch() {
+    private CompletableFuture<EpochInfo> readContainerEpoch() {
         log.info(" {}: Reading container epoch from storage", this.traceObjectId);
         val containerEpochFileName = NameUtils.getContainerEpochFileName(this.getId());
         UtilsWrapper wrapper = new UtilsWrapper((ChunkedSegmentStorage) this.storage, BUFFER_SIZE, this.config.getMetadataStoreInitTimeout());
@@ -984,8 +990,8 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
-                    log.info("{}: Read container epoch {} from storage", this.traceObjectId, containerEpoch.getEpoch());
-                    return CompletableFuture.completedFuture(containerEpoch.getEpoch() + 1);
+                    log.info("{}: Read container epoch {} from storage", this.traceObjectId, containerEpoch);
+                    return CompletableFuture.completedFuture(containerEpoch);
                 }, this.executor)
                 .handleAsync( (epoch, ex) -> {
                    if ( ex != null ) {

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainer.java
@@ -254,7 +254,8 @@ class StreamSegmentContainer extends AbstractService implements SegmentContainer
             // If we are recovering from storage, the durableLog will be
             // initialized with 0 epoch. So override the durableLog with backed up epoch.
             EpochInfo info = readContainerEpoch().get();
-            containerEpoch = info.getEpoch();
+            // Increment epoch for restore just like container restart.
+            containerEpoch = info.getEpoch() + 1;
             backedUpOperationSeq = info.getOperationSequenceNumber();
             this.durableLog.overrideEpoch(containerEpoch);
             this.metadata.setContainerEpochAfterRestore(containerEpoch);

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
@@ -236,7 +236,7 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
      * @param value operation sequence number to override
      */
     public void setOperationSequenceNumberAfterRestore(long value) {
-        Preconditions.checkArgument(value > 0, "epoch must be a non-negative number");
+        Preconditions.checkArgument(value > 0, "Operation sequence number must be a non-negative number");
         this.sequenceNumber.set(value);
     }
 

--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadata.java
@@ -222,12 +222,22 @@ public class StreamSegmentContainerMetadata implements UpdateableContainerMetada
 
 
     /**
-     * Setting container epoch. To be used in cases of Storage based container recovery.
+     * Setting container epoch. To be used in cases of restore phase of Pravega Backup-Restore process.
      * @param value epoch value to override.
      */
-    public void setContainerEpochAfterRecovery(long value) {
+    public void setContainerEpochAfterRestore(long value) {
         Preconditions.checkArgument(value > 0, "epoch must be a non-negative number");
         this.epoch.set(value);
+    }
+
+    /**
+     * Setting the restored operation sequence number.
+     * To be used in cases of restore phase of Pravega Backup-Restore process.
+     * @param value operation sequence number to override
+     */
+    public void setOperationSequenceNumberAfterRestore(long value) {
+        Preconditions.checkArgument(value > 0, "epoch must be a non-negative number");
+        this.sequenceNumber.set(value);
     }
 
     //endregion

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadataTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerMetadataTests.java
@@ -110,6 +110,20 @@ public class StreamSegmentContainerMetadataTests {
         Assert.assertEquals("Unexpected value from getContainerEpoch after exit from recovery mode.", epoch, m.getContainerEpoch());
     }
 
+    @Test
+    public void testWrongEpochAfterRestore() {
+        final long epoch = -1;
+        final StreamSegmentContainerMetadata m = new StreamSegmentContainerMetadata(CONTAINER_ID, 10);
+        Assert.assertThrows( IllegalArgumentException.class, () -> m.setContainerEpochAfterRestore(epoch));
+    }
+
+    @Test
+    public void testWrongSequenceNumberAfterRestore() {
+        final long sn = -1;
+        final StreamSegmentContainerMetadata m = new StreamSegmentContainerMetadata(CONTAINER_ID, 10);
+        Assert.assertThrows( IllegalArgumentException.class, () -> m.setOperationSequenceNumberAfterRestore(sn));
+    }
+
     /**
      * Tests the ability to map new StreamSegments.
      */

--- a/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
+++ b/segmentstore/server/src/test/java/io/pravega/segmentstore/server/containers/StreamSegmentContainerTests.java
@@ -3058,9 +3058,9 @@ public class StreamSegmentContainerTests extends ThreadPooledTestSuite {
             // Test 1 ends
 
             // Test 2: Exercise saved epoch is higher than contaier epoch
-            container1.metadata.setContainerEpochAfterRecovery(5);
+            container1.metadata.setContainerEpochAfterRestore(5);
             container1.flushToStorage(TIMEOUT).join();
-            container1.metadata.setContainerEpochAfterRecovery(3);
+            container1.metadata.setContainerEpochAfterRestore(3);
             AssertExtensions.assertSuppliedFutureThrows("", () -> container1.flushToStorage(TIMEOUT), ex -> Exceptions.unwrap(ex) instanceof IllegalContainerStateException );
             //Test 2 ends
             container1.stopAsync().awaitTerminated();


### PR DESCRIPTION
**Change log description**  
This changeset fixes the case where Pravega Backup-Restore fails as described in #7314 .  #7314 is caused due to a gap in the backup-restore process. Elaborating further. Pravega internal Tables save the operation sequence numbers running inside a Segment Store Container, into them trough a attribute called "PERSIST_SEQ_NO". It so happens that when we restore PRavega using the Backup-Resotre procedure, we install Pravega afresh, causing the operation sequence numbers to reset inside container. Due to a check present on the internal Tables, If this number hasnt run-up more than the "PERSIST_SEQ_NO", the operations on the Table will get rejected causing keys to not get stored in the tables.

**Purpose of the change**  
Fixes #7314

**What the code does**  
Backs up Operation Sequence Number of a container. Restores it and sets it in a container that is used after a container restores.

**How to verify it**  
See #7314 
