### PR TITLE
Fix typos in logging messages

### DIFF
--- a/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
+++ b/test/system/src/test/java/io/pravega/test/system/ConsumptionBasedRetentionWithMultipleReaderGroupsTest.java
@@ -425,7 +425,7 @@ public class ConsumptionBasedRetentionWithMultipleReaderGroupsTest extends Abstr
         scaleAndUpdateControllerURI(3);
         // scale to two segment store instances.
         Futures.getAndHandleExceptions(segmentStoreService.scaleService(2), ExecutionException::new);
-        log.info("Successfully statred 2 instance of segment store service");
+        log.info("Successfully started 2 instance of segment store service");
         assertTrue("Creating scope", streamManager.createScope(scope));
         assertTrue("Creating stream", streamManager.createStream(scope, stream, STREAM_CONFIGURATION));
 


### PR DESCRIPTION
**Change log description**  
Hi,
We found a typo in the logging messages.
It's an incremental commit but it can improve the quality of logging messages.

