### PR TITLE
Issue 7325: Segment store property not loaded

### DIFF
--- a/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
+++ b/segmentstore/server/src/main/java/io/pravega/segmentstore/server/store/ServiceConfig.java
@@ -97,7 +97,7 @@ public class ServiceConfig {
     //Connection Tracker related parameters
     public static final Property<Integer> DEFAULT_ALL_CONNECTIONS_MAX_OUTSTANDING_BYTES = Property.named("default.all.connections.max.outstanding.bytes",
             512 * 1024 * 1024);
-    public static final Property<Integer> DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING_BYTES = Property.named("default.all.connections.max.outstanding.bytes",
+    public static final Property<Integer> DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING_BYTES = Property.named("default.single.connections.max.outstanding.bytes",
             128 * 1024 * 1024);
 
 


### PR DESCRIPTION
**Change log description**  
Loads the `DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING_BYTES` property from the Segmentstore properly. 

**Purpose of the change**  
This commit fixes issue #7325.

**What the code does**  
It reads the `default.single.connections.max.outstanding.bytes` key from the `config.properties` file to load the `DEFAULT_SINGLE_CONNECTION_MAX_OUTSTANDING_BYTES` in `ServiceConfig` class. 

**How to verify it**  
1. Add two different values for `default.single.connections.max.outstanding.bytes` and `default.all.connections.max.outstanding.bytes` in the `config.properties` file.
2. Run the segmentstore, and check the first lines of the log, where the loaded properties are logged. 
3. Verify that the values printed in the log correspond to the values assigned in step 1. 

In my test, I've set my `config.properties` file with:
```
pravegaservice.default.all.connections.max.outstanding.bytes=577770912
pravegaservice.default.single.connections.max.outstanding.bytes=177777728
```

And the output log of the segmentstore was:

```
2023-11-23 12:18:24,399 168  [main] INFO  i.p.s.server.host.ServiceStarter - pravegaservice.default.single.connections.max.outstanding.bytes = 177777728

2023-11-23 12:18:24,400 169  [main] INFO  i.p.s.server.host.ServiceStarter - pravegaservice.default.all.connections.max.outstanding.bytes = 577770912
```