### PR TITLE
Issue 7408: Provide a default and minimum value for TimestampAggrigationTimeout

### DIFF
--- a/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
+++ b/client/src/main/java/io/pravega/client/admin/impl/StreamManagerImpl.java
@@ -128,6 +128,7 @@ public class StreamManagerImpl implements StreamManager {
         return  Futures.getThrowingException(controller.createStream(scopeName, streamName, StreamConfiguration.builder()
                         .scalingPolicy(config.getScalingPolicy())
                         .retentionPolicy(config.getRetentionPolicy())
+                        .timestampAggregationTimeout(config.getTimestampAggregationTimeout())
                         .tags(config.getTags())
                         .build()));
     }
@@ -141,6 +142,7 @@ public class StreamManagerImpl implements StreamManager {
                                                                     StreamConfiguration.builder()
                                                                                        .scalingPolicy(config.getScalingPolicy())
                                                                                        .retentionPolicy(config.getRetentionPolicy())
+                                                                                       .timestampAggregationTimeout(config.getTimestampAggregationTimeout())
                                                                                        .tags(config.getTags())
                                                                                        .build()));
     }

--- a/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
@@ -125,7 +125,7 @@ public class StreamConfiguration implements Serializable {
         private void validateTimestampAggregationTimeout(long timestampAggregationTimeout) {
             if (timestampAggregationTimeout == 0) {
                 // timestampAggregationTimeout is not set, setting it to default value.
-                this.timestampAggregationTimeout = DEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT;
+                this.timestampAggregationTimeout = getDefaultTimestampAggregationTimeout();
             } else {
                 Preconditions.checkArgument(timestampAggregationTimeout > 0L, "TimestampAggregationTimeout should be greater than 0");
             }

--- a/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
@@ -22,9 +22,11 @@ import java.util.List;
 import java.util.Set;
 
 import com.google.common.base.Preconditions;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Singular;
 
 /**
@@ -46,6 +48,7 @@ public class StreamConfiguration implements Serializable {
     /*
         Default timeout value for timestampAggregationTimeout
      */
+    @Getter(AccessLevel.PUBLIC)
     private static final long DEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT = 60000L;
 
     /**
@@ -76,6 +79,8 @@ public class StreamConfiguration implements Serializable {
      * If no writer have noted time within the timestampAggregationTimeout, readers that call 
      * {@link EventStreamReader#getCurrentTimeWindow(Stream)}
      * will receive a `null` when they are at the corresponding position in the stream.
+     *
+     * Passing 0 or not setting this field is considered to be as {@link StreamConfiguration#getDEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT()}
      *
      * @param timestampAggregationTimeout The duration after the last call to {@link EventStreamWriter#noteTime(long)}
      *                                    until which the writer would be considered active.
@@ -125,7 +130,7 @@ public class StreamConfiguration implements Serializable {
         private void validateTimestampAggregationTimeout(long timestampAggregationTimeout) {
             if (timestampAggregationTimeout == 0) {
                 // timestampAggregationTimeout is not set, setting it to default value.
-                this.timestampAggregationTimeout = getDefaultTimestampAggregationTimeout();
+                this.timestampAggregationTimeout = getDEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT();
             } else {
                 Preconditions.checkArgument(timestampAggregationTimeout > 0L, "TimestampAggregationTimeout should be greater than 0");
             }
@@ -159,13 +164,5 @@ public class StreamConfiguration implements Serializable {
      */
     public static boolean isTagOnlyChange(StreamConfiguration cfg1, StreamConfiguration cfg2) {
         return cfg1.equals(cfg2) && !cfg1.tags.equals(cfg2.tags);
-    }
-
-    /**
-     * Default value for timestampaggregationtimeout.
-     * @return Default value for timestampaggregationtimeout
-     */
-    public static long getDefaultTimestampAggregationTimeout() {
-        return DEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT;
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
@@ -128,11 +128,10 @@ public class StreamConfiguration implements Serializable {
         }
 
         private void validateTimestampAggregationTimeout(long timestampAggregationTimeout) {
+            Preconditions.checkArgument(timestampAggregationTimeout >= 0L, "TimestampAggregationTimeout should be greater than or equal to 0");
             if (timestampAggregationTimeout == 0) {
                 // timestampAggregationTimeout is not set, setting it to default value.
                 this.timestampAggregationTimeout = getDEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT();
-            } else {
-                Preconditions.checkArgument(timestampAggregationTimeout > 0L, "TimestampAggregationTimeout should be greater than 0");
             }
         }
 

--- a/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
@@ -43,6 +43,10 @@ public class StreamConfiguration implements Serializable {
        Maximum length of each Tag is 256 characters.
      */
     private static final int MAX_TAG_LENGTH = 256;
+    /*
+        Default timeout value for timestampAggregationTimeout
+     */
+    private static final long DEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT = 60000L;
 
     /**
      * API to return scaling policy.
@@ -113,8 +117,18 @@ public class StreamConfiguration implements Serializable {
 
         public StreamConfiguration build() {
             Set<String> tagSet = validateTags(this.tags);
+            validateTimestampAggregationTimeout(this.timestampAggregationTimeout);
             Preconditions.checkArgument(this.rolloverSizeBytes >= 0, String.format("Segment rollover size bytes cannot be less than 0, actual is %s", this.rolloverSizeBytes));
             return new StreamConfiguration(this.scalingPolicy, this.retentionPolicy, this.timestampAggregationTimeout, tagSet, this.rolloverSizeBytes);
+        }
+
+        private void validateTimestampAggregationTimeout(long timestampAggregationTimeout) {
+            if (timestampAggregationTimeout == 0) {
+                // timestampAggregationTimeout is not set, setting it to default value.
+                this.timestampAggregationTimeout = DEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT;
+            } else {
+                Preconditions.checkArgument(timestampAggregationTimeout > 0L, "TimestampAggregationTimeout should be greater than 0");
+            }
         }
 
         private Set<String> validateTags(List<String> tags) {
@@ -145,5 +159,13 @@ public class StreamConfiguration implements Serializable {
      */
     public static boolean isTagOnlyChange(StreamConfiguration cfg1, StreamConfiguration cfg2) {
         return cfg1.equals(cfg2) && !cfg1.tags.equals(cfg2.tags);
+    }
+
+    /**
+     * Default value for timestampaggregationtimeout
+     * @return Default value for timestampaggregationtimeout
+     */
+    public static long getDefaultTimestampAggregationTimeout() {
+        return DEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT;
     }
 }

--- a/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
+++ b/client/src/main/java/io/pravega/client/stream/StreamConfiguration.java
@@ -162,7 +162,7 @@ public class StreamConfiguration implements Serializable {
     }
 
     /**
-     * Default value for timestampaggregationtimeout
+     * Default value for timestampaggregationtimeout.
      * @return Default value for timestampaggregationtimeout
      */
     public static long getDefaultTimestampAggregationTimeout() {

--- a/client/src/test/java/io/pravega/client/control/impl/ModelHelperTest.java
+++ b/client/src/test/java/io/pravega/client/control/impl/ModelHelperTest.java
@@ -238,7 +238,7 @@ public class ModelHelperTest {
         assertEquals(ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS, policy.getScaleType());
         assertEquals(10, policy.getMinNumSegments());
         assertNull(config.getRetentionPolicy());
-        assertEquals(0, config.getTimestampAggregationTimeout());
+        assertEquals(60000, config.getTimestampAggregationTimeout());
         assertEquals(Collections.emptySet(), config.getTags());
     }
     

--- a/client/src/test/java/io/pravega/client/stream/StreamConfigurationTest.java
+++ b/client/src/test/java/io/pravega/client/stream/StreamConfigurationTest.java
@@ -38,6 +38,7 @@ public class StreamConfigurationTest {
         assertEquals(ScalingPolicy.fixed(1), streamConfig.getScalingPolicy() );
         assertEquals(0, streamConfig.getTags().size());
         assertEquals(0L, streamConfig.getRolloverSizeBytes());
+        assertEquals(StreamConfiguration.getDefaultTimestampAggregationTimeout(), streamConfig.getTimestampAggregationTimeout());
     }
 
     @Test
@@ -69,6 +70,8 @@ public class StreamConfigurationTest {
         assertThrows(IllegalArgumentException.class, () -> StreamConfiguration.builder().tags(tags).build());
         // Invalid rollover size
         assertThrows(IllegalArgumentException.class, () -> StreamConfiguration.builder().rolloverSizeBytes(-1024).build());
+        //Invalid timestampaggregationtimeout
+        assertThrows(IllegalArgumentException.class, () -> StreamConfiguration.builder().timestampAggregationTimeout(-10L).build());
     }
 
     @Test

--- a/client/src/test/java/io/pravega/client/stream/StreamConfigurationTest.java
+++ b/client/src/test/java/io/pravega/client/stream/StreamConfigurationTest.java
@@ -38,7 +38,7 @@ public class StreamConfigurationTest {
         assertEquals(ScalingPolicy.fixed(1), streamConfig.getScalingPolicy() );
         assertEquals(0, streamConfig.getTags().size());
         assertEquals(0L, streamConfig.getRolloverSizeBytes());
-        assertEquals(StreamConfiguration.getDefaultTimestampAggregationTimeout(), streamConfig.getTimestampAggregationTimeout());
+        assertEquals(StreamConfiguration.getDEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT(), streamConfig.getTimestampAggregationTimeout());
     }
 
     @Test

--- a/controller/src/main/java/io/pravega/controller/server/bucket/PeriodicWatermarking.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/PeriodicWatermarking.java
@@ -188,7 +188,7 @@ public class PeriodicWatermarking implements AutoCloseable {
         List<Entry<String, WriterMark>> activeWriters = new ArrayList<>();
         List<Entry<String, WriterMark>> inactiveWriters = new ArrayList<>();
         AtomicBoolean allActiveAreParticipating = new AtomicBoolean(true);
-        long timestampAggregationTimeout = config.getTimestampAggregationTimeout() == 0 ? StreamConfiguration.getDefaultTimestampAggregationTimeout() :
+        long timestampAggregationTimeout = config.getTimestampAggregationTimeout() == 0 ? StreamConfiguration.getDEFAULT_TIMESTAMP_AGGREGATION_TIMEOUT() :
                 config.getTimestampAggregationTimeout();
         writers.entrySet().forEach(x -> {
             if (watermarkClient.isWriterActive(x, timestampAggregationTimeout)) {

--- a/controller/src/main/java/io/pravega/controller/server/bucket/PeriodicWatermarking.java
+++ b/controller/src/main/java/io/pravega/controller/server/bucket/PeriodicWatermarking.java
@@ -188,8 +188,10 @@ public class PeriodicWatermarking implements AutoCloseable {
         List<Entry<String, WriterMark>> activeWriters = new ArrayList<>();
         List<Entry<String, WriterMark>> inactiveWriters = new ArrayList<>();
         AtomicBoolean allActiveAreParticipating = new AtomicBoolean(true);
+        long timestampAggregationTimeout = config.getTimestampAggregationTimeout() == 0 ? StreamConfiguration.getDefaultTimestampAggregationTimeout() :
+                config.getTimestampAggregationTimeout();
         writers.entrySet().forEach(x -> {
-            if (watermarkClient.isWriterActive(x, config.getTimestampAggregationTimeout())) {
+            if (watermarkClient.isWriterActive(x, timestampAggregationTimeout)) {
                 activeWriters.add(x);
                 if (!watermarkClient.isWriterParticipating(x.getValue().getTimestamp())) {
                     allActiveAreParticipating.set(false);

--- a/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
@@ -264,7 +264,7 @@ public class ModelHelperTest {
         Assert.assertEquals(ScalingConfig.TypeEnum.FIXED_NUM_SEGMENTS, streamProperty.getScalingPolicy().getType());
         Assert.assertEquals((Integer) 1, streamProperty.getScalingPolicy().getMinSegments());
         Assert.assertNull(streamProperty.getRetentionPolicy());
-        Assert.assertEquals((long) streamProperty.getTimestampAggregationTimeout(), 0L);
+        Assert.assertEquals((long) streamProperty.getTimestampAggregationTimeout(), 60000L);
         Assert.assertEquals((long) streamProperty.getRolloverSizeBytes(), 0L);
 
         streamConfig = StreamConfiguration.builder()

--- a/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
+++ b/controller/src/test/java/io/pravega/controller/rest/v1/ModelHelperTest.java
@@ -52,7 +52,7 @@ public class ModelHelperTest {
         Assert.assertEquals(ScalingPolicy.ScaleType.FIXED_NUM_SEGMENTS, streamConfig.getScalingPolicy().getScaleType());
         Assert.assertEquals(2, streamConfig.getScalingPolicy().getMinNumSegments());
         Assert.assertNull(streamConfig.getRetentionPolicy());
-        Assert.assertEquals(streamConfig.getTimestampAggregationTimeout(), 0);
+        Assert.assertEquals(streamConfig.getTimestampAggregationTimeout(), 60000);
         Assert.assertEquals(streamConfig.getRolloverSizeBytes(), 0);
 
         // Stream with Fixed Scaling Policy and no Retention Policy and positive rolloverSize

--- a/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
+++ b/test/integration/src/test/java/io/pravega/test/integration/WatermarkingTest.java
@@ -406,6 +406,7 @@ public class WatermarkingTest extends ThreadPooledTestSuite {
 
         streamManager.createStream(scope, streamName, StreamConfiguration.builder()
                                                                          .scalingPolicy(ScalingPolicy.fixed(numSegments))
+                                                                         .timestampAggregationTimeout(5000L)
                                                                          .build());
         @Cleanup
         EventStreamClientFactory clientFactory = EventStreamClientFactory.withScope(scope, clientConfig);


### PR DESCRIPTION
Change log description
Currently in the StreamConfiguration if TimestampAggrigationTimeout is not specified it defaults to 0ms which is a non-sensical value which is interpreted to mean that all writer's a perpetually inactive, and hence ignored for watermarking purposes.

Purpose of the change
Closes #7408

What the code does
In the StreamConfiguration if the TimestampAggrigationTimeout is not specified, the default value of 60sec is being set and if the value is specified it should be greater than 0 check is set. Also in the PeriodicWatermarking, for the streams created before, if the TimestampAggrigationTimeout is set to 0, we are considering the default value of 60sec

How to verify it
All the test cases should pass.