### PR TITLE
Issue 7387: Client api to exclude writer from timestamp aggregation calculation.

### DIFF
--- a/client/src/main/java/io/pravega/client/stream/EventStreamWriter.java
+++ b/client/src/main/java/io/pravega/client/stream/EventStreamWriter.java
@@ -117,11 +117,15 @@ public interface EventStreamWriter<Type> extends AutoCloseable {
     void noteTime(long timestamp);
 
     /**
-     * This is to notify the controller that the specified writer is shutting down gracefully and no longer
-     * needs to be considered for calculating entries for the marks segment.
+     * This api is to mark the writer as idle.
+     * This means that this writer won't be considered for the noteTime based aggregation above.
+     * Calling this api marks this writer inactive irrespective of {@link StreamConfiguration#getTimestampAggregationTimeout()}
+     * It doesn't mean that this writer won't be able to continue working,
+     * in fact a writer might call noteTime again after calling this method
+     * which would reintroduce it as an active writer for the purposes of timestamp calculation.
      *
      */
-    void removeWriter();
+    void markIdle();
 
     /**
      * Returns the configuration that this writer was create with.

--- a/client/src/main/java/io/pravega/client/stream/EventStreamWriter.java
+++ b/client/src/main/java/io/pravega/client/stream/EventStreamWriter.java
@@ -117,6 +117,13 @@ public interface EventStreamWriter<Type> extends AutoCloseable {
     void noteTime(long timestamp);
 
     /**
+     * This is to notify the controller that the specified writer is shutting down gracefully and no longer
+     * needs to be considered for calculating entries for the marks segment.
+     *
+     */
+    void removeWriter();
+
+    /**
      * Returns the configuration that this writer was create with.
      *
      * @return Writer configuration

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -359,8 +359,7 @@ public final class EventStreamWriterImpl<Type> implements EventStreamWriter<Type
             }
         }
         ExecutorServiceHelpers.shutdown(retransmitPool);
-        controller.removeWriter(writerId, stream)
-                .thenAccept(r -> log.info("Writer {} has been marked idle", writerId));
+        markIdle();
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -383,4 +383,10 @@ public final class EventStreamWriterImpl<Type> implements EventStreamWriter<Type
         WriterPosition position = new WriterPosition(offsets);
         controller.noteTimestampFromWriter(writerId, stream, timestamp, position);
     }
+
+    @Override
+    public void removeWriter() {
+        controller.removeWriter(writerId, stream).
+                thenAccept(r -> log.trace("Writer: {} has been shut down", writerId));
+    }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -359,6 +359,8 @@ public final class EventStreamWriterImpl<Type> implements EventStreamWriter<Type
             }
         }
         ExecutorServiceHelpers.shutdown(retransmitPool);
+        controller.removeWriter(writerId, stream)
+                .thenAccept(r -> log.trace("Writer {} has been shut down", writerId));
     }
 
     @Override

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -360,7 +360,7 @@ public final class EventStreamWriterImpl<Type> implements EventStreamWriter<Type
         }
         ExecutorServiceHelpers.shutdown(retransmitPool);
         controller.removeWriter(writerId, stream)
-                .thenAccept(r -> log.trace("Writer {} has been shut down", writerId));
+                .thenAccept(r -> log.info("Writer {} has been marked idle", writerId));
     }
 
     @Override
@@ -385,8 +385,8 @@ public final class EventStreamWriterImpl<Type> implements EventStreamWriter<Type
     }
 
     @Override
-    public void removeWriter() {
+    public void markIdle() {
         controller.removeWriter(writerId, stream).
-                thenAccept(r -> log.trace("Writer: {} has been shut down", writerId));
+                thenAccept(r -> log.info("Writer: {} has been marked idle", writerId));
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
+++ b/client/src/main/java/io/pravega/client/stream/impl/EventStreamWriterImpl.java
@@ -358,8 +358,8 @@ public final class EventStreamWriterImpl<Type> implements EventStreamWriter<Type
                 }
             }
         }
-        ExecutorServiceHelpers.shutdown(retransmitPool);
         markIdle();
+        ExecutorServiceHelpers.shutdown(retransmitPool);
     }
 
     @Override

--- a/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/ClientFactoryTest.java
@@ -41,6 +41,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -95,7 +96,8 @@ public class ClientFactoryTest {
         when(controllerClient.getCurrentSegments(scope, stream))
                 .thenReturn(CompletableFuture.completedFuture(currentSegments));
         when(outFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(outStream);
-
+        when(controllerClient.removeWriter(anyString(), any()))
+                .thenReturn(CompletableFuture.completedFuture(null));
         EventWriterConfig writerConfig = EventWriterConfig.builder().build();
         @Cleanup
         EventStreamWriter<String> writer = clientFactory.createEventWriter(stream, new JavaSerializer<String>(), writerConfig);

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -952,7 +952,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
                 config, executorService(), executorService(), null);
         writer.noteTime(123);
-        writer.removeWriter();
+        writer.markIdle();
         ImmutableMap<Segment, Long> expectedOffsets = ImmutableMap.of(segment1, 1111L);
         Mockito.verify(controller).noteTimestampFromWriter(eq("id"), eq(stream), eq(123L), eq(new WriterPosition(expectedOffsets)));
         Mockito.verify(controller).removeWriter(eq("id"), eq(stream));

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -60,6 +60,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class EventStreamWriterTest extends LeakDetectorTestSuite {
     @Test
@@ -72,6 +74,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         SegmentOutputStreamFactory streamFactory = Mockito.mock(SegmentOutputStreamFactory.class);
         Controller controller = Mockito.mock(Controller.class);
         Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment));
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         MockSegmentIoStreams outputStream = new MockSegmentIoStreams(segment, null);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(outputStream);
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory,
@@ -79,6 +82,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         writer.writeEvent("Foo");
         writer.writeEvent("Bar");
         writer.close();
+        verify(controller, times(1)).removeWriter("id", stream);
         try {
             writer.writeEvent("fail");
             fail();
@@ -97,6 +101,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         SegmentOutputStreamFactory streamFactory = Mockito.mock(SegmentOutputStreamFactory.class);
         Controller controller = Mockito.mock(Controller.class);
         Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment));
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         MockSegmentIoStreams outputStream = new MockSegmentIoStreams(segment, null);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(outputStream);
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory,
@@ -132,6 +137,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         SegmentOutputStreamFactory streamFactory = Mockito.mock(SegmentOutputStreamFactory.class);
         Controller controller = Mockito.mock(Controller.class);
         Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment));
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         SegmentOutputStream outputStream = Mockito.mock(SegmentOutputStream.class);
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(outputStream);
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory,
@@ -315,6 +321,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         Mockito.when(controller.getCurrentSegments(scope, streamName))
                .thenReturn(getSegmentsFuture(segment1))
                .thenReturn(getSegmentsFuture(segment2));
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
                 config, executorService(), executorService(), null);
@@ -359,6 +366,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         Mockito.when(controller.getCurrentSegments(scope, streamName))
                 .thenReturn(getSegmentsFuture(segment1))
                 .thenReturn(empty);
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
                 config, executorService(), executorService(), null);
@@ -415,6 +423,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         Mockito.when(controller.getCurrentSegments(scope, streamName))
                 .thenReturn(getSegmentsFuture(segment1))
                 .thenReturn(getSegmentsFuture(segment2));
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
                 config, executorService(), executorService(), null);
@@ -459,7 +468,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
             outputStream1.callBackForSealed = i.getArgument(1);
             return outputStream1;
         });
-
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         JavaSerializer<String> serializer = new JavaSerializer<>();
         val empty = CompletableFuture.completedFuture(new StreamSegments(new TreeMap<>()));
         Mockito.when(controller.getCurrentSegments(scope, streamName))
@@ -500,7 +509,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
             outputStream1.callBackForSealed = i.getArgument(1);
             return outputStream1;
         });
-
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         JavaSerializer<String> serializer = new JavaSerializer<>();
         val empty = CompletableFuture.completedFuture(new StreamSegments(new TreeMap<>()));
         Mockito.when(controller.getCurrentSegments(scope, streamName))
@@ -534,6 +543,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         Controller controller = Mockito.mock(Controller.class);
         FakeSegmentOutputStream outputStream = new FakeSegmentOutputStream(segment);
         Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment));
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment), any(), any(), any())).thenReturn(outputStream);
 
         JavaSerializer<String> serializer = new JavaSerializer<>();
@@ -571,6 +581,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
             outputStream2.callBackForSealed = i.getArgument(1);
             return outputStream2;
         });
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
@@ -619,7 +630,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
             return outputStream1;
         });
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment2), any(), any(), any())).thenReturn(outputStream2);
-
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         // Start of test
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
@@ -658,6 +669,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
                     outputStream.callBackForSealed = i.getArgument(1);
                     return outputStream;
                 });
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
@@ -697,6 +709,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
                     outputStream.callBackForSealed = i.getArgument(1);
                     return outputStream;
                 });
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
@@ -738,6 +751,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         Mockito.when(controller.getCurrentSegments(scope, streamName))
                 .thenReturn(getSegmentsFuture(segment1));
         Mockito.when(controller.getSuccessors(segment1)).thenReturn(getReplacement(segment1, segment2));
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment1), any(), any(), any()))
                 .thenAnswer(i -> {
                     outputStream.callBackForSealed = i.getArgument(1);
@@ -789,6 +803,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
                     outputStream.callBackForSealed = i.getArgument(1);
                     return outputStream;
                 });
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
@@ -834,6 +849,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
                     outputStream1.callBackForSealed = i.getArgument(1);
                     return outputStream1;
                 });
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
@@ -889,6 +905,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
                     outputStream3.callBackForSealed = i.getArgument(1);
                     return outputStream3;
                 });
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
@@ -929,7 +946,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment1));
         
         Mockito.when(mockOutputStream.getLastObservedWriteOffset()).thenReturn(1111L);
-        
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
@@ -953,7 +970,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment1), any(), any(), any())).thenReturn(mockOutputStream);
         Controller controller = Mockito.mock(Controller.class);
         Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment1));
-
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         JavaSerializer<String> serializer = new JavaSerializer<>();
         @Cleanup
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
@@ -974,7 +991,7 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         Mockito.when(streamFactory.createOutputStreamForSegment(eq(segment1), any(), any(), any())).thenReturn(mockOutputStream);
         Controller controller = Mockito.mock(Controller.class);
         Mockito.when(controller.getCurrentSegments(scope, streamName)).thenReturn(getSegmentsFuture(segment1));
-        
+        Mockito.when(controller.removeWriter("id", stream)).thenReturn(CompletableFuture.completedFuture(null));
         Mockito.when(mockOutputStream.getLastObservedWriteOffset()).thenReturn(1111L);
         
         CollectingExecutor executor = new CollectingExecutor();

--- a/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
+++ b/client/src/test/java/io/pravega/client/stream/impl/EventStreamWriterTest.java
@@ -952,9 +952,10 @@ public class EventStreamWriterTest extends LeakDetectorTestSuite {
         EventStreamWriter<String> writer = new EventStreamWriterImpl<>(stream, "id", controller, streamFactory, serializer,
                 config, executorService(), executorService(), null);
         writer.noteTime(123);
-        
+        writer.removeWriter();
         ImmutableMap<Segment, Long> expectedOffsets = ImmutableMap.of(segment1, 1111L);
         Mockito.verify(controller).noteTimestampFromWriter(eq("id"), eq(stream), eq(123L), eq(new WriterPosition(expectedOffsets)));
+        Mockito.verify(controller).removeWriter(eq("id"), eq(stream));
     }
     
     @Test

--- a/controller/src/test/java/io/pravega/controller/mocks/ControllerEventStreamWriterMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/ControllerEventStreamWriterMock.java
@@ -73,7 +73,7 @@ public class ControllerEventStreamWriterMock implements EventStreamWriter<Contro
     }
 
     @Override
-    public void removeWriter() {
+    public void markIdle() {
 
     }
 }

--- a/controller/src/test/java/io/pravega/controller/mocks/ControllerEventStreamWriterMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/ControllerEventStreamWriterMock.java
@@ -71,4 +71,9 @@ public class ControllerEventStreamWriterMock implements EventStreamWriter<Contro
     public void noteTime(long timestamp) {
         
     }
+
+    @Override
+    public void removeWriter() {
+
+    }
 }

--- a/controller/src/test/java/io/pravega/controller/mocks/ControllerEventTableWriterMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/ControllerEventTableWriterMock.java
@@ -70,4 +70,9 @@ public class ControllerEventTableWriterMock implements EventStreamWriter<Control
     public void noteTime(long timestamp) {
         
     }
+
+    @Override
+    public void removeWriter() {
+
+    }
 }

--- a/controller/src/test/java/io/pravega/controller/mocks/ControllerEventTableWriterMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/ControllerEventTableWriterMock.java
@@ -72,7 +72,7 @@ public class ControllerEventTableWriterMock implements EventStreamWriter<Control
     }
 
     @Override
-    public void removeWriter() {
+    public void markIdle() {
 
     }
 }

--- a/controller/src/test/java/io/pravega/controller/mocks/EventStreamWriterMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/EventStreamWriterMock.java
@@ -77,4 +77,9 @@ public class EventStreamWriterMock<T> implements EventStreamWriter<T> {
     public void noteTime(long timestamp) {
         throw new NotImplementedException("noteTime");
     }
+
+    @Override
+    public void removeWriter() {
+
+    }
 }

--- a/controller/src/test/java/io/pravega/controller/mocks/EventStreamWriterMock.java
+++ b/controller/src/test/java/io/pravega/controller/mocks/EventStreamWriterMock.java
@@ -79,7 +79,7 @@ public class EventStreamWriterMock<T> implements EventStreamWriter<T> {
     }
 
     @Override
-    public void removeWriter() {
+    public void markIdle() {
 
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -1051,5 +1051,10 @@ public abstract class ScaleRequestHandlerTest {
         public void noteTime(long timestamp) {
             
         }
+
+        @Override
+        public void removeWriter() {
+
+        }
     }
 }

--- a/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
+++ b/controller/src/test/java/io/pravega/controller/server/eventProcessor/ScaleRequestHandlerTest.java
@@ -1053,7 +1053,7 @@ public abstract class ScaleRequestHandlerTest {
         }
 
         @Override
-        public void removeWriter() {
+        public void markIdle() {
 
         }
     }

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -259,7 +259,7 @@ public abstract class TableMetadataTasksTest {
         }
 
         @Override
-        public void removeWriter() {
+        public void markIdle() {
 
         }
     }

--- a/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/KeyValueTable/TableMetadataTasksTest.java
@@ -257,5 +257,10 @@ public abstract class TableMetadataTasksTest {
         public void noteTime(long timestamp) {
 
         }
+
+        @Override
+        public void removeWriter() {
+
+        }
     }
 }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -3265,7 +3265,7 @@ public abstract class StreamMetadataTasksTest {
         }
 
         @Override
-        public void removeWriter() {
+        public void markIdle() {
 
         }
     }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamMetadataTasksTest.java
@@ -3263,5 +3263,10 @@ public abstract class StreamMetadataTasksTest {
         public void noteTime(long timestamp) {
             
         }
+
+        @Override
+        public void removeWriter() {
+
+        }
     }
 }

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -817,6 +817,11 @@ public class StreamTransactionMetadataTasksTest {
         public void noteTime(long timestamp) {
     
         }
+
+        @Override
+        public void removeWriter() {
+
+        }
     }
 
     private <T extends ControllerEvent> void createEventProcessor(final String readerGroupName,

--- a/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
+++ b/controller/src/test/java/io/pravega/controller/task/Stream/StreamTransactionMetadataTasksTest.java
@@ -819,7 +819,7 @@ public class StreamTransactionMetadataTasksTest {
         }
 
         @Override
-        public void removeWriter() {
+        public void markIdle() {
 
         }
     }

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
@@ -356,6 +356,11 @@ public class AutoScaleProcessorTest extends ThreadPooledTestSuite {
             public void noteTime(long timestamp) {
 
             }
+
+            @Override
+            public void removeWriter() {
+
+            }
         };
     }
 

--- a/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
+++ b/segmentstore/server/host/src/test/java/io/pravega/segmentstore/server/host/stat/AutoScaleProcessorTest.java
@@ -358,7 +358,7 @@ public class AutoScaleProcessorTest extends ThreadPooledTestSuite {
             }
 
             @Override
-            public void removeWriter() {
+            public void markIdle() {
 
             }
         };


### PR DESCRIPTION
**Change log description**  
We need to create a client api, calling which should exclude the writer from timestamp aggregation calculation without having it to wait for timeout.

**Purpose of the change**  
Fixes #7387 

**What the code does**  
An api is created in EventStreamWriterImpl, which accepts the user defined writerId and Stream and calls the controllers remove writer api. Also as part of this, we are calling the remove writer in the EventStreamWriter's close method.

**How to verify it**  
All test case should pass.
