### PR TITLE
Issue 7343: Fixing reader issue when data truncated

### DIFF
--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReader.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReader.java
@@ -102,8 +102,7 @@ public interface EventSegmentReader extends AutoCloseable {
     public abstract void close();
     
     /**
-     * Returns true if {@link #read()} can be invoked without blocking. (This may be because there
-     * is data in a buffer, or the call will throw EndOfSegmentException).
+     * Returns true if there is data in the buffer, or the call will throw EndOfSegmentException.
      *
      * @return False if data read is blocking.
      */

--- a/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/EventSegmentReaderImpl.java
@@ -149,7 +149,7 @@ class EventSegmentReaderImpl implements EventSegmentReader {
     @Synchronized
     public boolean isSegmentReady() {
         int bytesInBuffer = in.bytesInBuffer();
-        return bytesInBuffer >= WireCommands.TYPE_PLUS_LENGTH_SIZE || bytesInBuffer < 0;
+        return bytesInBuffer != 0;
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -263,7 +263,7 @@ class SegmentInputStreamImpl implements SegmentInputStream {
             result += request.getData().readableBytes();
             atEnd |= request.isEndOfSegment();
         }
-        if (result <= 8 && atEnd) {
+        if (result <= 0 && atEnd) {
            result = -1;
         }
         log.trace("bytesInBuffer {} on segment {} status is {}", result, getSegmentId(), this);        

--- a/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
+++ b/client/src/main/java/io/pravega/client/segment/impl/SegmentInputStreamImpl.java
@@ -263,7 +263,7 @@ class SegmentInputStreamImpl implements SegmentInputStream {
             result += request.getData().readableBytes();
             atEnd |= request.isEndOfSegment();
         }
-        if (result <= 0 && atEnd) {
+        if (result <= 8 && atEnd) {
            result = -1;
         }
         log.trace("bytesInBuffer {} on segment {} status is {}", result, getSegmentId(), this);        

--- a/client/src/main/java/io/pravega/client/stream/impl/Orderer.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/Orderer.java
@@ -60,7 +60,7 @@ public class Orderer {
         for (int i = 0; i < segments.size(); i++) {
             T inputStream = segments.get(MathHelpers.abs(counter.incrementAndGet()) % segments.size());
             if (inputStream.isSegmentReady()) {
-                log.trace("Selecting segment: {}", inputStream.getSegmentId());
+                log.trace("Selecting segment: {} to read", inputStream.getSegmentId());
                 return inputStream;
             } else {
                 inputStream.fillBuffer();

--- a/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
+++ b/client/src/test/java/io/pravega/client/segment/impl/SegmentInputStreamTest.java
@@ -494,7 +494,7 @@ public class SegmentInputStreamTest extends LeakDetectorTestSuite {
         fakeNetwork6.completeExceptionally(1, new SegmentTruncatedException());
         
         Orderer o = new Orderer();
-        List<EventSegmentReaderImpl> segments = ImmutableList.of(eventSegment1, eventSegment2, eventSegment3, eventSegment4, eventSegment5,eventSegment6);
+        List<EventSegmentReaderImpl> segments = ImmutableList.of(eventSegment1, eventSegment2, eventSegment3, eventSegment4, eventSegment5, eventSegment6);
         assertEquals(eventSegment2, o.nextSegment(segments));
         assertEquals(eventSegment3, o.nextSegment(segments));
         assertEquals(eventSegment4, o.nextSegment(segments));


### PR DESCRIPTION
**Change log description**  
It has been observed that for a stream having multiple segments and retention policy set, after some retention cycle, a slow reader is not able to read the data from the segments.

**Purpose of the change**  
Fixes #7343 

**What the code does**  
When the data is truncated in the segment and the bytesInBuffer is having partial data which is less than WireCommands.TYPE_PLUS_LENGTH_SIZE then the reader is consistently getting segment as not ready to be read. As part of this PR, modified the condition of isSegmentReady which should return true if data is present in the buffer.

**How to verify it**  
All the test cases should pass.
