### PR TITLE
Issue 7361 : Fix flakey test "testOwnership".

### DIFF
--- a/controller/src/test/java/io/pravega/controller/server/bucket/PravegaTablesStoreBucketServiceTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/bucket/PravegaTablesStoreBucketServiceTest.java
@@ -170,8 +170,6 @@ public class PravegaTablesStoreBucketServiceTest extends BucketServiceTest {
         assertEquals(1, bucketServices.size());
 
         assertTrue(watermarkingService.releaseBucketOwnership(1, dummyProcessId).join());
-        //For id which is not existing, it will return as true.
-        assertTrue(watermarkingService.releaseBucketOwnership(1, dummyProcessId).join());
         assertTrue(watermarkingService.releaseBucketOwnership(2, dummyProcessId).join());
         //All the bucket services get released from dummy process. Now actual owner will occupy this.
         assertEventuallyEquals(3, () -> watermarkingService.getBucketServices().size(), 10000);


### PR DESCRIPTION
**Change log description**  
It is notice that io.pravega.controller.server.bucket.PravegaTablesStoreBucketServiceTest.testOwnership is behaving as flakey.
GA build : https://github.com/pravega/pravega/actions/runs/7624867628/job/20768020138#step:6:2402

**Purpose of the change**  
Fixes #7361 

**What the code does**  
This will remove the flakey check. If a process have released a bucket already and again trying to release the same. Then its a race condition if another process(to whom the bucket is currently assigned) acquired ownership and successfully started the bucket then it will return false else if its trying to acquire the ownership then it will return true.

**How to verify it**  
Run the Junit test.