### PR TITLE
Issue 7428: Fix junit test failure for InProcPravegaClusterTest.

### DIFF
--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
@@ -92,6 +92,8 @@ public class ZooKeeperServiceRunner implements AutoCloseable {
         }
         if (secureZK) {
             ZKTLSUtils.setSecureZKServerProperties(this.keyStore, this.keyStorePasswordPath, this.trustStore, this.keyStorePasswordPath);
+        } else {
+            ZKTLSUtils.unsetSecureZKServerProperties();
         }
     }
 

--- a/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
+++ b/segmentstore/storage/impl/src/main/java/io/pravega/segmentstore/storage/impl/bookkeeper/ZooKeeperServiceRunner.java
@@ -92,8 +92,6 @@ public class ZooKeeperServiceRunner implements AutoCloseable {
         }
         if (secureZK) {
             ZKTLSUtils.setSecureZKServerProperties(this.keyStore, this.keyStorePasswordPath, this.trustStore, this.keyStorePasswordPath);
-        } else {
-            ZKTLSUtils.unsetSecureZKServerProperties();
         }
     }
 

--- a/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
+++ b/standalone/src/main/java/io/pravega/local/InProcPravegaCluster.java
@@ -487,6 +487,10 @@ public class InProcPravegaCluster implements AutoCloseable {
             }
         }
 
+        if (secureZK) {
+            ZKTLSUtils.unsetSecureZKClientProperties();
+        }
+
         if (this.zkService != null) {
             this.zkService.close();
             this.zkService = null;

--- a/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/AuthEnabledInProcPravegaClusterTest.java
@@ -15,20 +15,18 @@
  */
 package io.pravega.local;
 
-import java.net.URI;
-
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import io.grpc.StatusRuntimeException;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.StreamManager;
-import io.pravega.shared.security.auth.DefaultCredentials;
 import io.pravega.common.Exceptions;
+import io.pravega.shared.security.auth.DefaultCredentials;
 import io.pravega.test.common.AssertExtensions;
-import io.pravega.test.common.SerializedClassRunner;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.net.URI;
 
 import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
 
@@ -37,7 +35,6 @@ import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
  * in the parent class.
  */
 @Slf4j
-@RunWith(SerializedClassRunner.class)
 public class AuthEnabledInProcPravegaClusterTest {
 
     @ClassRule

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -15,10 +15,8 @@
  */
 package io.pravega.local;
 
-import io.pravega.test.common.SerializedClassRunner;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
 
@@ -27,7 +25,6 @@ import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
  * with appropriate configuration for itself as well as for sub-classes.
  */
 @Slf4j
-@RunWith(SerializedClassRunner.class)
 public class InProcPravegaClusterTest {
 
     final String msg = "Test message on the plaintext channel";

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -40,6 +40,7 @@ public class InProcPravegaClusterTest {
      */
     @Test(timeout = 50000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
+        //adding comment to trigger the GA build.
         PravegaEmulatorResource emulator = PravegaEmulatorResource.builder().build();
         emulator.before();
         try {

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -40,7 +40,6 @@ public class InProcPravegaClusterTest {
      */
     @Test(timeout = 50000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        //adding comment to trigger the GA build.
         PravegaEmulatorResource emulator = PravegaEmulatorResource.builder().build();
         emulator.before();
         try {

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -40,7 +40,7 @@ public class InProcPravegaClusterTest {
      */
     @Test(timeout = 50000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        //adding comment to retrigger the test
+        //adding comment to retrigger the test again in GA.
         PravegaEmulatorResource emulator = PravegaEmulatorResource.builder().build();
         emulator.before();
         try {

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -40,6 +40,7 @@ public class InProcPravegaClusterTest {
      */
     @Test(timeout = 50000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
+        //adding comment to retrigger the test
         PravegaEmulatorResource emulator = PravegaEmulatorResource.builder().build();
         emulator.before();
         try {

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -40,7 +40,7 @@ public class InProcPravegaClusterTest {
      */
     @Test(timeout = 50000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        //adding comment to retrigger the test again in GA.
+        log.info("Add logs to retrigger build.");
         PravegaEmulatorResource emulator = PravegaEmulatorResource.builder().build();
         emulator.before();
         try {

--- a/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/InProcPravegaClusterTest.java
@@ -40,7 +40,6 @@ public class InProcPravegaClusterTest {
      */
     @Test(timeout = 50000)
     public void testWriteAndReadEventWithValidClientConfig() throws Exception {
-        log.info("Add logs to retrigger build.");
         PravegaEmulatorResource emulator = PravegaEmulatorResource.builder().build();
         emulator.before();
         try {

--- a/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/SecurePravegaClusterTest.java
@@ -15,11 +15,9 @@
  */
 package io.pravega.local;
 
-import io.pravega.test.common.SerializedClassRunner;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
 
@@ -28,7 +26,6 @@ import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
  * in the parent class.
  */
 @Slf4j
-@RunWith(SerializedClassRunner.class)
 public class SecurePravegaClusterTest {
     @ClassRule
     public static final PravegaEmulatorResource EMULATOR = PravegaEmulatorResource.builder().authEnabled(true).tlsEnabled(true).build();

--- a/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
+++ b/standalone/src/test/java/io/pravega/local/TlsEnabledInProcPravegaClusterTest.java
@@ -16,20 +16,18 @@
 package io.pravega.local;
 
 import io.pravega.client.ClientConfig;
-
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.admin.impl.StreamManagerImpl;
 import io.pravega.client.control.impl.ControllerImplConfig;
-import io.pravega.test.common.SerializedClassRunner;
 import io.pravega.test.common.AssertExtensions;
-import java.net.URI;
-import javax.net.ssl.SSLHandshakeException;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import javax.net.ssl.SSLHandshakeException;
+import java.net.URI;
 
 import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
 
@@ -37,7 +35,6 @@ import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
  * Tests for TLS enabled standalone cluster. It inherits the test methods defined in the parent class.
  */
 @Slf4j
-@RunWith(SerializedClassRunner.class)
 public class TlsEnabledInProcPravegaClusterTest {
 
     @ClassRule

--- a/standalone/src/test/java/io/pravega/local/TlsProtocolVersion12Test.java
+++ b/standalone/src/test/java/io/pravega/local/TlsProtocolVersion12Test.java
@@ -15,14 +15,11 @@
  */
 package io.pravega.local;
 
-import io.pravega.test.common.SerializedClassRunner;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
 
-@RunWith(SerializedClassRunner.class)
 public class TlsProtocolVersion12Test {
 
     @ClassRule

--- a/standalone/src/test/java/io/pravega/local/TlsProtocolVersion13Test.java
+++ b/standalone/src/test/java/io/pravega/local/TlsProtocolVersion13Test.java
@@ -15,14 +15,11 @@
  */
 package io.pravega.local;
 
-import io.pravega.test.common.SerializedClassRunner;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import static io.pravega.local.PravegaSanityTests.testWriteAndReadAnEvent;
 
-@RunWith(SerializedClassRunner.class)
 public class TlsProtocolVersion13Test {
 
     @ClassRule


### PR DESCRIPTION
**Change log description**  
In Pravega master junit test for InProcPravegaClusterTest failing consistently.

**Purpose of the change**  
Fixes #7428.

**What the code does**  
This change will clear secure ZKClient properties from system properties so that next test subsequent test will not have stale client properties. I have also removed `@RunWith(SerializedClassRunner.class)` from standalone tests as it will improve standalone test execution time (i found that running tests in parallel is not causing any issue).

**How to verify it**  
Run **./gradlew clean :standalone:test**, all tests should succeed.